### PR TITLE
chore(lint): resolve all oxlint warnings and enforce zero-warning CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Lint
-        run: pnpm run lint
+        run: pnpm exec oxlint --max-warnings 0
 
       - name: Generate OpenAPI client
         run: pnpm --filter @repo/openapi build && pnpm --filter @repo/openapi-client build

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -164,7 +164,12 @@
   "overrides": [
     {
       // Tool config files require default exports
-      "files": ["**/astro.config.*", "**/build.config.*", "**/vitest.config.*"],
+      "files": [
+        "**/astro.config.*",
+        "**/build.config.*",
+        "**/vitest.config.*",
+        "**/vitest.workspace.*"
+      ],
       "rules": {
         "import/no-default-export": "off"
       }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -171,7 +171,8 @@
         "**/vitest.workspace.*"
       ],
       "rules": {
-        "import/no-default-export": "off"
+        "import/no-default-export": "off",
+        "import/no-anonymous-default-export": "off"
       }
     },
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -149,8 +149,34 @@
     // Conflicts with no-default-export; disable the opposite rule enabled by categories.style
     "import/no-named-export": "off",
     // ESM only, no require/module.exports
-    "import/no-commonjs": "warn"
+    "import/no-commonjs": "warn",
+
+    // ── Import: Style overrides ────────────────────────────────
+    // Allow namespace imports (e.g., import * as v from "valibot")
+    "import/no-namespace": "off",
+    // Allow separate import type + import from same module (conflicts with consistent-type-specifier-style)
+    "no-duplicate-imports": "off",
+    // Allow default-as-named (false positive for consola etc.)
+    "import/no-named-as-default": "off",
+    // Conflicts with no-default-export
+    "import/prefer-default-export": "off"
   },
+  "overrides": [
+    {
+      // Tool config files require default exports
+      "files": ["**/astro.config.*", "**/build.config.*", "**/vitest.config.*"],
+      "rules": {
+        "import/no-default-export": "off"
+      }
+    },
+    {
+      // CLI entry point uses side-effect import
+      "files": ["**/bin/**"],
+      "rules": {
+        "import/no-unassigned-import": "off"
+      }
+    }
+  ],
   "settings": {
     "vitest": {
       "typecheck": false

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -3,13 +3,13 @@ import { ofetch } from "ofetch";
 import { joinURL } from "ufo";
 import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.js";
 
-export type BacklogClientConfig = {
+type BacklogClientConfig = {
   host: string;
   apiKey?: string;
   accessToken?: string;
 };
 
-export const createClient = (config: BacklogClientConfig): $Fetch =>
+const createClient = (config: BacklogClientConfig): $Fetch =>
   ofetch.create({
     baseURL: joinURL(`https://${config.host}`, "/api/v2"),
     headers: config.accessToken ? { Authorization: `Bearer ${config.accessToken}` } : {},
@@ -26,3 +26,6 @@ export const createClient = (config: BacklogClientConfig): $Fetch =>
       }
     },
   });
+
+export { createClient };
+export type { BacklogClientConfig };

--- a/packages/api/src/rate-limit.ts
+++ b/packages/api/src/rate-limit.ts
@@ -1,9 +1,9 @@
-export const formatResetTime = (epochSeconds: number): string => {
+const formatResetTime = (epochSeconds: number): string => {
   const date = new Date(epochSeconds * 1000);
   return date.toLocaleString();
 };
 
-export class BacklogRateLimitError extends Error {
+class BacklogRateLimitError extends Error {
   override readonly name = "BacklogRateLimitError";
   readonly resetAt: Date | undefined;
 
@@ -12,3 +12,5 @@ export class BacklogRateLimitError extends Error {
     this.resetAt = resetAt;
   }
 }
+
+export { BacklogRateLimitError, formatResetTime };

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -3,8 +3,8 @@ import { join } from "node:path";
 import * as v from "valibot";
 import consola from "consola";
 import { read, write } from "rc9";
-import { RcSchema } from "#/schema.js";
 import type { Rc } from "#/schema.js";
+import { RcSchema } from "#/schema.js";
 
 const CONFIG_DIR_NAME = "backlog";
 const CONFIG_FILE_NAME = ".backlogrc";
@@ -15,7 +15,7 @@ const resolveConfigDir = (): string => {
   return join(base, CONFIG_DIR_NAME);
 };
 
-export const loadConfig = (): Rc => {
+const loadConfig = (): Rc => {
   const dir = resolveConfigDir();
   const raw = read({ name: CONFIG_FILE_NAME, dir });
   const result = v.safeParse(RcSchema, raw);
@@ -31,7 +31,9 @@ export const loadConfig = (): Rc => {
   return result.output;
 };
 
-export const writeConfig = (config: Rc): void => {
+const writeConfig = (config: Rc): void => {
   const dir = resolveConfigDir();
   write(config, { name: CONFIG_FILE_NAME, dir });
 };
+
+export { loadConfig, writeConfig };

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -13,21 +13,24 @@ const OAuthAuthSchema = v.object({
   clientSecret: v.optional(v.string()),
 });
 
-export const RcAuthSchema = v.variant("method", [ApiKeyAuthSchema, OAuthAuthSchema]);
+const RcAuthSchema = v.variant("method", [ApiKeyAuthSchema, OAuthAuthSchema]);
 
-export const RcSpaceSchema = v.object({
+const RcSpaceSchema = v.object({
   host: v.pipe(v.string(), v.regex(/^[a-z0-9-]+\.backlog\.(com|jp)$/)),
   auth: RcAuthSchema,
 });
 
-export const RcSchema = v.object({
+const RcSchema = v.object({
   defaultSpace: v.optional(v.string()),
   spaces: v.optional(v.array(RcSpaceSchema), []),
   aliases: v.optional(v.record(v.string(), v.string()), {}),
 });
 
-export type RcAuth = v.InferOutput<typeof RcAuthSchema>;
+type RcAuth = v.InferOutput<typeof RcAuthSchema>;
 
-export type RcSpace = v.InferOutput<typeof RcSpaceSchema>;
+type RcSpace = v.InferOutput<typeof RcSpaceSchema>;
 
-export type Rc = v.InferOutput<typeof RcSchema>;
+type Rc = v.InferOutput<typeof RcSchema>;
+
+export { RcAuthSchema, RcSchema, RcSpaceSchema };
+export type { Rc, RcAuth, RcSpace };

--- a/packages/config/src/space.ts
+++ b/packages/config/src/space.ts
@@ -2,7 +2,7 @@ import type { RcAuth, RcSpace } from "#/schema.js";
 
 import { loadConfig, writeConfig } from "#/config.js";
 
-export const addSpace = (space: RcSpace): void => {
+const addSpace = (space: RcSpace): void => {
   const config = loadConfig();
   const exists = config.spaces.some((s) => s.host === space.host);
 
@@ -16,7 +16,7 @@ export const addSpace = (space: RcSpace): void => {
   });
 };
 
-export const removeSpace = (host: string): void => {
+const removeSpace = (host: string): void => {
   const config = loadConfig();
   const index = config.spaces.findIndex((space) => space.host === host);
 
@@ -30,7 +30,7 @@ export const removeSpace = (host: string): void => {
   writeConfig({ ...config, spaces, defaultSpace });
 };
 
-export const updateSpaceAuth = (host: string, auth: RcAuth): void => {
+const updateSpaceAuth = (host: string, auth: RcAuth): void => {
   const config = loadConfig();
   const index = config.spaces.findIndex((space) => space.host === host);
   const space = config.spaces[index];
@@ -45,7 +45,7 @@ export const updateSpaceAuth = (host: string, auth: RcAuth): void => {
   });
 };
 
-export const findSpace = (spaces: readonly RcSpace[], host: string): RcSpace | null => {
+const findSpace = (spaces: readonly RcSpace[], host: string): RcSpace | null => {
   const exactMatch = spaces.find((s) => s.host === host);
   if (exactMatch) {
     return exactMatch;
@@ -66,7 +66,7 @@ export const findSpace = (spaces: readonly RcSpace[], host: string): RcSpace | n
   return null;
 };
 
-export const resolveSpace = (explicitHost?: string): RcSpace | null => {
+const resolveSpace = (explicitHost?: string): RcSpace | null => {
   const config = loadConfig();
   const host = explicitHost ?? process.env["BACKLOG_SPACE"] ?? config.defaultSpace;
 
@@ -76,3 +76,5 @@ export const resolveSpace = (explicitHost?: string): RcSpace | null => {
 
   return findSpace(config.spaces, host);
 };
+
+export { addSpace, findSpace, removeSpace, resolveSpace, updateSpaceAuth };


### PR DESCRIPTION
## Summary

- Group all inline exports (`export const/class/type`) into bottom-of-file `export { ... }` / `export type { ... }` statements to satisfy `import/group-exports`
- Disable style rules that conflict with project conventions (`no-namespace`, `no-duplicate-imports`, `prefer-default-export`, `no-named-as-default`)
- Add `overrides` to allow `export default` in tool config files (`astro.config.*`, `build.config.*`, `vitest.config.*`) and side-effect imports in `bin/`
- Enforce `--max-warnings 0` in CI so any new warning fails the build

## Test plan

- [x] `pnpm exec oxlint --max-warnings 0` → 0 warnings, 0 errors
- [x] `pnpm --filter @repo/api test` → 14 tests passed
- [x] `pnpm --filter @repo/config test` → 44 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)