### PR TITLE
feat(user): implement user commands

### DIFF
--- a/apps/cli/src/commands/user/activities.test.ts
+++ b/apps/cli/src/commands/user/activities.test.ts
@@ -1,0 +1,105 @@
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getUserActivities: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("user activities", () => {
+  it("displays activities in formatted output", async () => {
+    mockClient.getUserActivities.mockResolvedValue([
+      {
+        id: 1,
+        type: 1,
+        content: { summary: "Fix login bug" },
+        project: { name: "Project One" },
+        createdUser: { name: "Test User" },
+        created: "2024-01-15T10:30:00Z",
+      },
+      {
+        id: 2,
+        type: 2,
+        content: { key_id: 123 },
+        project: { name: "Project Two" },
+        createdUser: { name: "Test User" },
+        created: "2024-01-14T09:00:00Z",
+      },
+    ]);
+
+    const { activities } = await import("./activities");
+    await activities.run?.({ args: { user: "12345" } } as never);
+
+    expect(mockClient.getUserActivities).toHaveBeenCalledWith(12_345, expect.any(Object));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("2024-01-15"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Issue Created"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Fix login bug"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Project One"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("#123"));
+  });
+
+  it("shows message when no activities found", async () => {
+    mockClient.getUserActivities.mockResolvedValue([]);
+
+    const { activities } = await import("./activities");
+    await activities.run?.({ args: { user: "12345" } } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No activities found.");
+  });
+
+  it("passes activity type filter as array of numbers", async () => {
+    mockClient.getUserActivities.mockResolvedValue([]);
+
+    const { activities } = await import("./activities");
+    await activities.run?.({
+      args: { user: "12345", "activity-type": "1,2,3" },
+    } as never);
+
+    expect(mockClient.getUserActivities).toHaveBeenCalledWith(
+      12_345,
+      expect.objectContaining({
+        activityTypeId: [1, 2, 3],
+      }),
+    );
+  });
+
+  it("passes count parameter", async () => {
+    mockClient.getUserActivities.mockResolvedValue([]);
+
+    const { activities } = await import("./activities");
+    await activities.run?.({
+      args: { user: "12345", count: "50" },
+    } as never);
+
+    expect(mockClient.getUserActivities).toHaveBeenCalledWith(
+      12_345,
+      expect.objectContaining({ count: 50 }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getUserActivities.mockResolvedValue([
+      {
+        id: 1,
+        type: 1,
+        content: { summary: "Test" },
+        project: { name: "Proj" },
+        createdUser: { name: "User" },
+        created: "2024-01-15T10:30:00Z",
+      },
+    ]);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { activities } = await import("./activities");
+    await activities.run?.({ args: { user: "12345", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Test"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/user/activities.ts
+++ b/apps/cli/src/commands/user/activities.ts
@@ -1,0 +1,145 @@
+import { getClient } from "@repo/backlog-utils";
+import {
+  type Row,
+  formatDate,
+  outputArgs,
+  outputResult,
+  printTable,
+  splitArg,
+} from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import * as v from "valibot";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+import { ACTIVITY_LABELS } from "../../lib/activity-labels";
+
+const getActivitySummary = (activity: {
+  type: number;
+  content: {
+    summary?: string | null;
+    key_id?: number | null;
+    deletedStatus?: { name?: string | null } | null;
+    link?: { key_id?: number; title?: string }[] | null;
+  };
+}): string => {
+  if (activity.type === 34 && activity.content.deletedStatus?.name) {
+    return activity.content.deletedStatus.name;
+  }
+  if (activity.content.summary) {
+    return activity.content.summary;
+  }
+  if (activity.content.link && activity.content.link.length > 0) {
+    return activity.content.link
+      .map((item) => (item.key_id ? `#${item.key_id}` : (item.title ?? "")))
+      .filter(Boolean)
+      .join(", ");
+  }
+  if (activity.content.key_id) {
+    return `#${activity.content.key_id}`;
+  }
+  return "";
+};
+
+const commandUsage: CommandUsage = {
+  long: `List recent activities of a Backlog user.
+
+Shows the most recent updates performed by the specified user, including
+issue changes, wiki edits, git pushes, and other activities. Results are
+ordered by most recent first.
+
+Use \`--activity-type\` to filter by specific activity types (comma-separated IDs).
+Use \`--count\` to control how many activities are returned (default: 20, max: 100).`,
+
+  examples: [
+    { description: "List user activities", command: "bee user activities 12345" },
+    {
+      description: "Show only issue-related activities",
+      command: "bee user activities 12345 --activity-type 1,2,3",
+    },
+    {
+      description: "Show last 50 activities",
+      command: "bee user activities 12345 --count 50",
+    },
+    {
+      description: "Output as JSON",
+      command: "bee user activities 12345 --json",
+    },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const activities = withUsage(
+  defineCommand({
+    meta: {
+      name: "activities",
+      description: "List user activities",
+    },
+    args: {
+      ...outputArgs,
+      user: {
+        type: "positional",
+        description: "User ID",
+        required: true,
+        valueHint: "<number>",
+      },
+      "activity-type": {
+        type: "string",
+        description: "Filter by activity type IDs (comma-separated)",
+        valueHint: "<1,2,3>",
+      },
+      count: {
+        type: "string",
+        description: "Number of activities to return (default: 20)",
+        valueHint: "<1-100>",
+      },
+      order: {
+        type: "string",
+        description: "Sort order",
+        valueHint: "{asc|desc}",
+      },
+      "min-id": {
+        type: "string",
+        description: "Minimum activity ID",
+      },
+      "max-id": {
+        type: "string",
+        description: "Maximum activity ID",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const activityTypeId = splitArg(args["activity-type"], v.number());
+
+      const activityList = await client.getUserActivities(Number(args.user), {
+        activityTypeId,
+        count: args.count ? Number(args.count) : undefined,
+        order: args.order as "asc" | "desc" | undefined,
+        minId: args["min-id"] ? Number(args["min-id"]) : undefined,
+        maxId: args["max-id"] ? Number(args["max-id"]) : undefined,
+      });
+
+      outputResult(activityList, args, (data) => {
+        if (data.length === 0) {
+          consola.info("No activities found.");
+          return;
+        }
+
+        const rows: Row[] = data.map((activity) => [
+          { header: "DATE", value: formatDate(activity.created) },
+          { header: "TYPE", value: ACTIVITY_LABELS[activity.type] ?? `Type ${activity.type}` },
+          { header: "PROJECT", value: activity.project?.name ?? "" },
+          { header: "SUMMARY", value: getActivitySummary(activity) },
+        ]);
+
+        printTable(rows);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, activities };

--- a/apps/cli/src/commands/user/index.ts
+++ b/apps/cli/src/commands/user/index.ts
@@ -1,0 +1,14 @@
+import { defineCommand } from "citty";
+
+export const user = defineCommand({
+  meta: {
+    name: "user",
+    description: "Manage Backlog users",
+  },
+  subCommands: {
+    list: () => import("./list").then((m) => m.list),
+    view: () => import("./view").then((m) => m.view),
+    me: () => import("./me").then((m) => m.me),
+    activities: () => import("./activities").then((m) => m.activities),
+  },
+});

--- a/apps/cli/src/commands/user/list.test.ts
+++ b/apps/cli/src/commands/user/list.test.ts
@@ -1,0 +1,55 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getUsers: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("user list", () => {
+  it("displays user list in tabular format", async () => {
+    mockClient.getUsers.mockResolvedValue([
+      { id: 1, userId: "user1", name: "User One", roleType: 1 },
+      { id: 2, userId: "user2", name: "User Two", roleType: 2 },
+    ]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.getUsers).toHaveBeenCalled();
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("ID"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("user1"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Administrator"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Normal User"));
+  });
+
+  it("shows message when no users found", async () => {
+    mockClient.getUsers.mockResolvedValue([]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: {} } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No users found.");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getUsers.mockResolvedValue([
+      { id: 1, userId: "user1", name: "User One", roleType: 1 },
+    ]);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("user1"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/user/list.ts
+++ b/apps/cli/src/commands/user/list.ts
@@ -1,0 +1,58 @@
+import { getClient } from "@repo/backlog-utils";
+import { type Row, outputArgs, outputResult, printTable } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+import { ROLE_LABELS } from "../../lib/role-labels";
+
+const commandUsage: CommandUsage = {
+  long: `List all users in the Backlog space.
+
+Displays each user's ID, user ID, name, and role. Only space administrators
+can see the full list of users.`,
+
+  examples: [
+    { description: "List all users", command: "bee user list" },
+    { description: "Output as JSON", command: "bee user list --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const list = withUsage(
+  defineCommand({
+    meta: {
+      name: "list",
+      description: "List users",
+    },
+    args: {
+      ...outputArgs,
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const users = await client.getUsers();
+
+      outputResult(users, args, (data) => {
+        if (data.length === 0) {
+          consola.info("No users found.");
+          return;
+        }
+
+        const rows: Row[] = data.map((u) => [
+          { header: "ID", value: String(u.id) },
+          { header: "USER ID", value: u.userId ?? "" },
+          { header: "NAME", value: u.name },
+          { header: "ROLE", value: ROLE_LABELS[u.roleType] ?? `Unknown (${u.roleType})` },
+        ]);
+
+        printTable(rows);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, list };

--- a/apps/cli/src/commands/user/me.test.ts
+++ b/apps/cli/src/commands/user/me.test.ts
@@ -1,0 +1,51 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getMyself: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const sampleUser = {
+  id: 99_999,
+  userId: "myself",
+  name: "My Self",
+  roleType: 2,
+  lang: "ja",
+  mailAddress: "myself@example.com",
+  lastLoginTime: "2024-03-01T08:00:00Z",
+};
+
+describe("user me", () => {
+  it("displays authenticated user details", async () => {
+    mockClient.getMyself.mockResolvedValue(sampleUser);
+
+    const { me } = await import("./me");
+    await me.run?.({ args: {} } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.getMyself).toHaveBeenCalled();
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("My Self"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("myself"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("myself@example.com"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Normal User"));
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getMyself.mockResolvedValue(sampleUser);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { me } = await import("./me");
+    await me.run?.({ args: { json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("myself"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/user/me.ts
+++ b/apps/cli/src/commands/user/me.ts
@@ -1,8 +1,9 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult } from "@repo/cli-utils";
+import { formatDate, outputArgs, outputResult, printDefinitionList } from "@repo/cli-utils";
 import { defineCommand } from "citty";
+import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
-import { printUserDetail } from "./view";
+import { ROLE_LABELS } from "../../lib/role-labels";
 
 const commandUsage: CommandUsage = {
   long: `Display details of the authenticated user.
@@ -35,7 +36,20 @@ const me = withUsage(
 
       const myself = await client.getMyself();
 
-      outputResult(myself, args, printUserDetail);
+      outputResult(myself, args, (data) => {
+        consola.log("");
+        consola.log(`  ${data.name}`);
+        consola.log("");
+        printDefinitionList([
+          ["ID", String(data.id)],
+          ["User ID", data.userId],
+          ["Email", data.mailAddress],
+          ["Role", ROLE_LABELS[data.roleType] ?? `Unknown (${data.roleType})`],
+          ["Language", data.lang],
+          ["Last Login", data.lastLoginTime ? formatDate(data.lastLoginTime) : undefined],
+        ]);
+        consola.log("");
+      });
     },
   }),
   commandUsage,

--- a/apps/cli/src/commands/user/me.ts
+++ b/apps/cli/src/commands/user/me.ts
@@ -1,0 +1,44 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+import { printUserDetail } from "./view";
+
+const commandUsage: CommandUsage = {
+  long: `Display details of the authenticated user.
+
+This is a shortcut for \`bee user view\` that automatically looks up the
+currently authenticated user. Shows the same profile information: name,
+user ID, email address, role, language, and last login time.`,
+
+  examples: [
+    { description: "View your own profile", command: "bee user me" },
+    { description: "Output as JSON", command: "bee user me --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const me = withUsage(
+  defineCommand({
+    meta: {
+      name: "me",
+      description: "View the authenticated user",
+    },
+    args: {
+      ...outputArgs,
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const myself = await client.getMyself();
+
+      outputResult(myself, args, printUserDetail);
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, me };

--- a/apps/cli/src/commands/user/view.test.ts
+++ b/apps/cli/src/commands/user/view.test.ts
@@ -1,0 +1,61 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getUser: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const sampleUser = {
+  id: 12_345,
+  userId: "testuser",
+  name: "Test User",
+  roleType: 2,
+  lang: "ja",
+  mailAddress: "test@example.com",
+  lastLoginTime: "2024-01-15T10:30:00Z",
+};
+
+describe("user view", () => {
+  it("displays user details", async () => {
+    mockClient.getUser.mockResolvedValue(sampleUser);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { user: "12345" } } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.getUser).toHaveBeenCalledWith(12_345);
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Test User"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("testuser"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("test@example.com"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Normal User"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("2024-01-15"));
+  });
+
+  it("displays role label correctly for administrator", async () => {
+    mockClient.getUser.mockResolvedValue({ ...sampleUser, roleType: 1 });
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { user: "12345" } } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Administrator"));
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getUser.mockResolvedValue(sampleUser);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { user: "12345", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("testuser"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/user/view.ts
+++ b/apps/cli/src/commands/user/view.ts
@@ -5,31 +5,6 @@ import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
 import { ROLE_LABELS } from "../../lib/role-labels";
 
-type UserLike = {
-  id: number;
-  userId: string;
-  name: string;
-  roleType: number;
-  lang: string | null;
-  mailAddress: string;
-  lastLoginTime: string;
-};
-
-const printUserDetail = (data: UserLike): void => {
-  consola.log("");
-  consola.log(`  ${data.name}`);
-  consola.log("");
-  printDefinitionList([
-    ["ID", String(data.id)],
-    ["User ID", data.userId],
-    ["Email", data.mailAddress],
-    ["Role", ROLE_LABELS[data.roleType] ?? `Unknown (${data.roleType})`],
-    ["Language", data.lang],
-    ["Last Login", data.lastLoginTime ? formatDate(data.lastLoginTime) : undefined],
-  ]);
-  consola.log("");
-};
-
 const commandUsage: CommandUsage = {
   long: `Display details of a Backlog user.
 
@@ -68,10 +43,23 @@ const view = withUsage(
 
       const userData = await client.getUser(Number(args.user));
 
-      outputResult(userData, args, printUserDetail);
+      outputResult(userData, args, (data) => {
+        consola.log("");
+        consola.log(`  ${data.name}`);
+        consola.log("");
+        printDefinitionList([
+          ["ID", String(data.id)],
+          ["User ID", data.userId],
+          ["Email", data.mailAddress],
+          ["Role", ROLE_LABELS[data.roleType] ?? `Unknown (${data.roleType})`],
+          ["Language", data.lang],
+          ["Last Login", data.lastLoginTime ? formatDate(data.lastLoginTime) : undefined],
+        ]);
+        consola.log("");
+      });
     },
   }),
   commandUsage,
 );
 
-export { commandUsage, printUserDetail, view };
+export { commandUsage, view };

--- a/apps/cli/src/commands/user/view.ts
+++ b/apps/cli/src/commands/user/view.ts
@@ -1,0 +1,77 @@
+import { getClient } from "@repo/backlog-utils";
+import { formatDate, outputArgs, outputResult, printDefinitionList } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+import { ROLE_LABELS } from "../../lib/role-labels";
+
+type UserLike = {
+  id: number;
+  userId: string;
+  name: string;
+  roleType: number;
+  lang: string | null;
+  mailAddress: string;
+  lastLoginTime: string;
+};
+
+const printUserDetail = (data: UserLike): void => {
+  consola.log("");
+  consola.log(`  ${data.name}`);
+  consola.log("");
+  printDefinitionList([
+    ["ID", String(data.id)],
+    ["User ID", data.userId],
+    ["Email", data.mailAddress],
+    ["Role", ROLE_LABELS[data.roleType] ?? `Unknown (${data.roleType})`],
+    ["Language", data.lang],
+    ["Last Login", data.lastLoginTime ? formatDate(data.lastLoginTime) : undefined],
+  ]);
+  consola.log("");
+};
+
+const commandUsage: CommandUsage = {
+  long: `Display details of a Backlog user.
+
+Shows user profile information including name, user ID, email address,
+role, language, and last login time.
+
+Use \`bee user me\` as a shortcut to view your own profile.`,
+
+  examples: [
+    { description: "View user details", command: "bee user view 12345" },
+    { description: "Output as JSON", command: "bee user view 12345 --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const view = withUsage(
+  defineCommand({
+    meta: {
+      name: "view",
+      description: "View a user",
+    },
+    args: {
+      ...outputArgs,
+      user: {
+        type: "positional",
+        description: "User ID",
+        required: true,
+        valueHint: "<number>",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const userData = await client.getUser(Number(args.user));
+
+      outputResult(userData, args, printUserDetail);
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, printUserDetail, view };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -15,6 +15,7 @@ const main = defineCommand({
     auth: () => import("./commands/auth/index").then((m) => m.auth),
     project: () => import("./commands/project/index").then((m) => m.project),
     issue: () => import("./commands/issue/index").then((m) => m.issue),
+    user: () => import("./commands/user/index").then((m) => m.user),
   },
 });
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -53,6 +53,15 @@ export default defineConfig({
               ],
             },
             {
+              label: "user",
+              items: [
+                { label: "user list", link: "/commands/user/list" },
+                { label: "user view", link: "/commands/user/view" },
+                { label: "user me", link: "/commands/user/me" },
+                { label: "user activities", link: "/commands/user/activities" },
+              ],
+            },
+            {
               label: "project",
               items: [
                 { label: "project list", link: "/commands/project/list" },


### PR DESCRIPTION
## Summary

- Add `user` command group with 4 subcommands: `list`, `view`, `me`, `activities`
- `user list`: List all users in the space (ID, user ID, name, role)
- `user view <id>`: View user details (name, email, role, language, last login)
- `user me`: Shortcut to view the authenticated user's profile
- `user activities <id>`: List user activities with `--activity-type`, `--count`, `--order` filters
- All commands support `--json` output
- Add user command group to documentation sidebar

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run test` — 13 tests pass (list: 3, view: 3, me: 2, activities: 5)
- [x] `pnpm run lint` passes
- [x] `bee user list` displays user list
- [x] `bee user view <id>` displays user details
- [x] `bee user me` displays authenticated user info
- [x] `bee user activities <id>` displays activities
- [x] `bee user activities <id> --activity-type 1,2` filters by type
- [x] Each command works with `--json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)