### PR TITLE
docs: add CLAUDE.md with project conventions and workflow guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,3 +108,4 @@ Plan files (implementation plans, design docs, etc.) go in `.claude/plans/`.
 - **Commits**: Always in English, following [Conventional Commits](https://www.conventionalcommits.org/). Use `feat` / `fix` only when it genuinely affects semantic versioning — prefer `chore`, `refactor`, `docs`, `test`, `ci`, `build` for non-semver changes.
 - **PR / Issue titles**: Always in English.
 - **PR / Issue body**: English by default unless otherwise specified.
+- **PR assignee**: Always assign the user who requested the PR creation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,110 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+Backlog CLI (`backlog` / `bl`) — a command-line interface for the Backlog project management service. pnpm workspace monorepo with ESM-only packages.
+
+## Commands
+
+```sh
+# Install
+pnpm install
+
+# Lint (oxlint, NOT ESLint)
+pnpm run lint
+pnpm run lint:fix
+
+# Type check (oxlint type-aware linting, NOT tsc)
+pnpm run typecheck
+
+# Format (oxfmt)
+pnpm run format
+pnpm run format:check
+
+# Test (@repo/api)
+pnpm --filter @repo/api test                              # all tests
+pnpm --filter @repo/api exec vitest run src/client.test.ts # single file
+
+# Build
+pnpm --filter @nulab/backlog-cli build
+
+# Dev (CLI)
+pnpm --filter @nulab/backlog-cli dev
+```
+
+## Module Resolution: nodenext
+
+TypeScript is configured with `module: "nodenext"` / `moduleResolution: "nodenext"`. This means:
+
+- **Relative imports must include the `.js` extension**, even for `.ts` source files:
+  ```ts
+  // Correct
+  import { foo } from "./foo.js";
+  // Wrong
+  import { foo } from "./foo";
+  import { foo } from "./foo.ts";
+  ```
+- Use `import type` for type-only imports (enforced by oxlint)
+
+## Subpath Imports
+
+Each package uses Node.js subpath imports (`"imports"` field in package.json) to alias `#/*` to `./src/*`. Use this instead of relative paths when importing within a package:
+
+```ts
+// Preferred (subpath import)
+import { createClient } from "#/client.js";
+// Avoid (deep relative path)
+import { createClient } from "../../client.js";
+```
+
+## Architecture
+
+```
+apps/docs          — Astro Starlight documentation site
+packages/api       — Backlog API client (ofetch, rate-limit handling)
+packages/cli       — CLI entry point (citty framework, consola logging)
+packages/api-spec  — TypeSpec definitions for Backlog API v2
+packages/tsconfigs — Shared TypeScript base config
+```
+
+`@repo/api` exposes `createClient(config)` which returns an ofetch `$Fetch` instance preconfigured with Backlog API v2 base URL, auth, and rate-limit error handling.
+
+`@repo/cli` uses citty's `defineCommand` / `runMain` with subcommand registration.
+
+## Code Conventions (enforced by oxlint)
+
+- **Named exports only** — no default exports (`import/no-default-export`)
+- **`type` keyword** — use `type` instead of `interface` for type definitions
+- **`T[]` syntax** — use `T[]` instead of `Array<T>`
+- **`Record<K, V>`** — use `Record` instead of `{ [key: K]: V }`
+- **ESM only** — no `require()` or `module.exports`
+- **`node:` protocol** — use `node:fs` not `fs` for Node.js built-in modules
+- **Strict equality** — always `===` / `!==`
+- **Curly braces required** — for all control flow statements
+- **No floating Promises** — all Promises must be awaited or explicitly voided
+- **Catch variable**: name it `error`
+
+## Tooling
+
+- **Runtime**: Node.js 24 (managed by mise)
+- **Package manager**: pnpm (corepack-enabled)
+- **Linter**: oxlint (with plugins: import, typescript, unicorn)
+- **Formatter**: oxfmt
+- **Type checker**: `oxlint --type-aware --type-check` (not tsc)
+- **Test runner**: Vitest
+- **Build**: unbuild
+- **Git hooks**: lefthook (pre-commit: oxlint --fix + oxfmt)
+
+## Workflow
+
+Do NOT manually run lint or format during development. The pre-commit hook (lefthook) automatically runs `oxlint --fix` and `oxfmt` on staged files at commit time. Only `typecheck` and `test` need to be run manually when verifying changes.
+
+Plan files (implementation plans, design docs, etc.) go in `.claude/plans/`.
+
+## Commit & PR Conventions
+
+- **Commits**: Always in English, following [Conventional Commits](https://www.conventionalcommits.org/). Use `feat` / `fix` only when it genuinely affects semantic versioning — prefer `chore`, `refactor`, `docs`, `test`, `ci`, `build` for non-semver changes.
+- **PR / Issue titles**: Always in English.
+- **PR / Issue body**: English by default unless otherwise specified.


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with project conventions for Claude Code
- Documents module resolution (nodenext), subpath imports, oxlint type-aware linting, commit/PR conventions, and workflow guidance

## Test plan
- [x] Verify CI passes (lint, typecheck, format check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)