### PR TITLE
refactor: use sub-path imports in @repo/api

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@repo/tsconfigs": "workspace:*",
+    "@types/node": "^22.19.13",
     "unbuild": "^3.5.0",
     "vitest": "^3.1.0"
   }

--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { BacklogRateLimitError } from "./rate-limit.ts";
+import { BacklogRateLimitError } from "#/rate-limit.ts";
 
 vi.mock("ofetch", () => {
   const createMock = vi.fn((defaults: Record<string, unknown>) => defaults);
@@ -13,7 +13,7 @@ vi.mock("ufo", () => ({
 }));
 
 // eslint-disable-next-line import/first -- must follow vi.mock calls
-import { createClient } from "./client.ts";
+import { createClient } from "#/client.ts";
 
 describe("createClient", () => {
   it("sets baseURL from host", () => {

--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { BacklogRateLimitError } from "#/rate-limit.ts";
+import { BacklogRateLimitError } from "#/rate-limit.js";
 
 vi.mock("ofetch", () => {
   const createMock = vi.fn((defaults: Record<string, unknown>) => defaults);
@@ -13,7 +13,7 @@ vi.mock("ufo", () => ({
 }));
 
 // eslint-disable-next-line import/first -- must follow vi.mock calls
-import { createClient } from "#/client.ts";
+import { createClient } from "#/client.js";
 
 describe("createClient", () => {
   it("sets baseURL from host", () => {

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -1,7 +1,7 @@
 import type { $Fetch } from "ofetch";
 import { ofetch } from "ofetch";
 import { joinURL } from "ufo";
-import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.ts";
+import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.js";
 
 export type BacklogClientConfig = {
   host: string;

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -1,7 +1,7 @@
 import type { $Fetch } from "ofetch";
 import { ofetch } from "ofetch";
 import { joinURL } from "ufo";
-import { BacklogRateLimitError, formatResetTime } from "./rate-limit.ts";
+import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.ts";
 
 export type BacklogClientConfig = {
   host: string;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,4 @@
-export { createClient } from "#/client.ts";
-export type { BacklogClientConfig } from "#/client.ts";
-export { BacklogRateLimitError, formatResetTime } from "#/rate-limit.ts";
+export { createClient } from "#/client.js";
+export type { BacklogClientConfig } from "#/client.js";
+export { BacklogRateLimitError, formatResetTime } from "#/rate-limit.js";
 export type { $Fetch } from "ofetch";

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,4 @@
-export { createClient } from "./client.ts";
-export type { BacklogClientConfig } from "./client.ts";
-export { BacklogRateLimitError, formatResetTime } from "./rate-limit.ts";
+export { createClient } from "#/client.ts";
+export type { BacklogClientConfig } from "#/client.ts";
+export { BacklogRateLimitError, formatResetTime } from "#/rate-limit.ts";
 export type { $Fetch } from "ofetch";

--- a/packages/api/src/rate-limit.test.ts
+++ b/packages/api/src/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.ts";
+import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.js";
 
 describe("formatResetTime", () => {
   it("converts epoch seconds to a localized date-time string", () => {

--- a/packages/api/src/rate-limit.test.ts
+++ b/packages/api/src/rate-limit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { BacklogRateLimitError, formatResetTime } from "./rate-limit.ts";
+import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.ts";
 
 describe("formatResetTime", () => {
   it("converts epoch seconds to a localized date-time string", () => {

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,4 +1,9 @@
 {
   "extends": "@repo/tsconfigs/base.json",
-  "include": ["src"]
+  "include": ["src"],
+  "compilerOptions": {
+    "paths": {
+      "#/*": ["./src/*"]
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@repo/tsconfigs':
         specifier: workspace:*
         version: link:../tsconfigs
+      '@types/node':
+        specifier: ^22.19.13
+        version: 22.19.13
       unbuild:
         specifier: ^3.5.0
         version: 3.6.1(typescript@6.0.0-dev.20260303)


### PR DESCRIPTION
## Summary

- Replace relative `./foo.ts` imports with `#/foo.ts` sub-path imports across all `@repo/api` source and test files
- Aligns with the `#/*` import alias convention already used in `@repo/cli`

## Test plan

- [x] `nr test` in `packages/api` — 14 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)