### PR TITLE
feat(api): add automatic retry on rate-limit (429) responses

### DIFF
--- a/packages/api/src/client.test.ts
+++ b/packages/api/src/client.test.ts
@@ -1,133 +1,235 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BacklogRateLimitError } from "#/rate-limit.js";
 
-vi.mock("ofetch", () => {
-  const createMock = vi.fn((defaults: Record<string, unknown>) => defaults);
-  return {
-    ofetch: { create: createMock },
-  };
+const { mockFetch, mockCreate } = vi.hoisted(() => {
+  const fetch = vi.fn();
+  const create = vi.fn((_defaults: Record<string, unknown>) => fetch);
+  return { mockFetch: fetch, mockCreate: create };
 });
+
+vi.mock("ofetch", () => ({
+  ofetch: { create: mockCreate },
+}));
 
 vi.mock("ufo", () => ({
   joinURL: (...parts: string[]) => parts.join(""),
 }));
 
+vi.mock("node:timers/promises", () => ({
+  setTimeout: (ms: number) =>
+    new Promise<void>((resolve) => {
+      globalThis.setTimeout(resolve, ms);
+    }),
+}));
+
 // eslint-disable-next-line import/first -- must follow vi.mock calls
 import { createClient } from "#/client.js";
 
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
 describe("createClient", () => {
-  it("sets baseURL from host", () => {
-    const result = createClient({
-      host: "example.backlog.com",
-    }) as unknown as Record<string, unknown>;
+  describe("configuration", () => {
+    it("sets baseURL from host", () => {
+      createClient({ host: "example.backlog.com" });
 
-    expect(result.baseURL).toBe("https://example.backlog.com/api/v2");
-  });
-
-  it("sets apiKey as query param for API Key auth", () => {
-    const result = createClient({
-      host: "example.backlog.com",
-      apiKey: "test-key",
-    }) as unknown as Record<string, unknown>;
-
-    expect(result.query).toEqual({ apiKey: "test-key" });
-    expect(result.headers).toEqual({});
-  });
-
-  it("sets Authorization header for OAuth auth", () => {
-    const result = createClient({
-      host: "example.backlog.com",
-      accessToken: "test-token",
-    }) as unknown as Record<string, unknown>;
-
-    expect(result.headers).toEqual({
-      Authorization: "Bearer test-token",
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseURL: "https://example.backlog.com/api/v2",
+        }),
+      );
     });
-    expect(result.query).toEqual({});
+
+    it("sets apiKey as query param for API Key auth", () => {
+      createClient({ host: "example.backlog.com", apiKey: "test-key" });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: { apiKey: "test-key" },
+        }),
+      );
+    });
+
+    it("sets Authorization header for static accessToken", () => {
+      createClient({ host: "example.backlog.com", accessToken: "test-token" });
+
+      const callArgs = mockCreate.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      expect(callArgs.headers).toEqual({ Authorization: "Bearer test-token" });
+    });
+
+    it("sets Authorization header via getter for function accessToken", () => {
+      let token = "token-v1";
+      createClient({ host: "example.backlog.com", accessToken: () => token });
+
+      const callArgs = mockCreate.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      const headers = callArgs.headers as Record<string, string>;
+
+      expect(headers.Authorization).toBe("Bearer token-v1");
+
+      token = "token-v2";
+      expect(headers.Authorization).toBe("Bearer token-v2");
+    });
   });
 
-  it("throws BacklogRateLimitError on 429 with reset header", () => {
-    const resetEpoch = "1700000000";
-    const result = createClient({
-      host: "example.backlog.com",
-    }) as unknown as Record<string, unknown>;
-    const onResponseError = result.onResponseError as (ctx: {
-      response: { status: number; headers: Map<string, string> };
-    }) => void;
+  describe("429 error handling (onResponseError)", () => {
+    const getOnResponseError = () => {
+      createClient({ host: "example.backlog.com", rateLimitRetry: false });
+      const callArgs = mockCreate.mock.calls.at(-1)?.[0] as Record<string, unknown>;
+      return callArgs.onResponseError as (ctx: {
+        response: { status: number; headers: Map<string, string> };
+      }) => void;
+    };
 
-    const headers = new Map([["X-RateLimit-Reset", resetEpoch]]);
+    it("throws BacklogRateLimitError on 429 with reset header", () => {
+      const onResponseError = getOnResponseError();
+      const headers = new Map([["X-RateLimit-Reset", "1700000000"]]);
 
-    expect(() => {
-      onResponseError({
-        response: {
-          status: 429,
-          headers: headers as unknown as Map<string, string>,
-        },
-      });
-    }).toThrow(BacklogRateLimitError);
+      expect(() => {
+        onResponseError({
+          response: { status: 429, headers: headers as unknown as Map<string, string> },
+        });
+      }).toThrow(BacklogRateLimitError);
+    });
+
+    it("throws BacklogRateLimitError on 429 without reset header", () => {
+      const onResponseError = getOnResponseError();
+      const headers = new Map<string, string>();
+
+      expect(() => {
+        onResponseError({
+          response: { status: 429, headers: headers as unknown as Map<string, string> },
+        });
+      }).toThrow(BacklogRateLimitError);
+    });
+
+    it("includes resetAt in error when header present", () => {
+      const onResponseError = getOnResponseError();
+      const headers = new Map([["X-RateLimit-Reset", "1700000000"]]);
+
+      try {
+        onResponseError({
+          response: { status: 429, headers: headers as unknown as Map<string, string> },
+        });
+      } catch (error) {
+        expect(error).toBeInstanceOf(BacklogRateLimitError);
+        expect((error as BacklogRateLimitError).resetAt).toEqual(new Date(1_700_000_000 * 1000));
+      }
+    });
+
+    it("does not throw for non-429 responses", () => {
+      const onResponseError = getOnResponseError();
+      const headers = new Map<string, string>();
+
+      expect(() => {
+        onResponseError({
+          response: { status: 500, headers: headers as unknown as Map<string, string> },
+        });
+      }).not.toThrow();
+    });
   });
 
-  it("throws BacklogRateLimitError on 429 without reset header", () => {
-    const result = createClient({
-      host: "example.backlog.com",
-    }) as unknown as Record<string, unknown>;
-    const onResponseError = result.onResponseError as (ctx: {
-      response: { status: number; headers: Map<string, string> };
-    }) => void;
+  describe("rate limit retry", () => {
+    it("retries after waiting when resetAt is within 60s (default: rateLimitRetry=true)", async () => {
+      const now = Date.now();
+      const resetAt = new Date(now + 5000);
+      const rateLimitError = new BacklogRateLimitError("rate limited", resetAt);
 
-    const headers = new Map<string, string>();
+      mockFetch.mockRejectedValueOnce(rateLimitError).mockResolvedValueOnce({ ok: true });
 
-    expect(() => {
-      onResponseError({
-        response: {
-          status: 429,
-          headers: headers as unknown as Map<string, string>,
-        },
+      const client = createClient({ host: "example.backlog.com" });
+      const resultPromise = client("/test");
+
+      await vi.advanceTimersByTimeAsync(5000 + 1000);
+
+      await expect(resultPromise).resolves.toEqual({ ok: true });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws if retry also fails with 429", async () => {
+      const now = Date.now();
+      const resetAt = new Date(now + 5000);
+      const rateLimitError = new BacklogRateLimitError("rate limited", resetAt);
+
+      mockFetch.mockRejectedValueOnce(rateLimitError).mockRejectedValueOnce(rateLimitError);
+
+      const client = createClient({ host: "example.backlog.com" });
+      const resultPromise = client("/test");
+
+      // Attach rejection handler before advancing timers to avoid unhandled rejection
+      const assertion = expect(resultPromise).rejects.toThrow(BacklogRateLimitError);
+
+      await vi.advanceTimersByTimeAsync(5000 + 1000);
+
+      await assertion;
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not retry when rateLimitRetry is false", async () => {
+      const now = Date.now();
+      const resetAt = new Date(now + 5000);
+      const rateLimitError = new BacklogRateLimitError("rate limited", resetAt);
+
+      mockFetch.mockRejectedValueOnce(rateLimitError);
+
+      const client = createClient({
+        host: "example.backlog.com",
+        rateLimitRetry: false,
       });
-    }).toThrow(BacklogRateLimitError);
-  });
 
-  it("includes resetAt in BacklogRateLimitError when header present", () => {
-    const resetEpoch = "1700000000";
-    const result = createClient({
-      host: "example.backlog.com",
-    }) as unknown as Record<string, unknown>;
-    const onResponseError = result.onResponseError as (ctx: {
-      response: { status: number; headers: Map<string, string> };
-    }) => void;
+      await expect(client("/test")).rejects.toThrow(BacklogRateLimitError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
 
-    const headers = new Map([["X-RateLimit-Reset", resetEpoch]]);
+    it("does not retry when resetAt exceeds 60s", async () => {
+      const now = Date.now();
+      const resetAt = new Date(now + 120_000);
+      const rateLimitError = new BacklogRateLimitError("rate limited", resetAt);
 
-    try {
-      onResponseError({
-        response: {
-          status: 429,
-          headers: headers as unknown as Map<string, string>,
-        },
-      });
-    } catch (error) {
-      expect(error).toBeInstanceOf(BacklogRateLimitError);
-      expect((error as BacklogRateLimitError).resetAt).toEqual(new Date(Number(resetEpoch) * 1000));
-    }
-  });
+      mockFetch.mockRejectedValueOnce(rateLimitError);
 
-  it("does not throw for non-429 responses", () => {
-    const result = createClient({
-      host: "example.backlog.com",
-    }) as unknown as Record<string, unknown>;
-    const onResponseError = result.onResponseError as (ctx: {
-      response: { status: number; headers: Map<string, string> };
-    }) => void;
+      const client = createClient({ host: "example.backlog.com" });
 
-    const headers = new Map<string, string>();
+      await expect(client("/test")).rejects.toThrow(BacklogRateLimitError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
 
-    expect(() => {
-      onResponseError({
-        response: {
-          status: 500,
-          headers: headers as unknown as Map<string, string>,
-        },
-      });
-    }).not.toThrow();
+    it("does not retry when resetAt is undefined", async () => {
+      const rateLimitError = new BacklogRateLimitError("rate limited");
+
+      mockFetch.mockRejectedValueOnce(rateLimitError);
+
+      const client = createClient({ host: "example.backlog.com" });
+
+      await expect(client("/test")).rejects.toThrow(BacklogRateLimitError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry when resetAt is in the past", async () => {
+      const now = Date.now();
+      const resetAt = new Date(now - 5000);
+      const rateLimitError = new BacklogRateLimitError("rate limited", resetAt);
+
+      mockFetch.mockRejectedValueOnce(rateLimitError);
+
+      const client = createClient({ host: "example.backlog.com" });
+
+      await expect(client("/test")).rejects.toThrow(BacklogRateLimitError);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry non-rate-limit errors", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("network error"));
+
+      const client = createClient({ host: "example.backlog.com" });
+
+      await expect(client("/test")).rejects.toThrow("network error");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/api/src/client.ts
+++ b/packages/api/src/client.ts
@@ -1,18 +1,41 @@
+import { setTimeout } from "node:timers/promises";
 import type { $Fetch } from "ofetch";
 import { ofetch } from "ofetch";
 import { joinURL } from "ufo";
-import { BacklogRateLimitError, formatResetTime } from "#/rate-limit.js";
+import {
+  BacklogRateLimitError,
+  formatResetTime,
+  MAX_RATE_LIMIT_WAIT_MS,
+  RATE_LIMIT_BUFFER_MS,
+} from "#/rate-limit.js";
 
 type BacklogClientConfig = {
   host: string;
   apiKey?: string;
-  accessToken?: string;
+  accessToken?: string | (() => string);
+  rateLimitRetry?: boolean;
 };
 
-const createClient = (config: BacklogClientConfig): $Fetch =>
-  ofetch.create({
+const createClient = (config: BacklogClientConfig): $Fetch => {
+  const rateLimitRetry = config.rateLimitRetry ?? true;
+
+  let headers: Record<string, string> = {};
+  if (config.accessToken) {
+    if (typeof config.accessToken === "function") {
+      const getToken = config.accessToken;
+      headers = {
+        get Authorization() {
+          return `Bearer ${getToken()}`;
+        },
+      };
+    } else {
+      headers = { Authorization: `Bearer ${config.accessToken}` };
+    }
+  }
+
+  const baseFetch = ofetch.create({
     baseURL: joinURL(`https://${config.host}`, "/api/v2"),
-    headers: config.accessToken ? { Authorization: `Bearer ${config.accessToken}` } : {},
+    headers,
     query: config.apiKey ? { apiKey: config.apiKey } : {},
     onResponseError({ response }) {
       if (response.status === 429) {
@@ -26,6 +49,27 @@ const createClient = (config: BacklogClientConfig): $Fetch =>
       }
     },
   });
+
+  if (!rateLimitRetry) {
+    return baseFetch;
+  }
+
+  return (async (url: string, options?: Record<string, unknown>) => {
+    try {
+      return await baseFetch(url, options);
+    } catch (error) {
+      if (error instanceof BacklogRateLimitError && error.resetAt) {
+        const delay = error.resetAt.getTime() - Date.now();
+        if (delay > 0 && delay <= MAX_RATE_LIMIT_WAIT_MS) {
+          await setTimeout(delay + RATE_LIMIT_BUFFER_MS);
+          const retryResult = await baseFetch(url, options);
+          return retryResult;
+        }
+      }
+      throw error;
+    }
+  }) as $Fetch;
+};
 
 export { createClient };
 export type { BacklogClientConfig };

--- a/packages/api/src/rate-limit.ts
+++ b/packages/api/src/rate-limit.ts
@@ -1,3 +1,6 @@
+const MAX_RATE_LIMIT_WAIT_MS = 60_000;
+const RATE_LIMIT_BUFFER_MS = 1000;
+
 const formatResetTime = (epochSeconds: number): string => {
   const date = new Date(epochSeconds * 1000);
   return date.toLocaleString();
@@ -13,4 +16,4 @@ class BacklogRateLimitError extends Error {
   }
 }
 
-export { BacklogRateLimitError, formatResetTime };
+export { BacklogRateLimitError, formatResetTime, MAX_RATE_LIMIT_WAIT_MS, RATE_LIMIT_BUFFER_MS };


### PR DESCRIPTION
## Summary

- Add automatic retry-after-wait when `createClient` encounters a 429 rate-limit response with a `X-RateLimit-Reset` header (wait ≤ 60s, single retry, +1s buffer)
- Add `rateLimitRetry` option to `BacklogClientConfig` (default: `true`, set `false` to opt out)
- Add function-typed `accessToken` support for dynamic token resolution (OAuth refresh)

## Test plan

- [x] Retry succeeds after waiting (`rateLimitRetry: true`, default)
- [x] Retry fails again with 429 → throws without infinite loop
- [x] `rateLimitRetry: false` → no retry, immediate throw
- [x] `resetAt` > 60s → no retry
- [x] `resetAt` undefined → no retry
- [x] `resetAt` in the past → no retry
- [x] Non-rate-limit errors → no retry
- [x] Function `accessToken` getter resolves dynamically
- [x] All 22 tests pass, lint clean, typecheck clean (0 new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)