### PR TITLE
feat(notification): implement notification commands

### DIFF
--- a/apps/cli/src/commands/notification/count.test.ts
+++ b/apps/cli/src/commands/notification/count.test.ts
@@ -13,28 +13,36 @@ vi.mock("@repo/backlog-utils", () => ({
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("notification count", () => {
-  it("displays notification count", async () => {
+  it("counts all notifications when no flags are set", async () => {
     mockClient.getNotificationsCount.mockResolvedValue({ count: 42 });
 
     const { count } = await import("./count");
     await count.run?.({ args: {} } as never);
 
     expect(getClient).toHaveBeenCalled();
-    expect(mockClient.getNotificationsCount).toHaveBeenCalledWith({
-      alreadyRead: false,
-      resourceAlreadyRead: false,
-    });
+    expect(mockClient.getNotificationsCount).toHaveBeenCalledWith({});
     expect(consola.log).toHaveBeenCalledWith("42");
   });
 
-  it("passes already-read flag", async () => {
+  it("passes already-read as true", async () => {
     mockClient.getNotificationsCount.mockResolvedValue({ count: 10 });
 
     const { count } = await import("./count");
-    await count.run?.({ args: { "already-read": true } } as never);
+    await count.run?.({ args: { "already-read": "true" } } as never);
 
     expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
       expect.objectContaining({ alreadyRead: true }),
+    );
+  });
+
+  it("passes already-read as false", async () => {
+    mockClient.getNotificationsCount.mockResolvedValue({ count: 3 });
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { "already-read": "false" } } as never);
+
+    expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({ alreadyRead: false }),
     );
   });
 
@@ -42,7 +50,7 @@ describe("notification count", () => {
     mockClient.getNotificationsCount.mockResolvedValue({ count: 5 });
 
     const { count } = await import("./count");
-    await count.run?.({ args: { "resource-already-read": true } } as never);
+    await count.run?.({ args: { "resource-already-read": "true" } } as never);
 
     expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
       expect.objectContaining({ resourceAlreadyRead: true }),

--- a/apps/cli/src/commands/notification/count.test.ts
+++ b/apps/cli/src/commands/notification/count.test.ts
@@ -24,33 +24,42 @@ describe("notification count", () => {
     expect(consola.log).toHaveBeenCalledWith("42");
   });
 
-  it("passes already-read as true", async () => {
+  it("filters read notifications with --already-read read", async () => {
     mockClient.getNotificationsCount.mockResolvedValue({ count: 10 });
 
     const { count } = await import("./count");
-    await count.run?.({ args: { "already-read": "true" } } as never);
+    await count.run?.({ args: { "already-read": "read" } } as never);
 
     expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
       expect.objectContaining({ alreadyRead: true }),
     );
   });
 
-  it("passes already-read as false", async () => {
+  it("filters unread notifications with --already-read unread", async () => {
     mockClient.getNotificationsCount.mockResolvedValue({ count: 3 });
 
     const { count } = await import("./count");
-    await count.run?.({ args: { "already-read": "false" } } as never);
+    await count.run?.({ args: { "already-read": "unread" } } as never);
 
     expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
       expect.objectContaining({ alreadyRead: false }),
     );
   });
 
-  it("passes resource-already-read flag", async () => {
+  it("counts all with --already-read all", async () => {
+    mockClient.getNotificationsCount.mockResolvedValue({ count: 50 });
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { "already-read": "all" } } as never);
+
+    expect(mockClient.getNotificationsCount).toHaveBeenCalledWith({});
+  });
+
+  it("filters by resource-already-read", async () => {
     mockClient.getNotificationsCount.mockResolvedValue({ count: 5 });
 
     const { count } = await import("./count");
-    await count.run?.({ args: { "resource-already-read": "true" } } as never);
+    await count.run?.({ args: { "resource-already-read": "read" } } as never);
 
     expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
       expect.objectContaining({ resourceAlreadyRead: true }),

--- a/apps/cli/src/commands/notification/count.test.ts
+++ b/apps/cli/src/commands/notification/count.test.ts
@@ -1,0 +1,63 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getNotificationsCount: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("notification count", () => {
+  it("displays notification count", async () => {
+    mockClient.getNotificationsCount.mockResolvedValue({ count: 42 });
+
+    const { count } = await import("./count");
+    await count.run?.({ args: {} } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.getNotificationsCount).toHaveBeenCalledWith({
+      alreadyRead: false,
+      resourceAlreadyRead: false,
+    });
+    expect(consola.log).toHaveBeenCalledWith("42");
+  });
+
+  it("passes already-read flag", async () => {
+    mockClient.getNotificationsCount.mockResolvedValue({ count: 10 });
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { "already-read": true } } as never);
+
+    expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({ alreadyRead: true }),
+    );
+  });
+
+  it("passes resource-already-read flag", async () => {
+    mockClient.getNotificationsCount.mockResolvedValue({ count: 5 });
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { "resource-already-read": true } } as never);
+
+    expect(mockClient.getNotificationsCount).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceAlreadyRead: true }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getNotificationsCount.mockResolvedValue({ count: 42 });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("42"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/notification/count.ts
+++ b/apps/cli/src/commands/notification/count.ts
@@ -4,11 +4,11 @@ import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
 
-const parseBooleanFlag = (value: string | undefined): boolean | undefined => {
-  if (value === undefined) {
+const parseReadFilter = (value: string | undefined): boolean | undefined => {
+  if (value === undefined || value === "all") {
     return undefined;
   }
-  return value !== "false";
+  return value === "read";
 };
 
 const commandUsage: CommandUsage = {
@@ -21,11 +21,11 @@ Use \`--already-read\` and \`--resource-already-read\` to filter by read status.
     { description: "Count all notifications", command: "bee notification count" },
     {
       description: "Count only unread notifications",
-      command: "bee notification count --already-read false",
+      command: "bee notification count --already-read unread",
     },
     {
       description: "Count only read notifications",
-      command: "bee notification count --already-read true",
+      command: "bee notification count --already-read read",
     },
     { description: "Output as JSON", command: "bee notification count --json" },
   ],
@@ -45,22 +45,20 @@ const count = withUsage(
       ...outputArgs,
       "already-read": {
         type: "string",
-        description:
-          "Filter by read status. If true, count only read notifications. If false, count only unread notifications. If omitted, count all.",
-        valueHint: "{true|false}",
+        description: "Filter by read status. If omitted, count all.",
+        valueHint: "{read|unread|all}",
       },
       "resource-already-read": {
         type: "string",
-        description:
-          "Filter by resource read status. If true, count only notifications whose resource is already read. If false, count only notifications whose resource is not yet read. If omitted, count all.",
-        valueHint: "{true|false}",
+        description: "Filter by resource read status. If omitted, count all.",
+        valueHint: "{read|unread|all}",
       },
     },
     async run({ args }) {
       const { client } = await getClient();
 
-      const alreadyRead = parseBooleanFlag(args["already-read"]);
-      const resourceAlreadyRead = parseBooleanFlag(args["resource-already-read"]);
+      const alreadyRead = parseReadFilter(args["already-read"]);
+      const resourceAlreadyRead = parseReadFilter(args["resource-already-read"]);
 
       const params: Record<string, boolean> = {};
       if (alreadyRead !== undefined) {

--- a/apps/cli/src/commands/notification/count.ts
+++ b/apps/cli/src/commands/notification/count.ts
@@ -4,18 +4,28 @@ import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
 
+const parseBooleanFlag = (value: string | undefined): boolean | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  return value !== "false";
+};
+
 const commandUsage: CommandUsage = {
   long: `Display the count of notifications for the authenticated user.
 
-By default, returns the count of unread notifications. Use
-\`--already-read\` and \`--resource-already-read\` flags to filter
-which notifications are counted.`,
+By default, returns the count of all notifications regardless of read status.
+Use \`--already-read\` and \`--resource-already-read\` to filter by read status.`,
 
   examples: [
-    { description: "Count unread notifications", command: "bee notification count" },
+    { description: "Count all notifications", command: "bee notification count" },
     {
-      description: "Count including already-read notifications",
-      command: "bee notification count --already-read",
+      description: "Count only unread notifications",
+      command: "bee notification count --already-read false",
+    },
+    {
+      description: "Count only read notifications",
+      command: "bee notification count --already-read true",
     },
     { description: "Output as JSON", command: "bee notification count --json" },
   ],
@@ -34,21 +44,36 @@ const count = withUsage(
     args: {
       ...outputArgs,
       "already-read": {
-        type: "boolean",
-        description: "Include already-read notifications",
+        type: "string",
+        description:
+          "Filter by read status. If true, count only read notifications. If false, count only unread notifications. If omitted, count all.",
+        valueHint: "{true|false}",
       },
       "resource-already-read": {
-        type: "boolean",
-        description: "Include notifications whose resource is already read",
+        type: "string",
+        description:
+          "Filter by resource read status. If true, count only notifications whose resource is already read. If false, count only notifications whose resource is not yet read. If omitted, count all.",
+        valueHint: "{true|false}",
       },
     },
     async run({ args }) {
       const { client } = await getClient();
 
-      const result = await client.getNotificationsCount({
-        alreadyRead: args["already-read"] ?? false,
-        resourceAlreadyRead: args["resource-already-read"] ?? false,
-      });
+      const alreadyRead = parseBooleanFlag(args["already-read"]);
+      const resourceAlreadyRead = parseBooleanFlag(args["resource-already-read"]);
+
+      const params: Record<string, boolean> = {};
+      if (alreadyRead !== undefined) {
+        params.alreadyRead = alreadyRead;
+      }
+      if (resourceAlreadyRead !== undefined) {
+        params.resourceAlreadyRead = resourceAlreadyRead;
+      }
+
+      // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- backlog-js types require both fields but API accepts partial params
+      const result = await client.getNotificationsCount(
+        params as unknown as Parameters<typeof client.getNotificationsCount>[0],
+      );
 
       outputResult(result, args, (data) => {
         consola.log(String(data.count));

--- a/apps/cli/src/commands/notification/count.ts
+++ b/apps/cli/src/commands/notification/count.ts
@@ -1,0 +1,61 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Display the count of notifications for the authenticated user.
+
+By default, returns the count of unread notifications. Use
+\`--already-read\` and \`--resource-already-read\` flags to filter
+which notifications are counted.`,
+
+  examples: [
+    { description: "Count unread notifications", command: "bee notification count" },
+    {
+      description: "Count including already-read notifications",
+      command: "bee notification count --already-read",
+    },
+    { description: "Output as JSON", command: "bee notification count --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const count = withUsage(
+  defineCommand({
+    meta: {
+      name: "count",
+      description: "Count notifications",
+    },
+    args: {
+      ...outputArgs,
+      "already-read": {
+        type: "boolean",
+        description: "Include already-read notifications",
+      },
+      "resource-already-read": {
+        type: "boolean",
+        description: "Include notifications whose resource is already read",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const result = await client.getNotificationsCount({
+        alreadyRead: args["already-read"] ?? false,
+        resourceAlreadyRead: args["resource-already-read"] ?? false,
+      });
+
+      outputResult(result, args, (data) => {
+        consola.log(String(data.count));
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, count };

--- a/apps/cli/src/commands/notification/index.ts
+++ b/apps/cli/src/commands/notification/index.ts
@@ -1,0 +1,14 @@
+import { defineCommand } from "citty";
+
+export const notification = defineCommand({
+  meta: {
+    name: "notification",
+    description: "Manage Backlog notifications",
+  },
+  subCommands: {
+    list: () => import("./list").then((m) => m.list),
+    count: () => import("./count").then((m) => m.count),
+    read: () => import("./read").then((m) => m.read),
+    "read-all": () => import("./read-all").then((m) => m.readAll),
+  },
+});

--- a/apps/cli/src/commands/notification/list.test.ts
+++ b/apps/cli/src/commands/notification/list.test.ts
@@ -1,0 +1,112 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getNotifications: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("notification list", () => {
+  it("displays notifications in tabular format", async () => {
+    mockClient.getNotifications.mockResolvedValue([
+      {
+        id: 100,
+        alreadyRead: false,
+        reason: 2,
+        resourceAlreadyRead: false,
+        issue: { issueKey: "PROJ-1", summary: "Bug fix" },
+        sender: { name: "Alice" },
+        created: "2025-01-15T10:00:00Z",
+      },
+      {
+        id: 101,
+        alreadyRead: true,
+        reason: 1,
+        resourceAlreadyRead: true,
+        issue: { issueKey: "PROJ-2", summary: "Feature" },
+        sender: { name: "Bob" },
+        created: "2025-01-14T09:00:00Z",
+      },
+    ]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.getNotifications).toHaveBeenCalled();
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("PROJ-2"));
+  });
+
+  it("marks unread notifications with asterisk", async () => {
+    mockClient.getNotifications.mockResolvedValue([
+      {
+        id: 100,
+        alreadyRead: false,
+        reason: 2,
+        resourceAlreadyRead: false,
+        issue: { issueKey: "PROJ-1", summary: "Bug" },
+        sender: { name: "Alice" },
+        created: "2025-01-15T10:00:00Z",
+      },
+    ]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("*"));
+  });
+
+  it("shows message when no notifications found", async () => {
+    mockClient.getNotifications.mockResolvedValue([]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No notifications found.");
+  });
+
+  it("passes limit, min-id, max-id, and order parameters", async () => {
+    mockClient.getNotifications.mockResolvedValue([]);
+
+    const { list } = await import("./list");
+    await list.run?.({
+      args: { limit: "5", "min-id": "10", "max-id": "100", order: "asc" },
+    } as never);
+
+    expect(mockClient.getNotifications).toHaveBeenCalledWith({
+      count: 5,
+      minId: 10,
+      maxId: 100,
+      order: "asc",
+    });
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getNotifications.mockResolvedValue([
+      {
+        id: 100,
+        alreadyRead: false,
+        reason: 2,
+        resourceAlreadyRead: false,
+        issue: { issueKey: "PROJ-1", summary: "Bug" },
+        sender: { name: "Alice" },
+        created: "2025-01-15T10:00:00Z",
+      },
+    ]);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/notification/list.ts
+++ b/apps/cli/src/commands/notification/list.ts
@@ -1,0 +1,109 @@
+import { getClient } from "@repo/backlog-utils";
+import { type Row, formatDate, outputArgs, outputResult, printTable } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const REASON_LABELS: Record<number, string> = {
+  1: "Assigned",
+  2: "Commented",
+  3: "Issue created",
+  4: "Issue updated",
+  5: "File attached",
+  6: "Project user added",
+  9: "Other",
+  10: "Pull request assigned",
+  11: "Pull request commented",
+  12: "Pull request added",
+  13: "Pull request updated",
+  14: "Comment mentioned",
+  15: "Pull request comment mentioned",
+  16: "Team mentioned",
+  17: "Team mentioned in PR",
+};
+
+const commandUsage: CommandUsage = {
+  long: `List notifications for the authenticated user.
+
+Unread notifications are marked with an asterisk (\`*\`). Use \`--limit\` to
+control the number of notifications returned, and \`--min-id\` / \`--max-id\`
+for cursor-based pagination.`,
+
+  examples: [
+    { description: "List recent notifications", command: "bee notification list" },
+    { description: "List the last 5 notifications", command: "bee notification list --limit 5" },
+    {
+      description: "List notifications in ascending order",
+      command: "bee notification list --order asc",
+    },
+    { description: "Output as JSON", command: "bee notification list --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const list = withUsage(
+  defineCommand({
+    meta: {
+      name: "list",
+      description: "List notifications",
+    },
+    args: {
+      ...outputArgs,
+      limit: {
+        type: "string",
+        description: "Maximum number of notifications to return",
+        valueHint: "<1-100>",
+      },
+      "min-id": {
+        type: "string",
+        description: "Minimum notification ID",
+        valueHint: "<number>",
+      },
+      "max-id": {
+        type: "string",
+        description: "Maximum notification ID",
+        valueHint: "<number>",
+      },
+      order: {
+        type: "string",
+        description: "Sort order",
+        valueHint: "{asc|desc}",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const notifications = await client.getNotifications({
+        count: args.limit ? Number(args.limit) : undefined,
+        minId: args["min-id"] ? Number(args["min-id"]) : undefined,
+        maxId: args["max-id"] ? Number(args["max-id"]) : undefined,
+        order: args.order as "asc" | "desc" | undefined,
+      });
+
+      outputResult(notifications, args, (data) => {
+        if (data.length === 0) {
+          consola.info("No notifications found.");
+          return;
+        }
+
+        const rows: Row[] = data.map((n) => [
+          { header: "", value: n.alreadyRead ? " " : "*" },
+          { header: "ID", value: String(n.id) },
+          { header: "REASON", value: REASON_LABELS[n.reason] ?? String(n.reason) },
+          { header: "ISSUE", value: n.issue?.issueKey ?? "-" },
+          { header: "SUMMARY", value: n.issue?.summary ?? "-" },
+          { header: "SENDER", value: n.sender.name },
+          { header: "DATE", value: formatDate(n.created) },
+        ]);
+
+        printTable(rows);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, list };

--- a/apps/cli/src/commands/notification/list.ts
+++ b/apps/cli/src/commands/notification/list.ts
@@ -3,24 +3,7 @@ import { type Row, formatDate, outputArgs, outputResult, printTable } from "@rep
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
-
-const REASON_LABELS: Record<number, string> = {
-  1: "Assigned",
-  2: "Commented",
-  3: "Issue created",
-  4: "Issue updated",
-  5: "File attached",
-  6: "Project user added",
-  9: "Other",
-  10: "Pull request assigned",
-  11: "Pull request commented",
-  12: "Pull request added",
-  13: "Pull request updated",
-  14: "Comment mentioned",
-  15: "Pull request comment mentioned",
-  16: "Team mentioned",
-  17: "Team mentioned in PR",
-};
+import { NOTIFICATION_REASON_LABELS } from "../../lib/notification-reason-labels";
 
 const commandUsage: CommandUsage = {
   long: `List notifications for the authenticated user.
@@ -92,7 +75,7 @@ const list = withUsage(
         const rows: Row[] = data.map((n) => [
           { header: "", value: n.alreadyRead ? " " : "*" },
           { header: "ID", value: String(n.id) },
-          { header: "REASON", value: REASON_LABELS[n.reason] ?? String(n.reason) },
+          { header: "REASON", value: NOTIFICATION_REASON_LABELS[n.reason] ?? String(n.reason) },
           { header: "ISSUE", value: n.issue?.issueKey ?? "-" },
           { header: "SUMMARY", value: n.issue?.summary ?? "-" },
           { header: "SENDER", value: n.sender.name },

--- a/apps/cli/src/commands/notification/read-all.test.ts
+++ b/apps/cli/src/commands/notification/read-all.test.ts
@@ -1,0 +1,26 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  resetNotificationsMarkAsRead: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("notification read-all", () => {
+  it("marks all notifications as read", async () => {
+    mockClient.resetNotificationsMarkAsRead.mockResolvedValue({ count: 0 });
+
+    const { readAll } = await import("./read-all");
+    await readAll.run?.({ args: {} } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.resetNotificationsMarkAsRead).toHaveBeenCalled();
+    expect(consola.success).toHaveBeenCalledWith("Marked all notifications as read.");
+  });
+});

--- a/apps/cli/src/commands/notification/read-all.ts
+++ b/apps/cli/src/commands/notification/read-all.ts
@@ -1,0 +1,38 @@
+import { getClient } from "@repo/backlog-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Mark all notifications as read.
+
+This resets the unread notification count to zero.`,
+
+  examples: [
+    { description: "Mark all notifications as read", command: "bee notification read-all" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const readAll = withUsage(
+  defineCommand({
+    meta: {
+      name: "read-all",
+      description: "Mark all notifications as read",
+    },
+    args: {},
+    async run() {
+      const { client } = await getClient();
+
+      await client.resetNotificationsMarkAsRead();
+
+      consola.success("Marked all notifications as read.");
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, readAll };

--- a/apps/cli/src/commands/notification/read.test.ts
+++ b/apps/cli/src/commands/notification/read.test.ts
@@ -1,0 +1,26 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  markAsReadNotification: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("notification read", () => {
+  it("marks a notification as read", async () => {
+    mockClient.markAsReadNotification.mockResolvedValue(undefined);
+
+    const { read } = await import("./read");
+    await read.run?.({ args: { id: "12345" } } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.markAsReadNotification).toHaveBeenCalledWith(12_345);
+    expect(consola.success).toHaveBeenCalledWith("Marked notification 12345 as read.");
+  });
+});

--- a/apps/cli/src/commands/notification/read.ts
+++ b/apps/cli/src/commands/notification/read.ts
@@ -1,0 +1,46 @@
+import { getClient } from "@repo/backlog-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Mark a notification as read.
+
+Specify the notification ID to mark as read. Use \`bee notification list\`
+to find notification IDs.`,
+
+  examples: [
+    { description: "Mark a notification as read", command: "bee notification read 12345" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const read = withUsage(
+  defineCommand({
+    meta: {
+      name: "read",
+      description: "Mark a notification as read",
+    },
+    args: {
+      id: {
+        type: "positional",
+        description: "Notification ID",
+        required: true,
+        valueHint: "<number>",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      await client.markAsReadNotification(Number(args.id));
+
+      consola.success(`Marked notification ${args.id} as read.`);
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, read };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -15,6 +15,7 @@ const main = defineCommand({
     auth: () => import("./commands/auth/index").then((m) => m.auth),
     project: () => import("./commands/project/index").then((m) => m.project),
     issue: () => import("./commands/issue/index").then((m) => m.issue),
+    notification: () => import("./commands/notification/index").then((m) => m.notification),
   },
 });
 

--- a/apps/cli/src/lib/notification-reason-labels.ts
+++ b/apps/cli/src/lib/notification-reason-labels.ts
@@ -1,0 +1,19 @@
+const NOTIFICATION_REASON_LABELS: Record<number, string> = {
+  1: "Assigned",
+  2: "Commented",
+  3: "Issue created",
+  4: "Issue updated",
+  5: "File attached",
+  6: "Project user added",
+  9: "Other",
+  10: "Pull request assigned",
+  11: "Pull request commented",
+  12: "Pull request added",
+  13: "Pull request updated",
+  14: "Comment mentioned",
+  15: "Pull request comment mentioned",
+  16: "Team mentioned",
+  17: "Team mentioned in PR",
+};
+
+export { NOTIFICATION_REASON_LABELS };

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -53,6 +53,15 @@ export default defineConfig({
               ],
             },
             {
+              label: "notification",
+              items: [
+                { label: "notification list", link: "/commands/notification/list" },
+                { label: "notification count", link: "/commands/notification/count" },
+                { label: "notification read", link: "/commands/notification/read" },
+                { label: "notification read-all", link: "/commands/notification/read-all" },
+              ],
+            },
+            {
               label: "project",
               items: [
                 { label: "project list", link: "/commands/project/list" },


### PR DESCRIPTION
## Summary

- Add `notification list` command with unread `*` markers, `--limit`, `--min-id`, `--max-id`, `--order`, and `--json` support
- Add `notification count` command with 3-state `--already-read` / `--resource-already-read` filtering (`read`/`unread`/`all`)
- Add `notification read <id>` command to mark a single notification as read
- Add `notification read-all` command to mark all notifications as read
- Extract `NOTIFICATION_REASON_LABELS` to shared `lib/` for reuse
- Add documentation sidebar entries for all notification commands

## Test plan

- [x] `pnpm run typecheck` passes (5/5)
- [x] `pnpm run lint` passes (0 warnings, 0 errors)
- [x] Notification tests pass (13/13 across 4 test files)
- [x] `bee notification list` displays notifications with unread markers
- [x] `bee notification list --limit 5` limits results
- [x] `bee notification count` shows notification count
- [x] `bee notification count --already-read unread` counts only unread
- [x] `bee notification read 592233213` marks as read
- [x] `bee notification read-all` marks all as read
- [x] `bee notification list --json` outputs JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)