### PR TITLE
feat(project): implement project write commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,10 @@ Follow gh CLI conventions for `args` description strings:
 - **Choices use `{x|y}` notation** — write `{api-key|oauth}`, not `api-key or oauth`.
 - **`e.g.,` flows naturally in the sentence** — write `The hostname of the Backlog space. e.g., xxx.backlog.com`, not `Space hostname (e.g., xxx.backlog.com)`.
 - **Same-meaning arguments share the same description across commands** — if `--space` means the same thing in `auth login` and `auth logout`, use the identical description string. Do not vary wording per command context.
+- **Edit/update flags signal intent in the description** — in `edit` / `update` commands, descriptions must make it clear the flag sets a new value:
+  - String flags: `"New X of the Y"` (e.g., `"New name of the project"`)
+  - Boolean toggles: `"Change whether X"` (e.g., `"Change whether the chart is enabled"`)
+  - Enum flags: `"Change X. {a|b}"` (e.g., `"Change text formatting rule. {backlog|markdown}"`)
 
 ### Short flag aliases
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,16 @@ Follow gh CLI conventions for `args` description strings:
 - **`e.g.,` flows naturally in the sentence** — write `The hostname of the Backlog space. e.g., xxx.backlog.com`, not `Space hostname (e.g., xxx.backlog.com)`.
 - **Same-meaning arguments share the same description across commands** — if `--space` means the same thing in `auth login` and `auth logout`, use the identical description string. Do not vary wording per command context.
 
+### Short flag aliases
+
+Following gh CLI conventions, only assign single-letter aliases (`-n`, `-d`, etc.) to flags that are **high-frequency and cross-cutting** — flags users type routinely across many commands (e.g., `--name`, `--body`, `--title`). Leave all other flags long-form only:
+
+- **Settings / toggles** (`--archived`, `--chart-enabled`) — infrequently changed, long-form is fine.
+- **Operation-prefixed flags** (`--add-label`, `--remove-label`) — short aliases would obscure the operation semantics.
+- **Safety / confirmation flags** — intentionally verbose to force deliberate typing.
+
+When two flags in the same command would collide on the same letter, one (or both) must stay long-form. Prefer giving the alias to the more frequently used flag.
+
 ### Environment variable defaults for arguments
 
 When a command argument can be provided via an environment variable (e.g., `BACKLOG_PROJECT`), use citty's `default` property instead of runtime fallback logic:

--- a/apps/cli/src/commands/project/add-user.test.ts
+++ b/apps/cli/src/commands/project/add-user.test.ts
@@ -1,0 +1,85 @@
+import { getClient } from "@repo/backlog-utils";
+import { projectsAddUser } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  projectsAddUser: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+describe("project add-user", () => {
+  it("adds a user to a project", async () => {
+    setupMocks();
+    vi.mocked(projectsAddUser).mockResolvedValue({
+      data: { id: 12_345, name: "John Doe" },
+    } as never);
+
+    const { addUser } = await import("./add-user");
+    await addUser.run?.({
+      args: { project: "TEST", "user-id": "12345" },
+    } as never);
+
+    expect(projectsAddUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        path: { projectIdOrKey: "TEST" },
+        body: { userId: 12_345 },
+      }),
+    );
+    expect(consola.success).toHaveBeenCalledWith("Added user John Doe to project TEST.");
+  });
+
+  it("shows error when user-id is not a number", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    const { addUser } = await import("./add-user");
+
+    await expect(
+      addUser.run?.({
+        args: { project: "TEST", "user-id": "invalid" },
+      } as never),
+    ).rejects.toThrow("process.exit");
+
+    expect(consola.error).toHaveBeenCalledWith("User ID must be a number.");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    const user = { id: 12_345, name: "John Doe" };
+    vi.mocked(projectsAddUser).mockResolvedValue({
+      data: user,
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { addUser } = await import("./add-user");
+    await addUser.run?.({
+      args: { project: "TEST", "user-id": "12345", json: "" },
+    } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("John Doe"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/project/add-user.ts
+++ b/apps/cli/src/commands/project/add-user.ts
@@ -1,0 +1,73 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult } from "@repo/cli-utils";
+import { projectsAddUser } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Add a user to a Backlog project.
+
+The user is specified by their numeric user ID. Use "bee project users"
+to look up user IDs for a project.
+
+Requires Administrator or Project Administrator role.`,
+
+  examples: [
+    {
+      description: "Add a user to a project",
+      command: "bee project add-user -p PROJECT_KEY --user-id 12345",
+    },
+  ],
+
+  annotations: {
+    environment: [["BACKLOG_PROJECT", "Default project ID or project key"]],
+  },
+};
+
+const addUser = withUsage(
+  defineCommand({
+    meta: {
+      name: "add-user",
+      description: "Add a user to a project",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "string",
+        alias: "p",
+        description: "Project ID or project key",
+        required: true,
+        default: process.env.BACKLOG_PROJECT,
+      },
+      "user-id": {
+        type: "string",
+        description: "User ID (numeric)",
+        required: true,
+      },
+    },
+    async run({ args }) {
+      const userId = Number(args["user-id"]);
+      if (Number.isNaN(userId)) {
+        consola.error("User ID must be a number.");
+        return process.exit(1);
+      }
+
+      const { client } = await getClient();
+
+      const { data: user } = await projectsAddUser({
+        client,
+        throwOnError: true,
+        path: { projectIdOrKey: args.project },
+        body: { userId },
+      });
+
+      outputResult(user, args, (data) => {
+        consola.success(`Added user ${data.name} to project ${args.project}.`);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, addUser };

--- a/apps/cli/src/commands/project/create.test.ts
+++ b/apps/cli/src/commands/project/create.test.ts
@@ -1,0 +1,127 @@
+import { getClient } from "@repo/backlog-utils";
+import { promptRequired } from "@repo/cli-utils";
+import { projectsCreate } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  projectsCreate: vi.fn(),
+}));
+
+vi.mock("@repo/cli-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@repo/cli-utils")>();
+  return {
+    ...actual,
+    promptRequired: vi.fn(),
+  };
+});
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+describe("project create", () => {
+  it("creates a project with provided key and name", async () => {
+    setupMocks();
+    vi.mocked(promptRequired).mockResolvedValueOnce("TEST").mockResolvedValueOnce("Test Project");
+    vi.mocked(projectsCreate).mockResolvedValue({
+      data: { projectKey: "TEST", name: "Test Project", textFormattingRule: "markdown" },
+    } as never);
+
+    const { create } = await import("./create");
+    await create.run?.({ args: { key: "TEST", name: "Test Project" } } as never);
+
+    expect(projectsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        body: expect.objectContaining({
+          key: "TEST",
+          name: "Test Project",
+        }),
+      }),
+    );
+    expect(consola.success).toHaveBeenCalledWith("Created project TEST: Test Project");
+  });
+
+  it("prompts for key and name when not provided", async () => {
+    setupMocks();
+    vi.mocked(promptRequired)
+      .mockResolvedValueOnce("PROMPTED")
+      .mockResolvedValueOnce("Prompted Project");
+    vi.mocked(projectsCreate).mockResolvedValue({
+      data: { projectKey: "PROMPTED", name: "Prompted Project", textFormattingRule: "backlog" },
+    } as never);
+
+    const { create } = await import("./create");
+    await create.run?.({ args: {} } as never);
+
+    expect(promptRequired).toHaveBeenCalledWith("Project key:", undefined);
+    expect(promptRequired).toHaveBeenCalledWith("Project name:", undefined);
+    expect(projectsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          key: "PROMPTED",
+          name: "Prompted Project",
+        }),
+      }),
+    );
+  });
+
+  it("passes optional flags to API", async () => {
+    setupMocks();
+    vi.mocked(promptRequired).mockResolvedValueOnce("TEST").mockResolvedValueOnce("Test");
+    vi.mocked(projectsCreate).mockResolvedValue({
+      data: { projectKey: "TEST", name: "Test", textFormattingRule: "markdown" },
+    } as never);
+
+    const { create } = await import("./create");
+    await create.run?.({
+      args: {
+        key: "TEST",
+        name: "Test",
+        "chart-enabled": true,
+        "text-formatting-rule": "markdown",
+      },
+    } as never);
+
+    expect(projectsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({
+          chartEnabled: true,
+          textFormattingRule: "markdown",
+        }),
+      }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    vi.mocked(promptRequired).mockResolvedValueOnce("TEST").mockResolvedValueOnce("Test");
+    const project = { projectKey: "TEST", name: "Test", textFormattingRule: "markdown" };
+    vi.mocked(projectsCreate).mockResolvedValue({
+      data: project,
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { create } = await import("./create");
+    await create.run?.({ args: { key: "TEST", name: "Test", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/project/create.test.ts
+++ b/apps/cli/src/commands/project/create.test.ts
@@ -12,13 +12,10 @@ vi.mock("@repo/openapi-client", () => ({
   projectsCreate: vi.fn(),
 }));
 
-vi.mock("@repo/cli-utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@repo/cli-utils")>();
-  return {
-    ...actual,
-    promptRequired: vi.fn(),
-  };
-});
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+  promptRequired: vi.fn(),
+}));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 

--- a/apps/cli/src/commands/project/create.ts
+++ b/apps/cli/src/commands/project/create.ts
@@ -1,0 +1,95 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult, promptRequired } from "@repo/cli-utils";
+import { projectsCreate } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Create a new Backlog project.
+
+Project key must consist of uppercase letters (A-Z), numbers (0-9), and
+underscores (_). If name or key is not provided via flags, you will be
+prompted to enter them interactively.`,
+
+  examples: [
+    {
+      description: "Create a project with key and name",
+      command: 'bee project create --key TEST --name "Test Project"',
+    },
+    {
+      description: "Create a project with markdown formatting",
+      command:
+        'bee project create --key TEST --name "Test Project" --text-formatting-rule markdown',
+    },
+    {
+      description: "Create a project interactively",
+      command: "bee project create",
+    },
+  ],
+};
+
+const create = withUsage(
+  defineCommand({
+    meta: {
+      name: "create",
+      description: "Create a project",
+    },
+    args: {
+      ...outputArgs,
+      key: {
+        type: "string",
+        alias: "k",
+        description:
+          "Project key. Uppercase letters (A-Z), numbers (0-9) and underscore (_) can be used.",
+      },
+      name: {
+        type: "string",
+        alias: "n",
+        description: "Project name",
+      },
+      "chart-enabled": {
+        type: "boolean",
+        description: "Enable chart",
+      },
+      "subtasking-enabled": {
+        type: "boolean",
+        description: "Enable subtasking",
+      },
+      "project-leader-can-edit-project-leader": {
+        type: "boolean",
+        description: "Allow project administrators to manage each other",
+      },
+      "text-formatting-rule": {
+        type: "string",
+        description: "Formatting rules. {backlog|markdown}",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const key = await promptRequired("Project key:", args.key);
+      const name = await promptRequired("Project name:", args.name);
+
+      const { data: project } = await projectsCreate({
+        client,
+        throwOnError: true,
+        body: {
+          key,
+          name,
+          chartEnabled: args["chart-enabled"],
+          subtaskingEnabled: args["subtasking-enabled"],
+          projectLeaderCanEditProjectLeader: args["project-leader-can-edit-project-leader"],
+          textFormattingRule: args["text-formatting-rule"] as "backlog" | "markdown" | undefined,
+        },
+      });
+
+      outputResult(project, args, (data) => {
+        consola.success(`Created project ${data.projectKey}: ${data.name}`);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, create };

--- a/apps/cli/src/commands/project/delete.test.ts
+++ b/apps/cli/src/commands/project/delete.test.ts
@@ -12,13 +12,10 @@ vi.mock("@repo/openapi-client", () => ({
   projectsDelete: vi.fn(),
 }));
 
-vi.mock("@repo/cli-utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@repo/cli-utils")>();
-  return {
-    ...actual,
-    confirmOrExit: vi.fn(),
-  };
-});
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+  confirmOrExit: vi.fn(),
+}));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 

--- a/apps/cli/src/commands/project/delete.test.ts
+++ b/apps/cli/src/commands/project/delete.test.ts
@@ -1,0 +1,100 @@
+import { getClient } from "@repo/backlog-utils";
+import { confirmOrExit } from "@repo/cli-utils";
+import { projectsDelete } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  projectsDelete: vi.fn(),
+}));
+
+vi.mock("@repo/cli-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@repo/cli-utils")>();
+  return {
+    ...actual,
+    confirmOrExit: vi.fn(),
+  };
+});
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+describe("project delete", () => {
+  it("deletes project after confirmation", async () => {
+    setupMocks();
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    vi.mocked(projectsDelete).mockResolvedValue({
+      data: { projectKey: "TEST", name: "Test Project" },
+    } as never);
+
+    const { deleteProject } = await import("./delete");
+    await deleteProject.run?.({ args: { project: "TEST" } } as never);
+
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete project TEST? This cannot be undone.",
+      undefined,
+    );
+    expect(projectsDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        path: { projectIdOrKey: "TEST" },
+      }),
+    );
+    expect(consola.success).toHaveBeenCalledWith("Deleted project TEST: Test Project");
+  });
+
+  it("skips confirmation with --yes flag", async () => {
+    setupMocks();
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    vi.mocked(projectsDelete).mockResolvedValue({
+      data: { projectKey: "TEST", name: "Test Project" },
+    } as never);
+
+    const { deleteProject } = await import("./delete");
+    await deleteProject.run?.({ args: { project: "TEST", yes: true } } as never);
+
+    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+  });
+
+  it("cancels when user declines confirmation", async () => {
+    setupMocks();
+    vi.mocked(confirmOrExit).mockResolvedValue(false);
+
+    const { deleteProject } = await import("./delete");
+    await deleteProject.run?.({ args: { project: "TEST" } } as never);
+
+    expect(projectsDelete).not.toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    const project = { projectKey: "TEST", name: "Test Project" };
+    vi.mocked(projectsDelete).mockResolvedValue({
+      data: project,
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { deleteProject } = await import("./delete");
+    await deleteProject.run?.({ args: { project: "TEST", yes: true, json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/project/delete.ts
+++ b/apps/cli/src/commands/project/delete.ts
@@ -1,0 +1,78 @@
+import { getClient } from "@repo/backlog-utils";
+import { confirmOrExit, outputArgs, outputResult } from "@repo/cli-utils";
+import { projectsDelete } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Delete a Backlog project.
+
+This action is irreversible. You will be prompted for confirmation unless
+the --yes flag is provided.
+
+Requires Administrator role.`,
+
+  examples: [
+    {
+      description: "Delete a project (with confirmation)",
+      command: "bee project delete PROJECT_KEY",
+    },
+    {
+      description: "Delete a project without confirmation",
+      command: "bee project delete PROJECT_KEY --yes",
+    },
+  ],
+
+  annotations: {
+    environment: [["BACKLOG_PROJECT", "Default project ID or project key"]],
+  },
+};
+
+const deleteProject = withUsage(
+  defineCommand({
+    meta: {
+      name: "delete",
+      description: "Delete a project",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "positional",
+        description: "Project ID or project key",
+        required: true,
+        default: process.env.BACKLOG_PROJECT,
+      },
+      yes: {
+        type: "boolean",
+        alias: "y",
+        description: "Skip confirmation prompt",
+      },
+    },
+    async run({ args }) {
+      const confirmed = await confirmOrExit(
+        `Are you sure you want to delete project ${args.project}? This cannot be undone.`,
+        args.yes,
+      );
+
+      if (!confirmed) {
+        return;
+      }
+
+      const { client } = await getClient();
+
+      const { data: project } = await projectsDelete({
+        client,
+        throwOnError: true,
+        path: { projectIdOrKey: args.project },
+      });
+
+      outputResult(project, args, (data) => {
+        consola.success(`Deleted project ${data.projectKey}: ${data.name}`);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, deleteProject };

--- a/apps/cli/src/commands/project/edit.test.ts
+++ b/apps/cli/src/commands/project/edit.test.ts
@@ -1,0 +1,97 @@
+import { getClient } from "@repo/backlog-utils";
+import { projectsUpdate } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  projectsUpdate: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+describe("project edit", () => {
+  it("updates project name", async () => {
+    setupMocks();
+    vi.mocked(projectsUpdate).mockResolvedValue({
+      data: { projectKey: "TEST", name: "New Name" },
+    } as never);
+
+    const { edit } = await import("./edit");
+    await edit.run?.({ args: { project: "TEST", name: "New Name" } } as never);
+
+    expect(projectsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        path: { projectIdOrKey: "TEST" },
+        body: expect.objectContaining({ name: "New Name" }),
+      }),
+    );
+    expect(consola.success).toHaveBeenCalledWith("Updated project TEST: New Name");
+  });
+
+  it("updates project archived status", async () => {
+    setupMocks();
+    vi.mocked(projectsUpdate).mockResolvedValue({
+      data: { projectKey: "TEST", name: "Test" },
+    } as never);
+
+    const { edit } = await import("./edit");
+    await edit.run?.({ args: { project: "TEST", archived: true } } as never);
+
+    expect(projectsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ archived: true }),
+      }),
+    );
+  });
+
+  it("passes text formatting rule", async () => {
+    setupMocks();
+    vi.mocked(projectsUpdate).mockResolvedValue({
+      data: { projectKey: "TEST", name: "Test" },
+    } as never);
+
+    const { edit } = await import("./edit");
+    await edit.run?.({
+      args: { project: "TEST", "text-formatting-rule": "markdown" },
+    } as never);
+
+    expect(projectsUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ textFormattingRule: "markdown" }),
+      }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    const project = { projectKey: "TEST", name: "Test" };
+    vi.mocked(projectsUpdate).mockResolvedValue({
+      data: project,
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { edit } = await import("./edit");
+    await edit.run?.({ args: { project: "TEST", name: "Test", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/project/edit.ts
+++ b/apps/cli/src/commands/project/edit.ts
@@ -1,0 +1,105 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult } from "@repo/cli-utils";
+import { projectsUpdate } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Update an existing Backlog project.
+
+Only the specified fields will be updated. Fields that are not provided
+will remain unchanged.`,
+
+  examples: [
+    {
+      description: "Rename a project",
+      command: 'bee project edit PROJECT_KEY --name "New Name"',
+    },
+    {
+      description: "Archive a project",
+      command: "bee project edit PROJECT_KEY --archived",
+    },
+    {
+      description: "Change formatting rule to markdown",
+      command: "bee project edit PROJECT_KEY --text-formatting-rule markdown",
+    },
+  ],
+
+  annotations: {
+    environment: [["BACKLOG_PROJECT", "Default project ID or project key"]],
+  },
+};
+
+const edit = withUsage(
+  defineCommand({
+    meta: {
+      name: "edit",
+      description: "Edit a project",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "positional",
+        description: "Project ID or project key",
+        required: true,
+        default: process.env.BACKLOG_PROJECT,
+      },
+      name: {
+        type: "string",
+        alias: "n",
+        description: "Project name",
+      },
+      key: {
+        type: "string",
+        alias: "k",
+        description: "Project key",
+      },
+      "chart-enabled": {
+        type: "boolean",
+        description: "Enable chart",
+      },
+      "subtasking-enabled": {
+        type: "boolean",
+        description: "Enable subtasking",
+      },
+      "project-leader-can-edit-project-leader": {
+        type: "boolean",
+        description: "Allow project administrators to manage each other",
+      },
+      "text-formatting-rule": {
+        type: "string",
+        description: "Formatting rules. {backlog|markdown}",
+      },
+      archived: {
+        type: "boolean",
+        description: "Archive project",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const { data: project } = await projectsUpdate({
+        client,
+        throwOnError: true,
+        path: { projectIdOrKey: args.project },
+        body: {
+          name: args.name,
+          key: args.key,
+          chartEnabled: args["chart-enabled"],
+          subtaskingEnabled: args["subtasking-enabled"],
+          projectLeaderCanEditProjectLeader: args["project-leader-can-edit-project-leader"],
+          textFormattingRule: args["text-formatting-rule"] as "backlog" | "markdown" | undefined,
+          archived: args.archived,
+        },
+      });
+
+      outputResult(project, args, (data) => {
+        consola.success(`Updated project ${data.projectKey}: ${data.name}`);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, edit };

--- a/apps/cli/src/commands/project/edit.ts
+++ b/apps/cli/src/commands/project/edit.ts
@@ -48,32 +48,32 @@ const edit = withUsage(
       name: {
         type: "string",
         alias: "n",
-        description: "Project name",
+        description: "New name of the project",
       },
       key: {
         type: "string",
         alias: "k",
-        description: "Project key",
+        description: "New key of the project",
       },
       "chart-enabled": {
         type: "boolean",
-        description: "Enable chart",
+        description: "Change whether the chart is enabled",
       },
       "subtasking-enabled": {
         type: "boolean",
-        description: "Enable subtasking",
+        description: "Change whether subtasking is enabled",
       },
       "project-leader-can-edit-project-leader": {
         type: "boolean",
-        description: "Allow project administrators to manage each other",
+        description: "Change whether project administrators can manage each other",
       },
       "text-formatting-rule": {
         type: "string",
-        description: "Formatting rules. {backlog|markdown}",
+        description: "Change text formatting rule. {backlog|markdown}",
       },
       archived: {
         type: "boolean",
-        description: "Archive project",
+        description: "Change whether the project is archived",
       },
     },
     async run({ args }) {

--- a/apps/cli/src/commands/project/index.ts
+++ b/apps/cli/src/commands/project/index.ts
@@ -8,7 +8,12 @@ export const project = defineCommand({
   subCommands: {
     list: () => import("./list").then((m) => m.list),
     view: () => import("./view").then((m) => m.view),
+    create: () => import("./create").then((m) => m.create),
+    edit: () => import("./edit").then((m) => m.edit),
+    delete: () => import("./delete").then((m) => m.deleteProject),
     users: () => import("./users").then((m) => m.users),
     activities: () => import("./activities").then((m) => m.activities),
+    "add-user": () => import("./add-user").then((m) => m.addUser),
+    "remove-user": () => import("./remove-user").then((m) => m.removeUser),
   },
 });

--- a/apps/cli/src/commands/project/remove-user.test.ts
+++ b/apps/cli/src/commands/project/remove-user.test.ts
@@ -1,0 +1,85 @@
+import { getClient } from "@repo/backlog-utils";
+import { projectsDeleteUser } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  projectsDeleteUser: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+describe("project remove-user", () => {
+  it("removes a user from a project", async () => {
+    setupMocks();
+    vi.mocked(projectsDeleteUser).mockResolvedValue({
+      data: { id: 12_345, name: "John Doe" },
+    } as never);
+
+    const { removeUser } = await import("./remove-user");
+    await removeUser.run?.({
+      args: { project: "TEST", "user-id": "12345" },
+    } as never);
+
+    expect(projectsDeleteUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        path: { projectIdOrKey: "TEST" },
+        body: { userId: 12_345 },
+      }),
+    );
+    expect(consola.success).toHaveBeenCalledWith("Removed user John Doe from project TEST.");
+  });
+
+  it("shows error when user-id is not a number", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+
+    const { removeUser } = await import("./remove-user");
+
+    await expect(
+      removeUser.run?.({
+        args: { project: "TEST", "user-id": "abc" },
+      } as never),
+    ).rejects.toThrow("process.exit");
+
+    expect(consola.error).toHaveBeenCalledWith("User ID must be a number.");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    const user = { id: 12_345, name: "John Doe" };
+    vi.mocked(projectsDeleteUser).mockResolvedValue({
+      data: user,
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { removeUser } = await import("./remove-user");
+    await removeUser.run?.({
+      args: { project: "TEST", "user-id": "12345", json: "" },
+    } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("John Doe"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/project/remove-user.ts
+++ b/apps/cli/src/commands/project/remove-user.ts
@@ -1,0 +1,73 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult } from "@repo/cli-utils";
+import { projectsDeleteUser } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Remove a user from a Backlog project.
+
+The user is specified by their numeric user ID. Use "bee project users"
+to look up user IDs for a project.
+
+Requires Administrator or Project Administrator role.`,
+
+  examples: [
+    {
+      description: "Remove a user from a project",
+      command: "bee project remove-user -p PROJECT_KEY --user-id 12345",
+    },
+  ],
+
+  annotations: {
+    environment: [["BACKLOG_PROJECT", "Default project ID or project key"]],
+  },
+};
+
+const removeUser = withUsage(
+  defineCommand({
+    meta: {
+      name: "remove-user",
+      description: "Remove a user from a project",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "string",
+        alias: "p",
+        description: "Project ID or project key",
+        required: true,
+        default: process.env.BACKLOG_PROJECT,
+      },
+      "user-id": {
+        type: "string",
+        description: "User ID (numeric)",
+        required: true,
+      },
+    },
+    async run({ args }) {
+      const userId = Number(args["user-id"]);
+      if (Number.isNaN(userId)) {
+        consola.error("User ID must be a number.");
+        return process.exit(1);
+      }
+
+      const { client } = await getClient();
+
+      const { data: user } = await projectsDeleteUser({
+        client,
+        throwOnError: true,
+        path: { projectIdOrKey: args.project },
+        body: { userId },
+      });
+
+      outputResult(user, args, (data) => {
+        consola.success(`Removed user ${data.name} from project ${args.project}.`);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, removeUser };

--- a/packages/openapi/models/project.tsp
+++ b/packages/openapi/models/project.tsp
@@ -13,10 +13,10 @@ model Project {
   useDocument: boolean;
   useFileSharing: boolean;
   useWikiTreeView: boolean;
-  useSubversion: boolean;
-  useGit: boolean;
+  useSubversion?: boolean;
+  useGit?: boolean;
   useOriginalImageSizeAtWiki: boolean;
-  textFormattingRule: "backlog" | "markdown";
+  textFormattingRule: "backlog" | "markdown" | null;
   archived: boolean;
   displayOrder: int32;
   useDevAttributes: boolean;

--- a/packages/openapi/models/project.tsp
+++ b/packages/openapi/models/project.tsp
@@ -21,3 +21,108 @@ model Project {
   displayOrder: int32;
   useDevAttributes: boolean;
 }
+
+/** Request body for Add Project. */
+model AddProjectRequest {
+  @doc("Project Name")
+  name: string;
+
+  @doc("Project Key (Uppercase letters (A-Z), numbers (0-9) and underscore (_) can be used.)")
+  key: string;
+
+  @doc("Enable chart")
+  chartEnabled?: boolean;
+
+  @doc("Consider Resolved and statuses after as Closed")
+  useResolvedForChart?: boolean;
+
+  @doc("Enable subtasking")
+  subtaskingEnabled?: boolean;
+
+  @doc("Allow project administrators to manage each other")
+  projectLeaderCanEditProjectLeader?: boolean;
+
+  @doc("Enable Wiki")
+  useWiki?: boolean;
+
+  @doc("Enable shared files")
+  useFileSharing?: boolean;
+
+  @doc("Enable Wiki tree view")
+  useWikiTreeView?: boolean;
+
+  @doc("Enable Subversion")
+  useSubversion?: boolean;
+
+  @doc("Enable Git")
+  useGit?: boolean;
+
+  @doc("Display images in Wikis in their original size")
+  useOriginalImageSizeAtWiki?: boolean;
+
+  @doc("Formatting rules. {backlog|markdown}")
+  textFormattingRule?: "backlog" | "markdown";
+
+  @doc("Enable priorities, versions and milestones")
+  useDevAttributes?: boolean;
+}
+
+/** Request body for Update Project. */
+model UpdateProjectRequest {
+  @doc("Project Name")
+  name?: string;
+
+  @doc("Project Key")
+  key?: string;
+
+  @doc("Enable chart")
+  chartEnabled?: boolean;
+
+  @doc("Consider Resolved and statuses after as Closed")
+  useResolvedForChart?: boolean;
+
+  @doc("Enable subtasking")
+  subtaskingEnabled?: boolean;
+
+  @doc("Allow project administrators to manage each other")
+  projectLeaderCanEditProjectLeader?: boolean;
+
+  @doc("Enable Wiki")
+  useWiki?: boolean;
+
+  @doc("Enable shared files")
+  useFileSharing?: boolean;
+
+  @doc("Enable Wiki tree view")
+  useWikiTreeView?: boolean;
+
+  @doc("Enable Subversion")
+  useSubversion?: boolean;
+
+  @doc("Enable Git")
+  useGit?: boolean;
+
+  @doc("Display images in Wikis in their original size")
+  useOriginalImageSizeAtWiki?: boolean;
+
+  @doc("Formatting rules. {backlog|markdown}")
+  textFormattingRule?: "backlog" | "markdown";
+
+  @doc("Archive project")
+  archived?: boolean;
+
+  @doc("Enable priorities, versions and milestones")
+  useDevAttributes?: boolean;
+}
+
+/** Request body for Add Project User. */
+model AddProjectUserRequest {
+  @doc("User ID")
+  userId: int64;
+}
+
+/** Request body for Delete Project User. */
+model DeleteProjectUserRequest {
+  @doc("User ID")
+  userId: int64;
+}

--- a/packages/openapi/projects.tsp
+++ b/packages/openapi/projects.tsp
@@ -53,7 +53,10 @@ interface Projects {
   op create(
     @header contentType: "application/x-www-form-urlencoded",
     @body body: AddProjectRequest,
-  ): Project | BacklogErrorResponse;
+  ): {
+    @statusCode statusCode: 201;
+    @body body: Project;
+  } | BacklogErrorResponse;
 
   @summary("Update Project")
   @doc("Updates information about project.")

--- a/packages/openapi/projects.tsp
+++ b/packages/openapi/projects.tsp
@@ -46,4 +46,48 @@ interface Projects {
     @query count?: int32,
     @query order?: "asc" | "desc",
   ): Activity[] | BacklogErrorResponse;
+
+  @summary("Add Project")
+  @doc("Adds a new project.")
+  @post
+  op create(
+    @header contentType: "application/x-www-form-urlencoded",
+    @body body: AddProjectRequest,
+  ): Project | BacklogErrorResponse;
+
+  @summary("Update Project")
+  @doc("Updates information about project.")
+  @patch(#{implicitOptionality: true})
+  @route("/{projectIdOrKey}")
+  op update(
+    @path projectIdOrKey: string,
+    @header contentType: "application/x-www-form-urlencoded",
+    @body body: UpdateProjectRequest,
+  ): Project | BacklogErrorResponse;
+
+  @summary("Delete Project")
+  @doc("Deletes project.")
+  @delete
+  @route("/{projectIdOrKey}")
+  op delete(@path projectIdOrKey: string): Project | BacklogErrorResponse;
+
+  @summary("Add Project User")
+  @doc("Adds user to list of project members.")
+  @post
+  @route("/{projectIdOrKey}/users")
+  op addUser(
+    @path projectIdOrKey: string,
+    @header contentType: "application/x-www-form-urlencoded",
+    @body body: AddProjectUserRequest,
+  ): User | BacklogErrorResponse;
+
+  @summary("Delete Project User")
+  @doc("Removes user from list of project members.")
+  @delete
+  @route("/{projectIdOrKey}/users")
+  op deleteUser(
+    @path projectIdOrKey: string,
+    @header contentType: "application/x-www-form-urlencoded",
+    @body body: DeleteProjectUserRequest,
+  ): User | BacklogErrorResponse;
 }


### PR DESCRIPTION
## Summary
- Add 5 new project write commands: `create`, `edit`, `delete`, `add-user`, `remove-user`
- Add TypeSpec definitions for project write endpoints (`POST /projects`, `PATCH /projects/{id}`, `DELETE /projects/{id}`, `POST /projects/{id}/users`, `DELETE /projects/{id}/users`)
- Register new subcommands in project command group

## Details
- `create`: Supports interactive prompts for key/name via `promptRequired`, optional flags for chart, subtasking, text formatting rule
- `edit`: Only sends provided fields to API, supports name, key, archived, formatting rule changes
- `delete`: Uses `confirmOrExit` with `--yes` flag to skip confirmation
- `add-user` / `remove-user`: Numeric user ID validation, success/error messages

## Test plan (automated)
- [x] All 5 command files have corresponding test files (18 new tests)
- [x] Happy path tested for all commands
- [x] Error paths tested (invalid user ID, cancelled deletion)
- [x] `--json` output tested for all commands
- [x] `pnpm run typecheck` passes (6 packages)
- [x] `pnpm run test` passes (26 files, 179 tests)

## Manual testing

### `bee project create`
- [x] フラグ指定で作成: `bee project create -k TEST_CLI -n "Test Project"`
- [x] インタラクティブに作成: `bee project create` でキーと名前がプロンプト入力できる (TTY required)
- [x] オプションフラグ付きで作成: `--chart-enabled --subtasking-enabled --text-formatting-rule markdown`
- [x] `--json` で作成結果が JSON で出力される
- [x] 不正なキー (小文字・記号など) でバリデーションエラーになる

### `bee project edit`
- [x] 名前変更: `bee project edit PROJECT_KEY -n "New Name"`
- [x] 複数フィールド同時更新: `-n "New Name" --chart-enabled --text-formatting-rule markdown`
- [x] アーカイブ: `bee project edit PROJECT_KEY --archived`
- [x] `BACKLOG_PROJECT` 環境変数でプロジェクト指定を省略できる
- [x] `--json` で更新結果が JSON で出力される

### `bee project delete`
- [x] 確認プロンプトが表示され、承認すると削除される (TTY required)
- [x] 確認プロンプトで拒否すると削除されない (TTY required)
- [x] `--yes` で確認をスキップして削除される
- [x] `--json` で削除結果が JSON で出力される

### `bee project add-user`
- [x] ユーザー追加: `bee project add-user -p PROJECT_KEY --user-id 12345`
- [x] `--user-id` に数値以外を指定するとエラーになる
- [x] `BACKLOG_PROJECT` 環境変数でプロジェクト指定を省略できる
- [x] `--json` でユーザー情報が JSON で出力される

### `bee project remove-user`
- [x] ユーザー削除: `bee project remove-user -p PROJECT_KEY --user-id 12345`
- [x] `--user-id` に数値以外を指定するとエラーになる
- [x] `BACKLOG_PROJECT` 環境変数でプロジェクト指定を省略できる
- [x] `--json` でユーザー情報が JSON で出力される

### 共通
- [x] `bee project --help` に5つの新コマンドが表示される
- [x] 各コマンドの `--help` が gh CLI 風のヘルプを表示する

🤖 Generated with [Claude Code](https://claude.com/claude-code)