### PR TITLE
feat(issue): implement issue read commands

### DIFF
--- a/apps/cli/src/commands/issue/index.ts
+++ b/apps/cli/src/commands/issue/index.ts
@@ -1,0 +1,13 @@
+import { defineCommand } from "citty";
+
+export const issue = defineCommand({
+  meta: {
+    name: "issue",
+    description: "Manage Backlog issues",
+  },
+  subCommands: {
+    list: () => import("./list").then((m) => m.list),
+    view: () => import("./view").then((m) => m.view),
+    status: () => import("./status").then((m) => m.status),
+  },
+});

--- a/apps/cli/src/commands/issue/list.test.ts
+++ b/apps/cli/src/commands/issue/list.test.ts
@@ -1,0 +1,154 @@
+import { getClient } from "@repo/backlog-utils";
+import { issuesList } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  issuesList: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+const sampleIssues = [
+  {
+    issueKey: "PROJ-1",
+    summary: "First issue",
+    status: { name: "Open" },
+    issueType: { name: "Bug" },
+    priority: { name: "High" },
+    assignee: { name: "Alice" },
+  },
+  {
+    issueKey: "PROJ-2",
+    summary: "Second issue",
+    status: { name: "In Progress" },
+    issueType: { name: "Task" },
+    priority: { name: "Normal" },
+    assignee: null,
+  },
+];
+
+describe("issue list", () => {
+  it("displays issue list in tabular format", async () => {
+    setupMocks();
+    vi.mocked(issuesList).mockResolvedValue({
+      data: sampleIssues,
+    } as never);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(issuesList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+      }),
+    );
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("KEY"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("PROJ-2"));
+  });
+
+  it("shows message when no issues found", async () => {
+    setupMocks();
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [],
+    } as never);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No issues found.");
+  });
+
+  it("shows Unassigned for issues without assignee", async () => {
+    setupMocks();
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [sampleIssues[1]],
+    } as never);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Unassigned"));
+  });
+
+  it("passes project query parameter", async () => {
+    setupMocks();
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [],
+    } as never);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { project: "123" } } as never);
+
+    expect(issuesList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ "projectId[]": [123] }),
+      }),
+    );
+  });
+
+  it("passes assignee query parameter", async () => {
+    setupMocks();
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [],
+    } as never);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { assignee: "42" } } as never);
+
+    expect(issuesList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ "assigneeId[]": [42] }),
+      }),
+    );
+  });
+
+  it("passes keyword query parameter", async () => {
+    setupMocks();
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [],
+    } as never);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { keyword: "login bug" } } as never);
+
+    expect(issuesList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.objectContaining({ keyword: "login bug" }),
+      }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    vi.mocked(issuesList).mockResolvedValue({
+      data: sampleIssues,
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/issue/list.ts
+++ b/apps/cli/src/commands/issue/list.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { type Row, outputArgs, outputResult, printTable } from "@repo/cli-utils";
+import { type Row, outputArgs, outputResult, printTable, splitArg } from "@repo/cli-utils";
 import { issuesList, vIssueSortField } from "@repo/openapi-client";
 import { defineCommand } from "citty";
 import consola from "consola";
@@ -46,7 +46,7 @@ const list = withUsage(
       assignee: {
         type: "string",
         alias: "a",
-        description: "Assignee user ID. Use @me for yourself.",
+        description: "Assignee user ID (comma-separated for multiple). Use @me for yourself.",
       },
       status: {
         type: "string",
@@ -56,7 +56,7 @@ const list = withUsage(
       priority: {
         type: "string",
         alias: "P",
-        description: "Priority ID",
+        description: "Priority ID (comma-separated for multiple)",
       },
       keyword: {
         type: "string",
@@ -109,15 +109,10 @@ const list = withUsage(
     async run({ args }) {
       const { client } = await getClient();
 
-      const projectId = args.project
-        ? args.project.split(",").map((k) => Number(k.trim()))
-        : undefined;
-
-      const assigneeId = args.assignee ? [Number(args.assignee)] : undefined;
-      const statusId = args.status
-        ? args.status.split(",").map((s) => Number(s.trim()))
-        : undefined;
-      const priorityId = args.priority ? [Number(args.priority)] : undefined;
+      const projectId = splitArg(args.project, v.number());
+      const assigneeId = splitArg(args.assignee, v.number());
+      const statusId = splitArg(args.status, v.number());
+      const priorityId = splitArg(args.priority, v.number());
 
       const sort = args.sort ? v.parse(vIssueSortField, args.sort) : undefined;
       const order = args.order ? v.parse(v.picklist(["asc", "desc"]), args.order) : undefined;

--- a/apps/cli/src/commands/issue/list.ts
+++ b/apps/cli/src/commands/issue/list.ts
@@ -1,8 +1,9 @@
 import { getClient } from "@repo/backlog-utils";
 import { type Row, outputArgs, outputResult, printTable } from "@repo/cli-utils";
-import { issuesList } from "@repo/openapi-client";
+import { issuesList, vIssueSortField } from "@repo/openapi-client";
 import { defineCommand } from "citty";
 import consola from "consola";
+import * as v from "valibot";
 import { type CommandUsage, withUsage } from "../../lib/command-usage";
 
 const commandUsage: CommandUsage = {
@@ -118,6 +119,9 @@ const list = withUsage(
         : undefined;
       const priorityId = args.priority ? [Number(args.priority)] : undefined;
 
+      const sort = args.sort ? v.parse(vIssueSortField, args.sort) : undefined;
+      const order = args.order ? v.parse(v.picklist(["asc", "desc"]), args.order) : undefined;
+
       const { data: issues } = await issuesList({
         client,
         throwOnError: true,
@@ -127,30 +131,8 @@ const list = withUsage(
           "statusId[]": statusId,
           "priorityId[]": priorityId,
           keyword: args.keyword,
-          sort: args.sort as
-            | "id"
-            | "project"
-            | "issueType"
-            | "category"
-            | "version"
-            | "milestone"
-            | "summary"
-            | "status"
-            | "priority"
-            | "attachment"
-            | "sharedFile"
-            | "created"
-            | "createdUser"
-            | "updated"
-            | "updatedUser"
-            | "assignee"
-            | "startDate"
-            | "dueDate"
-            | "estimatedHours"
-            | "actualHours"
-            | "childIssue"
-            | undefined,
-          order: args.order as "asc" | "desc" | undefined,
+          sort,
+          order,
           count: args.count ? Number(args.count) : undefined,
           offset: args.offset ? Number(args.offset) : undefined,
           createdSince: args["created-since"],

--- a/apps/cli/src/commands/issue/list.ts
+++ b/apps/cli/src/commands/issue/list.ts
@@ -1,0 +1,185 @@
+import { getClient } from "@repo/backlog-utils";
+import { type Row, outputArgs, outputResult, printTable } from "@repo/cli-utils";
+import { issuesList } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `List issues from one or more Backlog projects.
+
+By default, issues are sorted by last updated date in descending order.
+Use filtering flags to narrow results by assignee, status, priority, and more.
+
+Multiple project keys can be specified as a comma-separated list.`,
+
+  examples: [
+    { description: "List issues in a project", command: "bee issue list -p PROJECT" },
+    { description: "List your assigned issues", command: "bee issue list -p PROJECT -a @me" },
+    {
+      description: "Filter by keyword and priority",
+      command: 'bee issue list -p PROJECT -k "login bug" --priority 高',
+    },
+    { description: "Output as JSON", command: "bee issue list -p PROJECT --json" },
+  ],
+
+  annotations: {
+    environment: [["BACKLOG_PROJECT", "Default project ID or project key"]],
+  },
+};
+
+const list = withUsage(
+  defineCommand({
+    meta: {
+      name: "list",
+      description: "List issues",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "string",
+        alias: "p",
+        description: "Project ID or project key (comma-separated for multiple)",
+        default: process.env.BACKLOG_PROJECT,
+      },
+      assignee: {
+        type: "string",
+        alias: "a",
+        description: "Assignee user ID. Use @me for yourself.",
+      },
+      status: {
+        type: "string",
+        alias: "S",
+        description: "Status ID (comma-separated for multiple)",
+      },
+      priority: {
+        type: "string",
+        alias: "P",
+        description: "Priority ID",
+      },
+      keyword: {
+        type: "string",
+        alias: "k",
+        description: "Keyword search",
+      },
+      "created-since": {
+        type: "string",
+        description: "Created since (yyyy-MM-dd)",
+      },
+      "created-until": {
+        type: "string",
+        description: "Created until (yyyy-MM-dd)",
+      },
+      "updated-since": {
+        type: "string",
+        description: "Updated since (yyyy-MM-dd)",
+      },
+      "updated-until": {
+        type: "string",
+        description: "Updated until (yyyy-MM-dd)",
+      },
+      "due-since": {
+        type: "string",
+        description: "Due date since (yyyy-MM-dd)",
+      },
+      "due-until": {
+        type: "string",
+        description: "Due date until (yyyy-MM-dd)",
+      },
+      sort: {
+        type: "string",
+        description:
+          "Sort field. {issueType|category|version|milestone|summary|status|priority|attachment|sharedFile|created|createdUser|updated|updatedUser|assignee|startDate|dueDate|estimatedHours|actualHours|childIssue}",
+      },
+      order: {
+        type: "string",
+        description: "Sort order. {asc|desc}",
+      },
+      count: {
+        type: "string",
+        alias: "L",
+        description: "Number of results (1-100, default: 20)",
+      },
+      offset: {
+        type: "string",
+        description: "Offset for pagination",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const projectId = args.project
+        ? args.project.split(",").map((k) => Number(k.trim()))
+        : undefined;
+
+      const assigneeId = args.assignee ? [Number(args.assignee)] : undefined;
+      const statusId = args.status
+        ? args.status.split(",").map((s) => Number(s.trim()))
+        : undefined;
+      const priorityId = args.priority ? [Number(args.priority)] : undefined;
+
+      const { data: issues } = await issuesList({
+        client,
+        throwOnError: true,
+        query: {
+          "projectId[]": projectId,
+          "assigneeId[]": assigneeId,
+          "statusId[]": statusId,
+          "priorityId[]": priorityId,
+          keyword: args.keyword,
+          sort: args.sort as
+            | "issueType"
+            | "category"
+            | "version"
+            | "milestone"
+            | "summary"
+            | "status"
+            | "priority"
+            | "attachment"
+            | "sharedFile"
+            | "created"
+            | "createdUser"
+            | "updated"
+            | "updatedUser"
+            | "assignee"
+            | "startDate"
+            | "dueDate"
+            | "estimatedHours"
+            | "actualHours"
+            | "childIssue"
+            | undefined,
+          order: args.order as "asc" | "desc" | undefined,
+          count: args.count ? Number(args.count) : undefined,
+          offset: args.offset ? Number(args.offset) : undefined,
+          createdSince: args["created-since"],
+          createdUntil: args["created-until"],
+          updatedSince: args["updated-since"],
+          updatedUntil: args["updated-until"],
+          dueDateSince: args["due-since"],
+          dueDateUntil: args["due-until"],
+        },
+      });
+
+      outputResult(issues, args, (data) => {
+        if (data.length === 0) {
+          consola.info("No issues found.");
+          return;
+        }
+
+        const rows: Row[] = data.map((issue) => [
+          { header: "KEY", value: issue.issueKey },
+          { header: "STATUS", value: issue.status.name },
+          { header: "TYPE", value: issue.issueType.name },
+          { header: "PRIORITY", value: issue.priority.name },
+          { header: "ASSIGNEE", value: issue.assignee?.name ?? "Unassigned" },
+          { header: "SUMMARY", value: issue.summary },
+        ]);
+
+        printTable(rows);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, list };

--- a/apps/cli/src/commands/issue/list.ts
+++ b/apps/cli/src/commands/issue/list.ts
@@ -128,6 +128,8 @@ const list = withUsage(
           "priorityId[]": priorityId,
           keyword: args.keyword,
           sort: args.sort as
+            | "id"
+            | "project"
             | "issueType"
             | "category"
             | "version"

--- a/apps/cli/src/commands/issue/status.test.ts
+++ b/apps/cli/src/commands/issue/status.test.ts
@@ -1,0 +1,105 @@
+import { getClient } from "@repo/backlog-utils";
+import { issuesList, usersGetMyself } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  usersGetMyself: vi.fn(),
+  issuesList: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+const sampleUser = {
+  id: 100,
+  name: "Alice",
+};
+
+describe("issue status", () => {
+  it("displays issues grouped by status", async () => {
+    setupMocks();
+    vi.mocked(usersGetMyself).mockResolvedValue({
+      data: sampleUser,
+    } as never);
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [
+        { issueKey: "PROJ-1", summary: "Open issue", status: { name: "Open" } },
+        { issueKey: "PROJ-2", summary: "Another open", status: { name: "Open" } },
+        { issueKey: "PROJ-3", summary: "In progress", status: { name: "In Progress" } },
+      ],
+    } as never);
+
+    const { status } = await import("./status");
+    await status.run?.({ args: {} } as never);
+
+    expect(usersGetMyself).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+      }),
+    );
+    expect(issuesList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        query: expect.objectContaining({
+          "assigneeId[]": [100],
+          count: 100,
+        }),
+      }),
+    );
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Alice"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Open (2)"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("In Progress (1)"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("PROJ-3"));
+  });
+
+  it("shows message when no issues assigned", async () => {
+    setupMocks();
+    vi.mocked(usersGetMyself).mockResolvedValue({
+      data: sampleUser,
+    } as never);
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [],
+    } as never);
+
+    const { status } = await import("./status");
+    await status.run?.({ args: {} } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No issues assigned to you.");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    vi.mocked(usersGetMyself).mockResolvedValue({
+      data: sampleUser,
+    } as never);
+    vi.mocked(issuesList).mockResolvedValue({
+      data: [{ issueKey: "PROJ-1", summary: "Test", status: { name: "Open" } }],
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { status } = await import("./status");
+    await status.run?.({ args: { json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/issue/status.ts
+++ b/apps/cli/src/commands/issue/status.ts
@@ -53,7 +53,7 @@ const status = withUsage(
       outputResult({ user: me, issues }, args, (data) => {
         const grouped = new Map<string, typeof data.issues>();
         for (const issue of data.issues) {
-          const {name} = issue.status;
+          const { name } = issue.status;
           const group = grouped.get(name) ?? [];
           group.push(issue);
           grouped.set(name, group);

--- a/apps/cli/src/commands/issue/status.ts
+++ b/apps/cli/src/commands/issue/status.ts
@@ -1,0 +1,79 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult } from "@repo/cli-utils";
+import { issuesList, usersGetMyself } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Show a summary of issues assigned to you, grouped by status.
+
+Fetches issues where you are the assignee and displays them organized by
+their current status (e.g., Open, In Progress, Resolved).`,
+
+  examples: [
+    { description: "Show your issue status summary", command: "bee issue status" },
+    { description: "Output as JSON", command: "bee issue status --json" },
+  ],
+};
+
+const status = withUsage(
+  defineCommand({
+    meta: {
+      name: "status",
+      description: "Show issue status summary for yourself",
+    },
+    args: {
+      ...outputArgs,
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const { data: me } = await usersGetMyself({
+        client,
+        throwOnError: true,
+      });
+
+      const { data: issues } = await issuesList({
+        client,
+        throwOnError: true,
+        query: {
+          "assigneeId[]": [me.id],
+          count: 100,
+        },
+      });
+
+      if (issues.length === 0) {
+        outputResult({ user: me, issues: [] }, args, () => {
+          consola.info("No issues assigned to you.");
+        });
+        return;
+      }
+
+      outputResult({ user: me, issues }, args, (data) => {
+        const grouped = new Map<string, typeof data.issues>();
+        for (const issue of data.issues) {
+          const {name} = issue.status;
+          const group = grouped.get(name) ?? [];
+          group.push(issue);
+          grouped.set(name, group);
+        }
+
+        consola.log("");
+        consola.log(`  Issues assigned to ${data.user.name}:`);
+        consola.log("");
+
+        for (const [statusName, statusIssues] of grouped) {
+          consola.log(`  ${statusName} (${statusIssues.length}):`);
+          for (const issue of statusIssues) {
+            consola.log(`    ${issue.issueKey}  ${issue.summary}`);
+          }
+          consola.log("");
+        }
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, status };

--- a/apps/cli/src/commands/issue/view.test.ts
+++ b/apps/cli/src/commands/issue/view.test.ts
@@ -1,0 +1,159 @@
+import { getClient, openUrl } from "@repo/backlog-utils";
+import { issuesGet, issuesGetComments } from "@repo/openapi-client";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(),
+  openUrl: vi.fn(),
+  issueUrl: vi.fn((host: string, key: string) => `https://${host}/view/${key}`),
+}));
+
+vi.mock("@repo/openapi-client", () => ({
+  issuesGet: vi.fn(),
+  issuesGetComments: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const mockClient = {
+  interceptors: { request: { use: vi.fn() } },
+};
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+const sampleIssue = {
+  id: 1,
+  issueKey: "PROJ-1",
+  summary: "Test issue",
+  description: "A test description",
+  status: { name: "Open" },
+  issueType: { name: "Bug" },
+  priority: { name: "High" },
+  assignee: { name: "Alice" },
+  createdUser: { name: "Bob" },
+  created: "2025-01-01T00:00:00Z",
+  updated: "2025-01-02T00:00:00Z",
+  startDate: null,
+  dueDate: null,
+  estimatedHours: null,
+  actualHours: null,
+  category: [],
+  milestone: [],
+  versions: [],
+};
+
+describe("issue view", () => {
+  it("displays issue details", async () => {
+    setupMocks();
+    vi.mocked(issuesGet).mockResolvedValue({
+      data: sampleIssue,
+    } as never);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { issueKey: "PROJ-1" } } as never);
+
+    expect(issuesGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        path: { issueIdOrKey: "PROJ-1" },
+      }),
+    );
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Test issue"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Open"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Bug"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("High"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Alice"));
+  });
+
+  it("shows Unassigned for issues without assignee", async () => {
+    setupMocks();
+    vi.mocked(issuesGet).mockResolvedValue({
+      data: { ...sampleIssue, assignee: null },
+    } as never);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { issueKey: "PROJ-1" } } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Unassigned"));
+  });
+
+  it("displays description when present", async () => {
+    setupMocks();
+    vi.mocked(issuesGet).mockResolvedValue({
+      data: sampleIssue,
+    } as never);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { issueKey: "PROJ-1" } } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Description"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("A test description"));
+  });
+
+  it("fetches and displays comments with --comments flag", async () => {
+    setupMocks();
+    vi.mocked(issuesGet).mockResolvedValue({
+      data: sampleIssue,
+    } as never);
+    vi.mocked(issuesGetComments).mockResolvedValue({
+      data: [
+        {
+          content: "A comment",
+          createdUser: { name: "Charlie" },
+          created: "2025-01-03T00:00:00Z",
+        },
+      ],
+    } as never);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { issueKey: "PROJ-1", comments: true } } as never);
+
+    expect(issuesGetComments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client: mockClient,
+        throwOnError: true,
+        path: { issueIdOrKey: "PROJ-1" },
+        query: { order: "asc" },
+      }),
+    );
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Comments"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Charlie"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("A comment"));
+  });
+
+  it("opens browser with --web flag", async () => {
+    setupMocks();
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { issueKey: "PROJ-1", web: true } } as never);
+
+    expect(openUrl).toHaveBeenCalledWith("https://example.backlog.com/view/PROJ-1");
+    expect(consola.info).toHaveBeenCalledWith(
+      "Opening https://example.backlog.com/view/PROJ-1 in your browser.",
+    );
+    expect(issuesGet).not.toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    vi.mocked(issuesGet).mockResolvedValue({
+      data: sampleIssue,
+    } as never);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { issueKey: "PROJ-1", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/issue/view.test.ts
+++ b/apps/cli/src/commands/issue/view.test.ts
@@ -45,7 +45,7 @@ const sampleIssue = {
   actualHours: null,
   category: [],
   milestone: [],
-  versions: [],
+  version: [],
 };
 
 describe("issue view", () => {

--- a/apps/cli/src/commands/issue/view.test.ts
+++ b/apps/cli/src/commands/issue/view.test.ts
@@ -56,7 +56,7 @@ describe("issue view", () => {
     } as never);
 
     const { view } = await import("./view");
-    await view.run?.({ args: { issueKey: "PROJ-1" } } as never);
+    await view.run?.({ args: { issue: "PROJ-1" } } as never);
 
     expect(issuesGet).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -80,7 +80,7 @@ describe("issue view", () => {
     } as never);
 
     const { view } = await import("./view");
-    await view.run?.({ args: { issueKey: "PROJ-1" } } as never);
+    await view.run?.({ args: { issue: "PROJ-1" } } as never);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Unassigned"));
   });
@@ -92,7 +92,7 @@ describe("issue view", () => {
     } as never);
 
     const { view } = await import("./view");
-    await view.run?.({ args: { issueKey: "PROJ-1" } } as never);
+    await view.run?.({ args: { issue: "PROJ-1" } } as never);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Description"));
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("A test description"));
@@ -114,7 +114,7 @@ describe("issue view", () => {
     } as never);
 
     const { view } = await import("./view");
-    await view.run?.({ args: { issueKey: "PROJ-1", comments: true } } as never);
+    await view.run?.({ args: { issue: "PROJ-1", comments: true } } as never);
 
     expect(issuesGetComments).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -133,7 +133,7 @@ describe("issue view", () => {
     setupMocks();
 
     const { view } = await import("./view");
-    await view.run?.({ args: { issueKey: "PROJ-1", web: true } } as never);
+    await view.run?.({ args: { issue: "PROJ-1", web: true } } as never);
 
     expect(openUrl).toHaveBeenCalledWith("https://example.backlog.com/view/PROJ-1");
     expect(consola.info).toHaveBeenCalledWith(
@@ -151,7 +151,7 @@ describe("issue view", () => {
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
     const { view } = await import("./view");
-    await view.run?.({ args: { issueKey: "PROJ-1", json: "" } } as never);
+    await view.run?.({ args: { issue: "PROJ-1", json: "" } } as never);
 
     expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
     writeSpy.mockRestore();

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -30,9 +30,9 @@ const view = withUsage(
     },
     args: {
       ...outputArgs,
-      issueKey: {
+      issue: {
         type: "positional",
-        description: "Issue key. e.g., PROJECT-123",
+        description: "Issue key or ID. e.g., PROJECT-123",
         required: true,
       },
       comments: {
@@ -49,7 +49,7 @@ const view = withUsage(
       const { client, host } = await getClient();
 
       if (args.web) {
-        const url = issueUrl(host, args.issueKey);
+        const url = issueUrl(host, args.issue);
         await openUrl(url);
         consola.info(`Opening ${url} in your browser.`);
         return;
@@ -58,7 +58,7 @@ const view = withUsage(
       const { data: issue } = await issuesGet({
         client,
         throwOnError: true,
-        path: { issueIdOrKey: args.issueKey },
+        path: { issueIdOrKey: args.issue },
       });
 
       const comments = args.comments
@@ -66,7 +66,7 @@ const view = withUsage(
             await issuesGetComments({
               client,
               throwOnError: true,
-              path: { issueIdOrKey: args.issueKey },
+              path: { issueIdOrKey: args.issue },
               query: { order: "asc" },
             })
           ).data

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -1,0 +1,145 @@
+import { getClient, issueUrl, openUrl } from "@repo/backlog-utils";
+import { formatDate, outputArgs, outputResult } from "@repo/cli-utils";
+import { issuesGet, issuesGetComments } from "@repo/openapi-client";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Display details of a Backlog issue.
+
+Shows the issue summary, status, type, priority, assignee, dates, and
+description. Use --comments to also fetch and display comments.
+
+Use --web to open the issue in your default browser instead of showing
+details in the terminal.`,
+
+  examples: [
+    { description: "View issue details", command: "bee issue view PROJECT-123" },
+    { description: "View with comments", command: "bee issue view PROJECT-123 --comments" },
+    { description: "Open issue in browser", command: "bee issue view PROJECT-123 --web" },
+    { description: "Output as JSON", command: "bee issue view PROJECT-123 --json" },
+  ],
+};
+
+const view = withUsage(
+  defineCommand({
+    meta: {
+      name: "view",
+      description: "View an issue",
+    },
+    args: {
+      ...outputArgs,
+      issueKey: {
+        type: "positional",
+        description: "Issue key. e.g., PROJECT-123",
+        required: true,
+      },
+      comments: {
+        type: "boolean",
+        description: "Include comments",
+      },
+      web: {
+        type: "boolean",
+        alias: "w",
+        description: "Open the issue in the browser",
+      },
+    },
+    async run({ args }) {
+      const { client, host } = await getClient();
+
+      if (args.web) {
+        const url = issueUrl(host, args.issueKey);
+        await openUrl(url);
+        consola.info(`Opening ${url} in your browser.`);
+        return;
+      }
+
+      const { data: issue } = await issuesGet({
+        client,
+        throwOnError: true,
+        path: { issueIdOrKey: args.issueKey },
+      });
+
+      const comments = args.comments
+        ? (
+            await issuesGetComments({
+              client,
+              throwOnError: true,
+              path: { issueIdOrKey: args.issueKey },
+              query: { order: "asc" },
+            })
+          ).data
+        : [];
+
+      outputResult(issue, args, (data) => {
+        consola.log("");
+        consola.log(`  ${data.issueKey}: ${data.summary}`);
+        consola.log("");
+        consola.log(`    Status:      ${data.status.name}`);
+        consola.log(`    Type:        ${data.issueType.name}`);
+        consola.log(`    Priority:    ${data.priority.name}`);
+        consola.log(`    Assignee:    ${data.assignee?.name ?? "Unassigned"}`);
+        consola.log(`    Created by:  ${data.createdUser.name}`);
+        consola.log(`    Created:     ${formatDate(data.created)}`);
+        consola.log(`    Updated:     ${formatDate(data.updated)}`);
+
+        if (data.startDate) {
+          consola.log(`    Start Date:  ${formatDate(data.startDate)}`);
+        }
+        if (data.dueDate) {
+          consola.log(`    Due Date:    ${formatDate(data.dueDate)}`);
+        }
+        if (data.estimatedHours != null) {
+          consola.log(`    Estimated:   ${data.estimatedHours}h`);
+        }
+        if (data.actualHours != null) {
+          consola.log(`    Actual:      ${data.actualHours}h`);
+        }
+        if (data.category.length > 0) {
+          consola.log(`    Categories:  ${data.category.map((c) => c.name).join(", ")}`);
+        }
+        if (data.milestone.length > 0) {
+          consola.log(`    Milestones:  ${data.milestone.map((m) => m.name).join(", ")}`);
+        }
+        if (data.versions.length > 0) {
+          consola.log(`    Versions:    ${data.versions.map((v) => v.name).join(", ")}`);
+        }
+
+        if (data.description) {
+          consola.log("");
+          consola.log("  Description:");
+          consola.log(
+            data.description
+              .split("\n")
+              .map((line) => `    ${line}`)
+              .join("\n"),
+          );
+        }
+
+        if (comments.length > 0) {
+          consola.log("");
+          consola.log("  Comments:");
+          for (const comment of comments) {
+            if (!comment.content) {
+              continue;
+            }
+            consola.log("");
+            consola.log(`    ${comment.createdUser.name} (${formatDate(comment.created)}):`);
+            consola.log(
+              comment.content
+                .split("\n")
+                .map((line) => `      ${line}`)
+                .join("\n"),
+            );
+          }
+        }
+
+        consola.log("");
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, view };

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -61,16 +61,15 @@ const view = withUsage(
         path: { issueIdOrKey: args.issue },
       });
 
-      const comments = args.comments
-        ? (
-            await issuesGetComments({
-              client,
-              throwOnError: true,
-              path: { issueIdOrKey: args.issue },
-              query: { order: "asc" },
-            })
-          ).data
-        : [];
+      const commentsResponse = args.comments
+        ? await issuesGetComments({
+            client,
+            throwOnError: true,
+            path: { issueIdOrKey: args.issue },
+            query: { order: "asc" },
+          })
+        : undefined;
+      const comments = commentsResponse?.data ?? [];
 
       outputResult(issue, args, (data) => {
         consola.log("");
@@ -90,10 +89,10 @@ const view = withUsage(
         if (data.dueDate) {
           consola.log(`    Due Date:    ${formatDate(data.dueDate)}`);
         }
-        if (data.estimatedHours != null) {
+        if (data.estimatedHours !== undefined) {
           consola.log(`    Estimated:   ${data.estimatedHours}h`);
         }
-        if (data.actualHours != null) {
+        if (data.actualHours !== undefined) {
           consola.log(`    Actual:      ${data.actualHours}h`);
         }
         if (data.category.length > 0) {

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -101,7 +101,7 @@ const view = withUsage(
         if (data.milestone.length > 0) {
           consola.log(`    Milestones:  ${data.milestone.map((m) => m.name).join(", ")}`);
         }
-        if (data.version.length > 0) {
+        if (data.version && data.version.length > 0) {
           consola.log(`    Versions:    ${data.version.map((v) => v.name).join(", ")}`);
         }
 

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -32,7 +32,7 @@ const view = withUsage(
       ...outputArgs,
       issue: {
         type: "positional",
-        description: "Issue key or ID. e.g., PROJECT-123",
+        description: "Issue ID or issue key. e.g., PROJECT-123",
         required: true,
       },
       comments: {

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -80,7 +80,7 @@ const view = withUsage(
         consola.log(`    Type:        ${data.issueType.name}`);
         consola.log(`    Priority:    ${data.priority.name}`);
         consola.log(`    Assignee:    ${data.assignee?.name ?? "Unassigned"}`);
-        consola.log(`    Created by:  ${data.createdUser.name}`);
+        consola.log(`    Created by:  ${data.createdUser?.name ?? "Unknown"}`);
         consola.log(`    Created:     ${formatDate(data.created)}`);
         consola.log(`    Updated:     ${formatDate(data.updated)}`);
 
@@ -102,8 +102,8 @@ const view = withUsage(
         if (data.milestone.length > 0) {
           consola.log(`    Milestones:  ${data.milestone.map((m) => m.name).join(", ")}`);
         }
-        if (data.versions.length > 0) {
-          consola.log(`    Versions:    ${data.versions.map((v) => v.name).join(", ")}`);
+        if (data.version.length > 0) {
+          consola.log(`    Versions:    ${data.version.map((v) => v.name).join(", ")}`);
         }
 
         if (data.description) {

--- a/apps/cli/src/commands/project/activities.ts
+++ b/apps/cli/src/commands/project/activities.ts
@@ -1,8 +1,16 @@
 import { getClient } from "@repo/backlog-utils";
-import { type Row, formatDate, outputArgs, outputResult, printTable } from "@repo/cli-utils";
+import {
+  type Row,
+  formatDate,
+  outputArgs,
+  outputResult,
+  printTable,
+  splitArg,
+} from "@repo/cli-utils";
 import { projectsGetActivities } from "@repo/openapi-client";
 import { defineCommand } from "citty";
 import consola from "consola";
+import * as v from "valibot";
 import { type CommandUsage, withUsage } from "../../lib/command-usage";
 import { ACTIVITY_LABELS } from "../../lib/activity-labels";
 
@@ -93,9 +101,7 @@ const activities = withUsage(
     async run({ args }) {
       const { client } = await getClient();
 
-      const activityTypeId = args["activity-type"]
-        ? args["activity-type"].split(",").map(Number)
-        : undefined;
+      const activityTypeId = splitArg(args["activity-type"], v.number());
 
       const { data: activityList } = await projectsGetActivities({
         client,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,6 +14,7 @@ const main = defineCommand({
   subCommands: {
     auth: () => import("./commands/auth/index").then((m) => m.auth),
     project: () => import("./commands/project/index").then((m) => m.project),
+    issue: () => import("./commands/issue/index").then((m) => m.issue),
   },
 });
 

--- a/packages/backlog-utils/src/client.test.ts
+++ b/packages/backlog-utils/src/client.test.ts
@@ -20,7 +20,7 @@ vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 /** Extract the last request interceptor function registered on the latest createClient result. */
 const getLastRequestInterceptor = (): ((request: Request) => Request) => {
   const client = vi.mocked(createClient).mock.results.at(-1)?.value;
-  const {calls} = client.interceptors.request.use.mock;
+  const { calls } = client.interceptors.request.use.mock;
   expect(calls.length).toBeGreaterThan(0);
   return calls.at(-1)[0];
 };

--- a/packages/backlog-utils/src/client.test.ts
+++ b/packages/backlog-utils/src/client.test.ts
@@ -17,11 +17,12 @@ vi.mock("@repo/openapi-client/client", () => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-/** Extract the request interceptor function registered on the latest createClient result. */
-const getRequestInterceptor = (): ((request: Request) => Request) => {
+/** Extract the last request interceptor function registered on the latest createClient result. */
+const getLastRequestInterceptor = (): ((request: Request) => Request) => {
   const client = vi.mocked(createClient).mock.results.at(-1)?.value;
-  expect(client.interceptors.request.use).toHaveBeenCalled();
-  return client.interceptors.request.use.mock.calls[0][0];
+  const {calls} = client.interceptors.request.use.mock;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls.at(-1)[0];
 };
 
 describe("getClient", () => {
@@ -45,7 +46,7 @@ describe("getClient", () => {
       }),
     );
 
-    const interceptor = getRequestInterceptor();
+    const interceptor = getLastRequestInterceptor();
     const req = new Request("https://example.com/test");
     const modified = interceptor(req);
     expect(new URL(modified.url).searchParams.get("apiKey")).toBe("test-key");
@@ -71,7 +72,7 @@ describe("getClient", () => {
       }),
     );
 
-    const interceptor = getRequestInterceptor();
+    const interceptor = getLastRequestInterceptor();
     const req = new Request("https://example.com/test");
     interceptor(req);
     expect(req.headers.get("Authorization")).toBe("Bearer access-token");
@@ -95,7 +96,7 @@ describe("getClient", () => {
       }),
     );
 
-    const interceptor = getRequestInterceptor();
+    const interceptor = getLastRequestInterceptor();
     const req = new Request("https://example.com/test");
     const modified = interceptor(req);
     expect(new URL(modified.url).searchParams.get("apiKey")).toBe("configured-key");
@@ -116,7 +117,7 @@ describe("getClient", () => {
       }),
     );
 
-    const interceptor = getRequestInterceptor();
+    const interceptor = getLastRequestInterceptor();
     const req = new Request("https://example.com/test");
     const modified = interceptor(req);
     expect(new URL(modified.url).searchParams.get("apiKey")).toBe("env-api-key");

--- a/packages/backlog-utils/src/client.ts
+++ b/packages/backlog-utils/src/client.ts
@@ -8,6 +8,19 @@ import { ofetch } from "ofetch";
 /** The type of the authenticated API client. */
 type BacklogClient = Client;
 
+/** Adds a request interceptor that removes query parameters with empty values. */
+const addEmptyQueryParamFilter = (client: Client): void => {
+  client.interceptors.request.use((request) => {
+    const url = new URL(request.url);
+    for (const [key, value] of [...url.searchParams.entries()]) {
+      if (value === "") {
+        url.searchParams.delete(key);
+      }
+    }
+    return new Request(url, request);
+  });
+};
+
 /** Adds a request interceptor that sets the apiKey query parameter. */
 const addApiKeyAuth = (client: Client, apiKey: string): void => {
   client.interceptors.request.use((request) => {
@@ -50,6 +63,7 @@ const getClient = async (): Promise<{
         baseUrl,
         onResponseError: handleRateLimitError,
       });
+      addEmptyQueryParamFilter(client);
       addApiKeyAuth(client, resolved.auth.apiKey);
       return { client, host: resolved.host };
     }
@@ -70,6 +84,7 @@ const getClient = async (): Promise<{
       baseUrl: `https://${envHost}/api/v2`,
       onResponseError: handleRateLimitError,
     });
+    addEmptyQueryParamFilter(client);
     addApiKeyAuth(client, envApiKey);
     return { client, host: envHost };
   }
@@ -163,6 +178,7 @@ const createOAuthClient = (
   });
 
   const client = createClient({ baseUrl, ofetch: customOfetch });
+  addEmptyQueryParamFilter(client);
   client.interceptors.request.use((request) => {
     request.headers.set("Authorization", `Bearer ${currentAccessToken}`);
     return request;

--- a/packages/backlog-utils/src/client.ts
+++ b/packages/backlog-utils/src/client.ts
@@ -12,10 +12,11 @@ type BacklogClient = Client;
 const addEmptyQueryParamFilter = (client: Client): void => {
   client.interceptors.request.use((request) => {
     const url = new URL(request.url);
-    for (const [key, value] of [...url.searchParams.entries()]) {
-      if (value === "") {
-        url.searchParams.delete(key);
-      }
+    const keysToDelete = [...url.searchParams.entries()]
+      .filter(([, value]) => value === "")
+      .map(([key]) => key);
+    for (const key of keysToDelete) {
+      url.searchParams.delete(key);
     }
     return new Request(url, request);
   });

--- a/packages/backlog-utils/src/client.ts
+++ b/packages/backlog-utils/src/client.ts
@@ -15,6 +15,9 @@ const addEmptyQueryParamFilter = (client: Client): void => {
     const keysToDelete = [...url.searchParams.entries()]
       .filter(([, value]) => value === "")
       .map(([key]) => key);
+    if (keysToDelete.length === 0) {
+      return request;
+    }
     for (const key of keysToDelete) {
       url.searchParams.delete(key);
     }

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "consola": "^3.4.2"
+    "consola": "^3.4.2",
+    "valibot": "^1.2.0"
   },
   "devDependencies": {
     "@repo/test-utils": "workspace:*",

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -1,5 +1,6 @@
 export { outputArgs, outputResult, pickFields, filterFields } from "./output";
 export { promptRequired, confirmOrExit } from "./prompt";
 export { readStdin } from "./stdin";
+export { splitArg } from "./split-arg";
 export { formatDate } from "./format";
 export { printTable, type Column, type Row } from "./table";

--- a/packages/cli-utils/src/split-arg.test.ts
+++ b/packages/cli-utils/src/split-arg.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import * as v from "valibot";
+import { splitArg } from "./split-arg";
+
+describe("splitArg", () => {
+  it("returns empty array when input is undefined", () => {
+    expect(splitArg(undefined, v.string())).toEqual([]);
+  });
+
+  it("splits comma-separated string values with a string schema", () => {
+    expect(splitArg("a,b,c", v.string())).toEqual(["a", "b", "c"]);
+  });
+
+  it("trims whitespace from each element", () => {
+    expect(splitArg(" a , b , c ", v.string())).toEqual(["a", "b", "c"]);
+  });
+
+  it("drops empty strings after splitting", () => {
+    expect(splitArg("a,,b,", v.string())).toEqual(["a", "b"]);
+  });
+
+  it("validates each element against a picklist and drops invalid values", () => {
+    const schema = v.picklist(["open", "closed", "all"]);
+    expect(splitArg("open,invalid,closed", schema)).toEqual(["open", "closed"]);
+  });
+
+  it("returns empty array when all values are invalid for picklist", () => {
+    const schema = v.picklist(["open", "closed"]);
+    expect(splitArg("foo,bar", schema)).toEqual([]);
+  });
+
+  it("coerces string to number when schema expects a number", () => {
+    expect(splitArg("1,2,3", v.number())).toEqual([1, 2, 3]);
+  });
+
+  it("drops elements that cannot be coerced to a valid number", () => {
+    expect(splitArg("1,abc,3", v.number())).toEqual([1, 3]);
+  });
+
+  it("works with pipe schemas that accept string input", () => {
+    const schema = v.pipe(v.union([v.number(), v.string()]), v.transform(Number), v.number());
+    expect(splitArg("1,2,3", schema)).toEqual([1, 2, 3]);
+  });
+
+  it("returns single element array for non-comma value", () => {
+    expect(splitArg("hello", v.string())).toEqual(["hello"]);
+  });
+
+  it("returns empty array for empty string input", () => {
+    expect(splitArg("", v.string())).toEqual([]);
+  });
+});

--- a/packages/cli-utils/src/split-arg.ts
+++ b/packages/cli-utils/src/split-arg.ts
@@ -1,0 +1,36 @@
+import { type BaseIssue, type BaseSchema, type InferOutput, safeParse } from "valibot";
+
+const splitArg = <TSchema extends BaseSchema<unknown, unknown, BaseIssue<unknown>>>(
+  input: string | undefined,
+  schema: TSchema,
+): InferOutput<TSchema>[] => {
+  if (!input) {
+    return [];
+  }
+
+  const parts = input
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const results: InferOutput<TSchema>[] = [];
+
+  for (const part of parts) {
+    const result = safeParse(schema, part);
+    if (result.success) {
+      results.push(result.output);
+      continue;
+    }
+
+    const num = Number(part);
+    if (!Number.isNaN(num)) {
+      const numResult = safeParse(schema, num);
+      if (numResult.success) {
+        results.push(numResult.output);
+      }
+    }
+  }
+
+  return results;
+};
+
+export { splitArg };

--- a/packages/openapi-client/src/index.ts
+++ b/packages/openapi-client/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./generated/index";
+export { vIssueSortField } from "./generated/valibot.gen";

--- a/packages/openapi/issues.tsp
+++ b/packages/openapi/issues.tsp
@@ -1,0 +1,136 @@
+using TypeSpec.Http;
+
+namespace Backlog;
+
+// ────────────────────────────────────────────
+// Enums
+// ────────────────────────────────────────────
+
+/** Parent/child issue filter. */
+enum ParentChildType {
+  All: 0,
+  ExcludeChild: 1,
+  ChildOnly: 2,
+  NeitherParentNorChild: 3,
+  ParentOnly: 4,
+}
+
+/** Sort field for issue list. */
+enum IssueSortField {
+  issueType,
+  category,
+  version,
+  milestone,
+  summary,
+  status,
+  priority,
+  attachment,
+  sharedFile,
+  created,
+  createdUser,
+  updated,
+  updatedUser,
+  assignee,
+  startDate,
+  dueDate,
+  estimatedHours,
+  actualHours,
+  childIssue,
+}
+
+// ────────────────────────────────────────────
+// Operations
+// ────────────────────────────────────────────
+
+@route("/issues")
+@tag("Issues")
+interface Issues {
+  @summary("Get Issue List")
+  @doc("Returns list of issues.")
+  @get
+  op list(
+    @query("projectId[]") projectId?: int64[],
+    @query("issueTypeId[]") issueTypeId?: int64[],
+    @query("categoryId[]") categoryId?: int64[],
+    @query("versionId[]") versionId?: int64[],
+    @query("milestoneId[]") milestoneId?: int64[],
+    @query("statusId[]") statusId?: int64[],
+    @query("priorityId[]") priorityId?: int64[],
+    @query("assigneeId[]") assigneeId?: int64[],
+    @query("createdUserId[]") createdUserId?: int64[],
+    @query("resolutionId[]") resolutionId?: int64[],
+    @query parentChild?: ParentChildType,
+    @query attachment?: boolean,
+    @query sharedFile?: boolean,
+    @query sort?: IssueSortField,
+    @query order?: "asc" | "desc",
+    @query offset?: int32,
+    @query count?: int32,
+    @query createdSince?: string,
+    @query createdUntil?: string,
+    @query updatedSince?: string,
+    @query updatedUntil?: string,
+    @query startDateSince?: string,
+    @query startDateUntil?: string,
+    @query dueDateSince?: string,
+    @query dueDateUntil?: string,
+    @query("id[]") id?: int64[],
+    @query("parentIssueId[]") parentIssueId?: int64[],
+    @query keyword?: string,
+  ): Issue[] | BacklogErrorResponse;
+
+  @summary("Count Issue")
+  @doc("Returns number of issues.")
+  @get
+  @route("/count")
+  op count(
+    @query("projectId[]") projectId?: int64[],
+    @query("issueTypeId[]") issueTypeId?: int64[],
+    @query("categoryId[]") categoryId?: int64[],
+    @query("versionId[]") versionId?: int64[],
+    @query("milestoneId[]") milestoneId?: int64[],
+    @query("statusId[]") statusId?: int64[],
+    @query("priorityId[]") priorityId?: int64[],
+    @query("assigneeId[]") assigneeId?: int64[],
+    @query("createdUserId[]") createdUserId?: int64[],
+    @query("resolutionId[]") resolutionId?: int64[],
+    @query parentChild?: ParentChildType,
+    @query attachment?: boolean,
+    @query sharedFile?: boolean,
+    @query sort?: IssueSortField,
+    @query order?: "asc" | "desc",
+    @query offset?: int32,
+    @query count?: int32,
+    @query createdSince?: string,
+    @query createdUntil?: string,
+    @query updatedSince?: string,
+    @query updatedUntil?: string,
+    @query startDateSince?: string,
+    @query startDateUntil?: string,
+    @query dueDateSince?: string,
+    @query dueDateUntil?: string,
+    @query("id[]") id?: int64[],
+    @query("parentIssueId[]") parentIssueId?: int64[],
+    @query keyword?: string,
+  ): IssueCount | BacklogErrorResponse;
+
+  @summary("Get Issue")
+  @doc("Returns information about issue.")
+  @get
+  @route("/{issueIdOrKey}")
+  op get(
+    @path issueIdOrKey: string,
+  ): Issue | BacklogErrorResponse;
+
+  @summary("Get Comment List")
+  @doc("Returns list of comments in issue.")
+  @get
+  @route("/{issueIdOrKey}/comments")
+  op getComments(
+    @path issueIdOrKey: string,
+    @query minId?: int64,
+    @query maxId?: int64,
+    @query count?: int32,
+    @query order?: "asc" | "desc",
+  ): Comment[] | BacklogErrorResponse;
+}

--- a/packages/openapi/issues.tsp
+++ b/packages/openapi/issues.tsp
@@ -17,6 +17,8 @@ enum ParentChildType {
 
 /** Sort field for issue list. */
 enum IssueSortField {
+  id,
+  project,
   issueType,
   category,
   version,

--- a/packages/openapi/main.tsp
+++ b/packages/openapi/main.tsp
@@ -5,6 +5,7 @@ import "@typespec/openapi3";
 import "./models";
 import "./users.tsp";
 import "./projects.tsp";
+import "./issues.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;

--- a/packages/openapi/models/issue.tsp
+++ b/packages/openapi/models/issue.tsp
@@ -10,7 +10,7 @@ model IssueType {
   projectId: int64;
   name: string;
   color: string;
-  displayOrder: int32;
+  displayOrder: int32 | null;
 }
 
 /** Backlog priority. */
@@ -37,8 +37,9 @@ model Resolution {
 /** Backlog category. */
 model Category {
   id: int64;
+  projectId: int64;
   name: string;
-  displayOrder: int32;
+  displayOrder: int32 | null;
 }
 
 /** Backlog version/milestone. */
@@ -50,7 +51,7 @@ model Version {
   startDate: string | null;
   releaseDueDate: string | null;
   archived: boolean;
-  displayOrder: int32;
+  displayOrder: int32 | null;
 }
 
 /** Backlog issue attachment. */
@@ -58,6 +59,8 @@ model Attachment {
   id: int64;
   name: string;
   size: int64;
+  createdUser: User | null;
+  created: utcDateTime;
 }
 
 /** Backlog shared file. */
@@ -67,7 +70,7 @@ model SharedFile {
   type: string;
   dir: string;
   name: string;
-  size: int64;
+  size: int64 | null;
   createdUser: User | null;
   created: utcDateTime;
   updatedUser: User | null;
@@ -92,6 +95,24 @@ model CustomFieldValue {
   value: unknown;
 }
 
+/** Backlog shared external file link on an issue. */
+model IssueSharedExternalFileLink {
+  id: int64;
+  serviceType: string;
+  name: string;
+  url: string;
+  createdUser: User | null;
+  created: utcDateTime;
+  updatedUser: User | null;
+  updated: utcDateTime;
+}
+
+/** Summary of child issues. */
+model ChildIssueSummary {
+  closed: int32;
+  total: int32;
+}
+
 // ────────────────────────────────────────────
 // Issue
 // ────────────────────────────────────────────
@@ -101,30 +122,32 @@ model Issue {
   id: int64;
   projectId: int64;
   issueKey: string;
-  keyId: int64;
+  keyId: int32;
   issueType: IssueType;
   summary: string;
-  description: string | null;
+  description: string;
   resolution: Resolution | null;
   priority: Priority;
   status: Status;
   assignee: User | null;
   category: Category[];
-  versions: Version[];
+  version: Version[];
   milestone: Version[];
   startDate: string | null;
   dueDate: string | null;
-  estimatedHours: float64 | null;
-  actualHours: float64 | null;
+  estimatedHours: float32 | null;
+  actualHours: float32 | null;
   parentIssueId: int64 | null;
-  createdUser: User;
+  createdUser: User | null;
   created: utcDateTime;
   updatedUser: User | null;
   updated: utcDateTime;
-  customFields: CustomFieldValue[];
+  customFieldValues: CustomFieldValue[];
   attachments: Attachment[];
   sharedFiles: SharedFile[];
+  sharedExternalFileLinks: IssueSharedExternalFileLink[];
   stars: Star[];
+  childIssueSummary: ChildIssueSummary | null;
 }
 
 // ────────────────────────────────────────────

--- a/packages/openapi/models/issue.tsp
+++ b/packages/openapi/models/issue.tsp
@@ -131,7 +131,7 @@ model Issue {
   status: Status;
   assignee: User | null;
   category: Category[];
-  version: Version[];
+  version?: Version[];
   milestone: Version[];
   startDate: string | null;
   dueDate: string | null;
@@ -142,12 +142,12 @@ model Issue {
   created: utcDateTime;
   updatedUser: User | null;
   updated: utcDateTime;
-  customFieldValues: CustomFieldValue[];
+  customFieldValues?: CustomFieldValue[];
   attachments: Attachment[];
   sharedFiles: SharedFile[];
-  sharedExternalFileLinks: IssueSharedExternalFileLink[];
+  sharedExternalFileLinks?: IssueSharedExternalFileLink[];
   stars: Star[];
-  childIssueSummary: ChildIssueSummary | null;
+  childIssueSummary?: ChildIssueSummary | null;
 }
 
 // ────────────────────────────────────────────

--- a/packages/openapi/models/issue.tsp
+++ b/packages/openapi/models/issue.tsp
@@ -1,0 +1,165 @@
+namespace Backlog;
+
+// ────────────────────────────────────────────
+// Issue-related models
+// ────────────────────────────────────────────
+
+/** Backlog issue type. */
+model IssueType {
+  id: int64;
+  projectId: int64;
+  name: string;
+  color: string;
+  displayOrder: int32;
+}
+
+/** Backlog priority. */
+model Priority {
+  id: int64;
+  name: string;
+}
+
+/** Backlog issue status. */
+model Status {
+  id: int64;
+  projectId: int64;
+  name: string;
+  color: string;
+  displayOrder: int32;
+}
+
+/** Backlog resolution. */
+model Resolution {
+  id: int64;
+  name: string;
+}
+
+/** Backlog category. */
+model Category {
+  id: int64;
+  name: string;
+  displayOrder: int32;
+}
+
+/** Backlog version/milestone. */
+model Version {
+  id: int64;
+  projectId: int64;
+  name: string;
+  description: string | null;
+  startDate: string | null;
+  releaseDueDate: string | null;
+  archived: boolean;
+  displayOrder: int32;
+}
+
+/** Backlog issue attachment. */
+model Attachment {
+  id: int64;
+  name: string;
+  size: int64;
+}
+
+/** Backlog shared file. */
+model SharedFile {
+  id: int64;
+  projectId: int64;
+  type: string;
+  dir: string;
+  name: string;
+  size: int64;
+  createdUser: User | null;
+  created: utcDateTime;
+  updatedUser: User | null;
+  updated: utcDateTime;
+}
+
+/** Backlog star. */
+model Star {
+  id: int64;
+  comment: string | null;
+  url: string;
+  title: string;
+  presenter: User | null;
+  created: utcDateTime;
+}
+
+/** Backlog custom field value. */
+model CustomFieldValue {
+  id: int64;
+  fieldTypeId: int32;
+  name: string;
+  value: unknown;
+}
+
+// ────────────────────────────────────────────
+// Issue
+// ────────────────────────────────────────────
+
+/** Backlog issue. */
+model Issue {
+  id: int64;
+  projectId: int64;
+  issueKey: string;
+  keyId: int64;
+  issueType: IssueType;
+  summary: string;
+  description: string | null;
+  resolution: Resolution | null;
+  priority: Priority;
+  status: Status;
+  assignee: User | null;
+  category: Category[];
+  versions: Version[];
+  milestone: Version[];
+  startDate: string | null;
+  dueDate: string | null;
+  estimatedHours: float64 | null;
+  actualHours: float64 | null;
+  parentIssueId: int64 | null;
+  createdUser: User;
+  created: utcDateTime;
+  updatedUser: User | null;
+  updated: utcDateTime;
+  customFields: CustomFieldValue[];
+  attachments: Attachment[];
+  sharedFiles: SharedFile[];
+  stars: Star[];
+}
+
+// ────────────────────────────────────────────
+// Comment
+// ────────────────────────────────────────────
+
+/** Change log entry within a comment. */
+model ChangeLog {
+  field: string;
+  newValue: string | null;
+  originalValue: string | null;
+  attachmentInfo: unknown;
+  attributeInfo: unknown;
+  notificationInfo: unknown;
+}
+
+/** Backlog issue comment. */
+model Comment {
+  id: int64;
+  projectId: int64;
+  issueId: int64;
+  content: string | null;
+  changeLog: ChangeLog[] | null;
+  createdUser: User;
+  created: utcDateTime;
+  updated: utcDateTime;
+  stars: Star[];
+  notifications: unknown[];
+}
+
+// ────────────────────────────────────────────
+// Issue count response
+// ────────────────────────────────────────────
+
+/** Response for issue count endpoint. */
+model IssueCount {
+  count: int32;
+}

--- a/packages/openapi/models/main.tsp
+++ b/packages/openapi/models/main.tsp
@@ -2,3 +2,4 @@ import "./common.tsp";
 import "./oauth.tsp";
 import "./project.tsp";
 import "./activity.tsp";
+import "./issue.tsp";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       consola:
         specifier: ^3.4.2
         version: 3.4.2
+      valibot:
+        specifier: ^1.2.0
+        version: 1.2.0(typescript@5.9.3)
     devDependencies:
       '@repo/test-utils':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- Add `bee issue list` command with filtering by project, assignee, status, priority, keyword, date ranges, sorting, and pagination
- Add `bee issue view` command with `--comments` flag to include comments and `--web` flag to open in browser
- Add `bee issue status` command to show personal issue summary grouped by status
- Add TypeSpec API definitions for Issue models (Issue, Comment, IssueType, Priority, Status, Resolution, etc.) and operations (list, count, get, getComments)
- Register `issue` subcommand in CLI entry point

## Test plan

- [x] `pnpm run typecheck` passes across all packages
- [x] `pnpm run test` passes (210 tests, 31 files — 16 new tests for issue commands)
- [x] Manual: `bee issue list -p PROJECT` displays issue list
- [x] Manual: `bee issue view PROJECT-123` displays issue details
- [x] Manual: `bee issue view PROJECT-123 --comments` displays comments
- [x] Manual: `bee issue view PROJECT-123 --web` opens browser
- [x] Manual: `bee issue status` displays status summary
- [x] Manual: `--json` flag works on all commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)