### PR TITLE
feat: add structured Backlog API error handling with code mapping

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { defineCommand, runCommand, runMain } from "citty";
+import { handleBacklogApiError } from "./lib/api-error-handler";
 import { showCommandUsage } from "./lib/command-usage";
 import { handleValidationError } from "./lib/validation-error";
 import pkg from "../package.json" with { type: "json" };
@@ -24,10 +25,11 @@ const rawArgs = process.argv.slice(2);
 if (rawArgs.includes("--help") || rawArgs.includes("-h") || rawArgs.includes("--version")) {
   void runMain(main, { showUsage: showCommandUsage });
 } else {
+  const useJson = rawArgs.includes("--json") || !process.stdout.isTTY;
   try {
     await runCommand(main, { rawArgs });
   } catch (error) {
-    if (!handleValidationError(error)) {
+    if (!handleBacklogApiError(error, { json: useJson }) && !handleValidationError(error)) {
       consola.error(error);
     }
     process.exit(1);

--- a/apps/cli/src/lib/api-error-handler.test.ts
+++ b/apps/cli/src/lib/api-error-handler.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import consola from "consola";
+import { handleBacklogApiError } from "./api-error-handler";
+
+vi.mock("consola", () => ({
+  default: {
+    error: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handleBacklogApiError", () => {
+  it("returns false for non-Backlog error objects", () => {
+    expect(handleBacklogApiError(new Error("something"), { json: false })).toBe(false);
+    expect(handleBacklogApiError("string", { json: false })).toBe(false);
+    expect(handleBacklogApiError(null, { json: false })).toBe(false);
+    expect(handleBacklogApiError({}, { json: false })).toBe(false);
+  });
+
+  it("returns true and logs formatted error for Backlog API error", () => {
+    const error = {
+      errors: [{ message: "No such project.", code: 6, moreInfo: "" }],
+    };
+
+    expect(handleBacklogApiError(error, { json: false })).toBe(true);
+    expect(consola.error).toHaveBeenCalledWith("NoResourceError: No such project.");
+  });
+
+  it("logs each error for multiple errors", () => {
+    const error = {
+      errors: [
+        { message: "Invalid param.", code: 7, moreInfo: "" },
+        { message: "Name is required.", code: 7, moreInfo: "name" },
+      ],
+    };
+
+    expect(handleBacklogApiError(error, { json: false })).toBe(true);
+    expect(consola.error).toHaveBeenCalledWith("InvalidRequestError: Invalid param.");
+    expect(consola.error).toHaveBeenCalledWith("InvalidRequestError: Name is required. (name)");
+  });
+
+  it("outputs raw JSON to stderr when json is true", () => {
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const error = {
+      errors: [{ message: "No such project.", code: 6, moreInfo: "" }],
+    };
+
+    expect(handleBacklogApiError(error, { json: true })).toBe(true);
+    expect(consola.error).not.toHaveBeenCalled();
+    expect(stderrWrite).toHaveBeenCalledWith(`${JSON.stringify(error)}\n`);
+
+    stderrWrite.mockRestore();
+  });
+});

--- a/apps/cli/src/lib/api-error-handler.ts
+++ b/apps/cli/src/lib/api-error-handler.ts
@@ -1,0 +1,22 @@
+import { formatBacklogError, isBacklogErrorResponse } from "@repo/backlog-utils";
+import consola from "consola";
+
+/**
+ * Handles Backlog API error responses thrown by hey-api client (throwOnError).
+ * Returns true if the error was a Backlog API error and was handled.
+ */
+export const handleBacklogApiError = (error: unknown, options: { json: boolean }): boolean => {
+  if (!isBacklogErrorResponse(error)) {
+    return false;
+  }
+
+  if (options.json) {
+    process.stderr.write(`${JSON.stringify(error)}\n`);
+    return true;
+  }
+
+  for (const line of formatBacklogError(error)) {
+    consola.error(line);
+  }
+  return true;
+};

--- a/packages/backlog-utils/src/api-error.test.ts
+++ b/packages/backlog-utils/src/api-error.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+import { formatBacklogError, isBacklogErrorResponse, errorCodeName } from "./api-error";
+
+describe("errorCodeName", () => {
+  test("returns error name for known code", () => {
+    expect(errorCodeName(1)).toBe("InternalError");
+    expect(errorCodeName(6)).toBe("NoResourceError");
+    expect(errorCodeName(13)).toBe("TooManyRequestsError");
+  });
+
+  test("returns undefined for unknown code", () => {
+    expect(errorCodeName(0)).toBeUndefined();
+    expect(errorCodeName(99)).toBeUndefined();
+  });
+});
+
+describe("isBacklogErrorResponse", () => {
+  test("returns true for valid Backlog error response", () => {
+    expect(
+      isBacklogErrorResponse({
+        errors: [{ message: "No such project.", code: 6, moreInfo: "" }],
+      }),
+    ).toBe(true);
+  });
+
+  test("returns true for multiple errors", () => {
+    expect(
+      isBacklogErrorResponse({
+        errors: [
+          { message: "Error 1", code: 7, moreInfo: "" },
+          { message: "Error 2", code: 7, moreInfo: "details" },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test("returns false for non-object values", () => {
+    expect(isBacklogErrorResponse(null)).toBe(false);
+    expect(isBacklogErrorResponse(undefined)).toBe(false);
+    expect(isBacklogErrorResponse("string")).toBe(false);
+    expect(isBacklogErrorResponse(42)).toBe(false);
+  });
+
+  test("returns false for objects without errors array", () => {
+    expect(isBacklogErrorResponse({})).toBe(false);
+    expect(isBacklogErrorResponse({ errors: "not array" })).toBe(false);
+    expect(isBacklogErrorResponse({ errors: [] })).toBe(false);
+  });
+
+  test("returns false for errors with missing fields", () => {
+    expect(isBacklogErrorResponse({ errors: [{ message: "hi" }] })).toBe(false);
+    expect(isBacklogErrorResponse({ errors: [{ code: 1 }] })).toBe(false);
+  });
+});
+
+describe("formatBacklogError", () => {
+  test("formats error with known code and no moreInfo", () => {
+    const result = formatBacklogError({
+      errors: [{ message: "No such project.", code: 6, moreInfo: "" }],
+    });
+    expect(result).toEqual(["NoResourceError: No such project."]);
+  });
+
+  test("formats error with moreInfo", () => {
+    const result = formatBacklogError({
+      errors: [
+        {
+          message: "No such project.",
+          code: 6,
+          moreInfo: "https://example.com/docs",
+        },
+      ],
+    });
+    expect(result).toEqual(["NoResourceError: No such project. (https://example.com/docs)"]);
+  });
+
+  test("formats multiple errors", () => {
+    const result = formatBacklogError({
+      errors: [
+        { message: "Invalid param.", code: 7, moreInfo: "" },
+        { message: "Name is required.", code: 7, moreInfo: "name" },
+      ],
+    });
+    expect(result).toEqual([
+      "InvalidRequestError: Invalid param.",
+      "InvalidRequestError: Name is required. (name)",
+    ]);
+  });
+
+  test("formats error with unknown code", () => {
+    const result = formatBacklogError({
+      errors: [{ message: "Something broke.", code: 999, moreInfo: "" }],
+    });
+    expect(result).toEqual(["UnknownError: Something broke."]);
+  });
+});

--- a/packages/backlog-utils/src/api-error.ts
+++ b/packages/backlog-utils/src/api-error.ts
@@ -1,0 +1,51 @@
+const errorCodeNames: Record<number, string> = {
+  1: "InternalError",
+  2: "LicenceError",
+  3: "LicenceExpiredError",
+  4: "AccessDeniedError",
+  5: "UnauthorizedOperationError",
+  6: "NoResourceError",
+  7: "InvalidRequestError",
+  8: "SpaceOverCapacityError",
+  9: "ResourceOverflowError",
+  10: "TooLargeFileError",
+  11: "AuthenticationError",
+  12: "RequiredMFAError",
+  13: "TooManyRequestsError",
+};
+
+type BacklogErrorDetail = {
+  message: string;
+  code: number;
+  moreInfo: string;
+};
+
+type BacklogErrorResponse = {
+  errors: BacklogErrorDetail[];
+};
+
+const errorCodeName = (code: number): string | undefined => errorCodeNames[code];
+
+const isBacklogErrorDetail = (value: unknown): value is BacklogErrorDetail =>
+  typeof value === "object" &&
+  value !== null &&
+  typeof (value as BacklogErrorDetail).message === "string" &&
+  typeof (value as BacklogErrorDetail).code === "number" &&
+  typeof (value as BacklogErrorDetail).moreInfo === "string";
+
+const isBacklogErrorResponse = (value: unknown): value is BacklogErrorResponse =>
+  typeof value === "object" &&
+  value !== null &&
+  Array.isArray((value as BacklogErrorResponse).errors) &&
+  (value as BacklogErrorResponse).errors.length > 0 &&
+  (value as BacklogErrorResponse).errors.every(isBacklogErrorDetail);
+
+const formatBacklogError = (response: BacklogErrorResponse): string[] =>
+  response.errors.map((e) => {
+    const name = errorCodeNames[e.code] ?? "UnknownError";
+    const info = e.moreInfo ? ` (${e.moreInfo})` : "";
+    return `${name}: ${e.message}${info}`;
+  });
+
+export { errorCodeName, isBacklogErrorResponse, formatBacklogError };
+export type { BacklogErrorResponse };

--- a/packages/backlog-utils/src/index.ts
+++ b/packages/backlog-utils/src/index.ts
@@ -1,3 +1,5 @@
+export { formatBacklogError, isBacklogErrorResponse } from "./api-error";
+export type { BacklogErrorResponse } from "./api-error";
 export { addApiKeyAuth, addBearerAuth, getClient } from "./client";
 export type { BacklogClient } from "./client";
 export { exchangeAuthorizationCode, refreshAccessToken } from "./oauth";

--- a/packages/openapi/models/common.tsp
+++ b/packages/openapi/models/common.tsp
@@ -6,18 +6,26 @@ namespace Backlog;
 // Error
 // ────────────────────────────────────────────
 
+/** Error code returned by the Backlog API. */
+enum BacklogErrorCode {
+  InternalError: 1,
+  LicenceError: 2,
+  LicenceExpiredError: 3,
+  AccessDeniedError: 4,
+  UnauthorizedOperationError: 5,
+  NoResourceError: 6,
+  InvalidRequestError: 7,
+  SpaceOverCapacityError: 8,
+  ResourceOverflowError: 9,
+  TooLargeFileError: 10,
+  AuthenticationError: 11,
+  RequiredMFAError: 12,
+  TooManyRequestsError: 13,
+}
+
 model BacklogErrorDetail {
   message: string;
-
-  @doc("""
-    1: InternalError, 2: LicenceError, 3: LicenceExpiredError,
-    4: AccessDeniedError, 5: UnauthorizedOperationError, 6: NoResourceError,
-    7: InvalidRequestError, 8: SpaceOverCapacityError, 9: ResourceOverflowError,
-    10: TooLargeFileError, 11: AuthenticationError, 12: RequiredMFAError,
-    13: TooManyRequestsError
-    """)
-  code: int32;
-
+  code: BacklogErrorCode;
   moreInfo: string;
 }
 


### PR DESCRIPTION
## Summary

- Map Backlog API error codes (1–13) to human-readable error type names (e.g., `NoResourceError`, `InvalidRequestError`) in CLI error output
- Output raw JSON to stderr when `--json` flag is present or stdout is not a TTY, for programmatic consumption
- Define `BacklogErrorCode` enum in TypeSpec replacing inline `@doc` comment on `code: int32`, improving type safety in generated client code

## Changes

- `packages/openapi/models/common.tsp` — Add `BacklogErrorCode` enum, update `BacklogErrorDetail.code` to use it
- `packages/backlog-utils/src/api-error.ts` — Error code name mapping, response shape detection, formatting utility
- `apps/cli/src/lib/api-error-handler.ts` — Global error handler for Backlog API errors with JSON/human-readable output
- `apps/cli/src/index.ts` — Integrate `handleBacklogApiError` into global catch, add `--json`/TTY detection

## Test plan

- [x] 11 unit tests for `api-error.ts` (code mapping, shape detection, formatting)
- [x] 4 unit tests for `api-error-handler.ts` (human-readable output, JSON output, non-Backlog error passthrough)
- [x] All 194 existing tests pass
- [x] TypeSpec compiles successfully
- [x] OpenAPI client regenerated with `BacklogErrorCode` type
- [x] `typecheck` passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)