### PR TITLE
feat(document): implement document commands

### DIFF
--- a/apps/cli/src/commands/document/attachments.test.ts
+++ b/apps/cli/src/commands/document/attachments.test.ts
@@ -1,0 +1,122 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getDocument: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+const sampleAttachments = [
+  {
+    id: 1,
+    name: "report.pdf",
+    size: 2_048_576,
+    createdUser: { name: "Alice" },
+    created: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: 2,
+    name: "screenshot.png",
+    size: 512,
+    createdUser: { name: "Bob" },
+    created: "2025-01-02T00:00:00Z",
+  },
+];
+
+describe("document attachments", () => {
+  it("displays attachment list in tabular format", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue({
+      id: "doc-1",
+      attachments: sampleAttachments,
+    });
+
+    const { attachments } = await import("./attachments");
+    await attachments.run?.({ args: { document: "doc-1" } } as never);
+
+    expect(mockClient.getDocument).toHaveBeenCalledWith("doc-1");
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("NAME"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("report.pdf"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("screenshot.png"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Alice"));
+  });
+
+  it("shows message when no attachments found", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue({
+      id: "doc-1",
+      attachments: [],
+    });
+
+    const { attachments } = await import("./attachments");
+    await attachments.run?.({ args: { document: "doc-1" } } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No attachments found.");
+  });
+
+  it("formats file sizes correctly", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue({
+      id: "doc-1",
+      attachments: [
+        {
+          id: 1,
+          name: "small.txt",
+          size: 500,
+          createdUser: { name: "Alice" },
+          created: "2025-01-01T00:00:00Z",
+        },
+        {
+          id: 2,
+          name: "medium.txt",
+          size: 5120,
+          createdUser: { name: "Bob" },
+          created: "2025-01-02T00:00:00Z",
+        },
+        {
+          id: 3,
+          name: "large.txt",
+          size: 2_097_152,
+          createdUser: { name: "Charlie" },
+          created: "2025-01-03T00:00:00Z",
+        },
+      ],
+    });
+
+    const { attachments } = await import("./attachments");
+    await attachments.run?.({ args: { document: "doc-1" } } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("500 B"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("5.0 KB"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("2.0 MB"));
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue({
+      id: "doc-1",
+      attachments: sampleAttachments,
+    });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { attachments } = await import("./attachments");
+    await attachments.run?.({ args: { document: "doc-1", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("report.pdf"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/document/attachments.ts
+++ b/apps/cli/src/commands/document/attachments.ts
@@ -1,0 +1,71 @@
+import { getClient } from "@repo/backlog-utils";
+import { type Row, formatDate, outputArgs, outputResult, printTable } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const formatSize = (bytes: number): string => {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+const commandUsage: CommandUsage = {
+  long: "List attachments of a Backlog document.",
+
+  examples: [
+    { description: "List attachments", command: "bee document attachments 12345" },
+    { description: "Output as JSON", command: "bee document attachments 12345 --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const attachments = withUsage(
+  defineCommand({
+    meta: {
+      name: "attachments",
+      description: "List document attachments",
+    },
+    args: {
+      ...outputArgs,
+      document: {
+        type: "positional",
+        description: "Document ID",
+        valueHint: "<DOCUMENT-ID>",
+        required: true,
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const doc = await client.getDocument(args.document);
+
+      outputResult(doc.attachments, args, (data) => {
+        if (data.length === 0) {
+          consola.info("No attachments found.");
+          return;
+        }
+
+        const rows: Row[] = data.map((file) => [
+          { header: "ID", value: String(file.id) },
+          { header: "NAME", value: file.name },
+          { header: "SIZE", value: formatSize(file.size) },
+          { header: "CREATED BY", value: file.createdUser?.name ?? "Unknown" },
+          { header: "CREATED", value: formatDate(file.created) },
+        ]);
+
+        printTable(rows);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, attachments };

--- a/apps/cli/src/commands/document/attachments.ts
+++ b/apps/cli/src/commands/document/attachments.ts
@@ -1,18 +1,15 @@
 import { getClient } from "@repo/backlog-utils";
-import { type Row, formatDate, outputArgs, outputResult, printTable } from "@repo/cli-utils";
+import {
+  type Row,
+  formatDate,
+  formatSize,
+  outputArgs,
+  outputResult,
+  printTable,
+} from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
-
-const formatSize = (bytes: number): string => {
-  if (bytes < 1024) {
-    return `${bytes} B`;
-  }
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
-  }
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-};
 
 const commandUsage: CommandUsage = {
   long: "List attachments of a Backlog document.",

--- a/apps/cli/src/commands/document/create.test.ts
+++ b/apps/cli/src/commands/document/create.test.ts
@@ -1,0 +1,124 @@
+import { promptRequired, readStdin } from "@repo/cli-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  addDocument: vi.fn(),
+  getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PROJECT" }]),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+  promptRequired: vi.fn(),
+  readStdin: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("document create", () => {
+  it("creates a document with provided fields", async () => {
+    vi.mocked(promptRequired).mockResolvedValueOnce("100").mockResolvedValueOnce("Meeting Notes");
+    mockClient.addDocument.mockResolvedValue({
+      id: "1",
+      title: "Meeting Notes",
+    });
+
+    const { create } = await import("./create");
+    await create.run?.({
+      args: { project: "100", title: "Meeting Notes", body: "Content here" },
+    } as never);
+
+    expect(mockClient.addDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: 100,
+        title: "Meeting Notes",
+        content: "Content here",
+      }),
+    );
+    expect(consola.success).toHaveBeenCalledWith("Created document: Meeting Notes");
+  });
+
+  it("prompts for required fields when not provided", async () => {
+    vi.mocked(promptRequired).mockResolvedValueOnce("100").mockResolvedValueOnce("Title");
+    mockClient.addDocument.mockResolvedValue({
+      id: "2",
+      title: "Title",
+    });
+
+    const { create } = await import("./create");
+    await create.run?.({ args: {} } as never);
+
+    expect(promptRequired).toHaveBeenCalledWith("Project:", undefined);
+    expect(promptRequired).toHaveBeenCalledWith("Title:", undefined);
+  });
+
+  it("reads body from stdin when --body is -", async () => {
+    vi.mocked(promptRequired).mockResolvedValueOnce("100").mockResolvedValueOnce("Title");
+    vi.mocked(readStdin).mockResolvedValue("Stdin content");
+    mockClient.addDocument.mockResolvedValue({
+      id: "3",
+      title: "Title",
+    });
+
+    const { create } = await import("./create");
+    await create.run?.({
+      args: { project: "100", title: "Title", body: "-" },
+    } as never);
+
+    expect(readStdin).toHaveBeenCalled();
+    expect(mockClient.addDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Stdin content",
+      }),
+    );
+  });
+
+  it("passes optional fields to API", async () => {
+    vi.mocked(promptRequired).mockResolvedValueOnce("100").mockResolvedValueOnce("Title");
+    mockClient.addDocument.mockResolvedValue({
+      id: "4",
+      title: "Title",
+    });
+
+    const { create } = await import("./create");
+    await create.run?.({
+      args: {
+        project: "100",
+        title: "Title",
+        emoji: "star",
+        "parent-id": "999",
+        "add-last": true,
+      },
+    } as never);
+
+    expect(mockClient.addDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emoji: "star",
+        parentId: "999",
+        addLast: true,
+      }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    vi.mocked(promptRequired).mockResolvedValueOnce("100").mockResolvedValueOnce("Title");
+    mockClient.addDocument.mockResolvedValue({
+      id: "5",
+      title: "Title",
+    });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { create } = await import("./create");
+    await create.run?.({
+      args: { project: "100", title: "Title", json: "" },
+    } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Title"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/document/create.ts
+++ b/apps/cli/src/commands/document/create.ts
@@ -1,0 +1,104 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult, promptRequired, readStdin } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
+import { resolveProjectIds } from "../../lib/resolve-project";
+
+const commandUsage: CommandUsage = {
+  long: `Create a new Backlog document.
+
+Requires a project and title. When run interactively, omitted required
+fields will be prompted.
+
+Use \`--body -\` to read content from standard input.`,
+
+  examples: [
+    {
+      description: "Create a document with title and body",
+      command: 'bee document create -p PROJECT -t "Meeting Notes" -b "Content here"',
+    },
+    {
+      description: "Create a document from stdin",
+      command: 'echo "Content" | bee document create -p PROJECT -t "Notes" --body -',
+    },
+    {
+      description: "Create a child document",
+      command: 'bee document create -p PROJECT -t "Sub Page" --parent-id 12345',
+    },
+    {
+      description: "Output as JSON",
+      command: 'bee document create -p PROJECT -t "Title" --json',
+    },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH, ENV_PROJECT],
+  },
+};
+
+const create = withUsage(
+  defineCommand({
+    meta: {
+      name: "create",
+      description: "Create a document",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "string",
+        alias: "p",
+        description: "Project ID or project key",
+        default: process.env.BACKLOG_PROJECT,
+      },
+      title: {
+        type: "string",
+        alias: "t",
+        description: "Document title",
+      },
+      body: {
+        type: "string",
+        alias: "b",
+        description: "Document body content",
+      },
+      emoji: {
+        type: "string",
+        description: "Emoji for the document",
+      },
+      "parent-id": {
+        type: "string",
+        description: "Parent document ID for creating as a child document",
+      },
+      "add-last": {
+        type: "boolean",
+        description: "Add document to the end of the list",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const project = await promptRequired("Project:", args.project);
+      const title = await promptRequired("Title:", args.title);
+
+      const [projectId] = await resolveProjectIds(client, [project]);
+
+      const body = args.body === "-" ? await readStdin() : args.body;
+
+      const doc = await client.addDocument({
+        projectId,
+        title,
+        content: body,
+        emoji: args.emoji,
+        parentId: args["parent-id"],
+        addLast: args["add-last"],
+      });
+
+      outputResult(doc, args, (data) => {
+        consola.success(`Created document: ${data.title}`);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, create };

--- a/apps/cli/src/commands/document/delete.test.ts
+++ b/apps/cli/src/commands/document/delete.test.ts
@@ -1,0 +1,67 @@
+import { confirmOrExit } from "@repo/cli-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  deleteDocument: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+  confirmOrExit: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("document delete", () => {
+  it("deletes document after confirmation", async () => {
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    mockClient.deleteDocument.mockResolvedValue({ id: "1", title: "My Doc" });
+
+    const { deleteDocument } = await import("./delete");
+    await deleteDocument.run?.({ args: { document: "12345" } } as never);
+
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete document 12345? This cannot be undone.",
+      undefined,
+    );
+    expect(mockClient.deleteDocument).toHaveBeenCalledWith("12345");
+    expect(consola.success).toHaveBeenCalledWith("Deleted document: My Doc");
+  });
+
+  it("skips confirmation with --yes flag", async () => {
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    mockClient.deleteDocument.mockResolvedValue({ id: "1", title: "My Doc" });
+
+    const { deleteDocument } = await import("./delete");
+    await deleteDocument.run?.({ args: { document: "12345", yes: true } } as never);
+
+    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+  });
+
+  it("cancels when user declines confirmation", async () => {
+    vi.mocked(confirmOrExit).mockResolvedValue(false);
+
+    const { deleteDocument } = await import("./delete");
+    await deleteDocument.run?.({ args: { document: "12345" } } as never);
+
+    expect(mockClient.deleteDocument).not.toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    mockClient.deleteDocument.mockResolvedValue({ id: "1", title: "My Doc" });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { deleteDocument } = await import("./delete");
+    await deleteDocument.run?.({ args: { document: "12345", yes: true, json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("My Doc"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/document/delete.ts
+++ b/apps/cli/src/commands/document/delete.ts
@@ -1,0 +1,71 @@
+import { getClient } from "@repo/backlog-utils";
+import { confirmOrExit, outputArgs, outputResult } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Delete a Backlog document.
+
+This action is irreversible. You will be prompted for confirmation unless
+\`--yes\` is provided.`,
+
+  examples: [
+    {
+      description: "Delete a document (with confirmation)",
+      command: "bee document delete 12345",
+    },
+    {
+      description: "Delete a document without confirmation",
+      command: "bee document delete 12345 --yes",
+    },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const deleteDocument = withUsage(
+  defineCommand({
+    meta: {
+      name: "delete",
+      description: "Delete a document",
+    },
+    args: {
+      ...outputArgs,
+      document: {
+        type: "positional",
+        description: "Document ID",
+        valueHint: "<DOCUMENT-ID>",
+        required: true,
+      },
+      yes: {
+        type: "boolean",
+        alias: "y",
+        description: "Skip confirmation prompt",
+      },
+    },
+    async run({ args }) {
+      const confirmed = await confirmOrExit(
+        `Are you sure you want to delete document ${args.document}? This cannot be undone.`,
+        args.yes,
+      );
+
+      if (!confirmed) {
+        return;
+      }
+
+      const { client } = await getClient();
+
+      const doc = await client.deleteDocument(args.document);
+
+      outputResult(doc, args, (data) => {
+        consola.success(`Deleted document: ${data.title}`);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, deleteDocument };

--- a/apps/cli/src/commands/document/index.ts
+++ b/apps/cli/src/commands/document/index.ts
@@ -1,0 +1,16 @@
+import { defineCommand } from "citty";
+
+export const document = defineCommand({
+  meta: {
+    name: "document",
+    description: "Manage Backlog documents",
+  },
+  subCommands: {
+    list: () => import("./list").then((m) => m.list),
+    view: () => import("./view").then((m) => m.view),
+    tree: () => import("./tree").then((m) => m.tree),
+    attachments: () => import("./attachments").then((m) => m.attachments),
+    create: () => import("./create").then((m) => m.create),
+    delete: () => import("./delete").then((m) => m.deleteDocument),
+  },
+});

--- a/apps/cli/src/commands/document/list.test.ts
+++ b/apps/cli/src/commands/document/list.test.ts
@@ -1,0 +1,130 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getDocuments: vi.fn(),
+  getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PROJECT" }]),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+const sampleDocuments = [
+  {
+    id: "doc-1",
+    projectId: 100,
+    title: "Meeting Notes",
+    plain: "Some content",
+    json: "{}",
+    statusId: 1,
+    emoji: "\ud83d\udcdd",
+    attachments: [],
+    tags: [],
+    createdUser: { name: "Alice" },
+    created: "2025-01-01T00:00:00Z",
+    updatedUser: { name: "Bob" },
+    updated: "2025-01-02T00:00:00Z",
+  },
+  {
+    id: "doc-2",
+    projectId: 100,
+    title: "Design Doc",
+    plain: "Design content",
+    json: "{}",
+    statusId: 1,
+    emoji: null,
+    attachments: [],
+    tags: [],
+    createdUser: { name: "Charlie" },
+    created: "2025-01-03T00:00:00Z",
+    updatedUser: { name: "Charlie" },
+    updated: "2025-01-04T00:00:00Z",
+  },
+];
+
+describe("document list", () => {
+  it("displays document list in tabular format", async () => {
+    setupMocks();
+    mockClient.getDocuments.mockResolvedValue(sampleDocuments);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { project: "PROJECT" } } as never);
+
+    expect(getClient).toHaveBeenCalled();
+    expect(mockClient.getDocuments).toHaveBeenCalled();
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("ID"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Meeting Notes"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("doc-2"));
+  });
+
+  it("shows message when no documents found", async () => {
+    setupMocks();
+    mockClient.getDocuments.mockResolvedValue([]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { project: "PROJECT" } } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No documents found.");
+  });
+
+  it("passes keyword query parameter", async () => {
+    setupMocks();
+    mockClient.getDocuments.mockResolvedValue([]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { project: "PROJECT", keyword: "meeting" } } as never);
+
+    expect(mockClient.getDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ keyword: "meeting" }),
+    );
+  });
+
+  it("passes sort and order parameters", async () => {
+    setupMocks();
+    mockClient.getDocuments.mockResolvedValue([]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { project: "PROJECT", sort: "created", order: "asc" } } as never);
+
+    expect(mockClient.getDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "created", order: "asc" }),
+    );
+  });
+
+  it("passes count and offset parameters", async () => {
+    setupMocks();
+    mockClient.getDocuments.mockResolvedValue([]);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { project: "PROJECT", count: "10", offset: "5" } } as never);
+
+    expect(mockClient.getDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({ count: 10, offset: 5 }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    mockClient.getDocuments.mockResolvedValue(sampleDocuments);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { list } = await import("./list");
+    await list.run?.({ args: { project: "PROJECT", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/document/list.ts
+++ b/apps/cli/src/commands/document/list.ts
@@ -1,0 +1,110 @@
+import { getClient } from "@repo/backlog-utils";
+import {
+  type Row,
+  formatDate,
+  outputArgs,
+  outputResult,
+  printTable,
+  splitArg,
+} from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import * as v from "valibot";
+import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
+import { resolveProjectIds } from "../../lib/resolve-project";
+
+const commandUsage: CommandUsage = {
+  long: `List documents from a Backlog project.
+
+By default, documents are sorted by last updated date. Use \`--keyword\` to
+search within document titles and content.`,
+
+  examples: [
+    { description: "List documents in a project", command: "bee document list -p PROJECT" },
+    {
+      description: "Search documents by keyword",
+      command: 'bee document list -p PROJECT -k "meeting notes"',
+    },
+    { description: "Output as JSON", command: "bee document list -p PROJECT --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH, ENV_PROJECT],
+  },
+};
+
+const list = withUsage(
+  defineCommand({
+    meta: {
+      name: "list",
+      description: "List documents",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "string",
+        alias: "p",
+        description: "Project ID or project key (comma-separated for multiple)",
+        default: process.env.BACKLOG_PROJECT,
+      },
+      keyword: {
+        type: "string",
+        alias: "k",
+        description: "Keyword search",
+      },
+      sort: {
+        type: "string",
+        description: "Sort field",
+        valueHint: "{created|updated}",
+      },
+      order: {
+        type: "string",
+        description: "Sort order",
+        valueHint: "{asc|desc}",
+      },
+      count: {
+        type: "string",
+        alias: "L",
+        description: "Number of results (default: 20)",
+        valueHint: "<1-100>",
+      },
+      offset: {
+        type: "string",
+        description: "Offset for pagination",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const projectId = await resolveProjectIds(client, splitArg(args.project, v.string()));
+
+      const documents = await client.getDocuments({
+        projectId,
+        keyword: args.keyword,
+        sort: args.sort as "created" | "updated" | undefined,
+        order: args.order as "asc" | "desc" | undefined,
+        count: args.count ? Number(args.count) : undefined,
+        offset: args.offset ? Number(args.offset) : 0,
+      });
+
+      outputResult(documents, args, (data) => {
+        if (data.length === 0) {
+          consola.info("No documents found.");
+          return;
+        }
+
+        const rows: Row[] = data.map((doc) => [
+          { header: "ID", value: doc.id },
+          { header: "EMOJI", value: doc.emoji ?? "" },
+          { header: "TITLE", value: doc.title },
+          { header: "UPDATED", value: formatDate(doc.updated) },
+        ]);
+
+        printTable(rows);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, list };

--- a/apps/cli/src/commands/document/tree.test.ts
+++ b/apps/cli/src/commands/document/tree.test.ts
@@ -1,0 +1,122 @@
+import { getClient } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getDocumentTree: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+const sampleTree = {
+  projectId: "100",
+  activeTree: {
+    id: "root",
+    children: [
+      {
+        id: "doc-1",
+        name: "Getting Started",
+        emoji: "\ud83d\ude80",
+        children: [
+          {
+            id: "doc-2",
+            name: "Installation",
+            children: [],
+          },
+        ],
+      },
+      {
+        id: "doc-3",
+        name: "API Reference",
+        children: [],
+      },
+    ],
+  },
+};
+
+describe("document tree", () => {
+  it("displays tree structure", async () => {
+    setupMocks();
+    mockClient.getDocumentTree.mockResolvedValue(sampleTree);
+
+    const { tree } = await import("./tree");
+    await tree.run?.({ args: { project: "PROJECT" } } as never);
+
+    expect(mockClient.getDocumentTree).toHaveBeenCalledWith("PROJECT");
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Getting Started"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Installation"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("API Reference"));
+  });
+
+  it("displays emoji in tree nodes", async () => {
+    setupMocks();
+    mockClient.getDocumentTree.mockResolvedValue(sampleTree);
+
+    const { tree } = await import("./tree");
+    await tree.run?.({ args: { project: "PROJECT" } } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("\ud83d\ude80"));
+  });
+
+  it("shows message when no documents found", async () => {
+    setupMocks();
+    mockClient.getDocumentTree.mockResolvedValue({
+      projectId: "100",
+      activeTree: { id: "root", children: [] },
+    });
+
+    const { tree } = await import("./tree");
+    await tree.run?.({ args: { project: "PROJECT" } } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No documents found.");
+  });
+
+  it("shows message when activeTree is undefined", async () => {
+    setupMocks();
+    mockClient.getDocumentTree.mockResolvedValue({
+      projectId: "100",
+    });
+
+    const { tree } = await import("./tree");
+    await tree.run?.({ args: { project: "PROJECT" } } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No documents found.");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    mockClient.getDocumentTree.mockResolvedValue(sampleTree);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { tree } = await import("./tree");
+    await tree.run?.({ args: { project: "PROJECT", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
+    writeSpy.mockRestore();
+  });
+
+  it("renders tree connectors correctly", async () => {
+    setupMocks();
+    mockClient.getDocumentTree.mockResolvedValue(sampleTree);
+
+    const { tree } = await import("./tree");
+    await tree.run?.({ args: { project: "PROJECT" } } as never);
+
+    // First child uses ├── connector
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("\u251c\u2500\u2500"));
+    // Last child uses └── connector
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("\u2514\u2500\u2500"));
+  });
+});

--- a/apps/cli/src/commands/document/tree.ts
+++ b/apps/cli/src/commands/document/tree.ts
@@ -1,0 +1,87 @@
+import { getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult } from "@repo/cli-utils";
+import { type Entity } from "backlog-js";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Display the document tree structure of a Backlog project.
+
+Shows the hierarchical structure of documents with tree-style indentation.`,
+
+  examples: [
+    { description: "Show document tree", command: "bee document tree PROJECT" },
+    { description: "Output as JSON", command: "bee document tree PROJECT --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH, ENV_PROJECT],
+  },
+};
+
+const renderNode = (
+  node: Entity.Document.DocumentTreeNode,
+  prefix: string,
+  isLast: boolean,
+): string[] => {
+  const connector = isLast ? "\u2514\u2500\u2500" : "\u251c\u2500\u2500";
+  const emoji = node.emoji ? `${node.emoji} ` : "";
+  const name = node.name ?? node.id;
+  const lines: string[] = [`${prefix}${connector} ${emoji}${name}`];
+
+  const childPrefix = prefix + (isLast ? "    " : "\u2502   ");
+  for (let i = 0; i < node.children.length; i++) {
+    const child = node.children[i];
+    lines.push(...renderNode(child, childPrefix, i === node.children.length - 1));
+  }
+
+  return lines;
+};
+
+const renderTree = (children: Entity.Document.DocumentTreeNode[]): string[] => {
+  const lines: string[] = [];
+  for (let i = 0; i < children.length; i++) {
+    const child = children[i];
+    lines.push(...renderNode(child, "", i === children.length - 1));
+  }
+  return lines;
+};
+
+const tree = withUsage(
+  defineCommand({
+    meta: {
+      name: "tree",
+      description: "Display document tree",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        type: "positional",
+        description: "Project ID or project key",
+        required: true,
+        default: process.env.BACKLOG_PROJECT,
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const docTree = await client.getDocumentTree(args.project);
+
+      outputResult(docTree, args, (data) => {
+        if (!data.activeTree || data.activeTree.children.length === 0) {
+          consola.info("No documents found.");
+          return;
+        }
+
+        const lines = renderTree(data.activeTree.children);
+        for (const line of lines) {
+          consola.log(line);
+        }
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, tree };

--- a/apps/cli/src/commands/document/view.test.ts
+++ b/apps/cli/src/commands/document/view.test.ts
@@ -11,7 +11,7 @@ vi.mock("@repo/backlog-utils", () => ({
   openUrl: vi.fn(),
   documentUrl: vi.fn(
     (host: string, projectKey: string, docId: string) =>
-      `https://${host}/projects/${projectKey}/document/${docId}`,
+      `https://${host}/document/${projectKey}/${docId}`,
   ),
 }));
 
@@ -82,11 +82,9 @@ describe("document view", () => {
     const { view } = await import("./view");
     await view.run?.({ args: { document: "doc-1", project: "PROJECT", web: true } } as never);
 
-    expect(openUrl).toHaveBeenCalledWith(
-      "https://example.backlog.com/projects/PROJECT/document/doc-1",
-    );
+    expect(openUrl).toHaveBeenCalledWith("https://example.backlog.com/document/PROJECT/doc-1");
     expect(consola.info).toHaveBeenCalledWith(
-      "Opening https://example.backlog.com/projects/PROJECT/document/doc-1 in your browser.",
+      "Opening https://example.backlog.com/document/PROJECT/doc-1 in your browser.",
     );
     expect(mockClient.getDocument).not.toHaveBeenCalled();
   });

--- a/apps/cli/src/commands/document/view.test.ts
+++ b/apps/cli/src/commands/document/view.test.ts
@@ -1,0 +1,117 @@
+import { getClient, openUrl } from "@repo/backlog-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getDocument: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+  openUrl: vi.fn(),
+  documentUrl: vi.fn(
+    (host: string, projectKey: string, docId: string) =>
+      `https://${host}/projects/${projectKey}/document/${docId}`,
+  ),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+const setupMocks = () => {
+  vi.mocked(getClient).mockResolvedValue({
+    client: mockClient as never,
+    host: "example.backlog.com",
+  });
+};
+
+const sampleDocument = {
+  id: "doc-1",
+  projectId: 100,
+  title: "Meeting Notes",
+  plain: "Some document content",
+  json: "{}",
+  statusId: 1,
+  emoji: "\ud83d\udcdd",
+  attachments: [],
+  tags: [{ id: 1, name: "important" }],
+  createdUser: { name: "Alice" },
+  created: "2025-01-01T00:00:00Z",
+  updatedUser: { name: "Bob" },
+  updated: "2025-01-02T00:00:00Z",
+};
+
+describe("document view", () => {
+  it("displays document details", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue(sampleDocument);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { document: "doc-1" } } as never);
+
+    expect(mockClient.getDocument).toHaveBeenCalledWith("doc-1");
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Meeting Notes"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Alice"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("important"));
+  });
+
+  it("displays emoji when present", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue(sampleDocument);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { document: "doc-1" } } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("\ud83d\udcdd"));
+  });
+
+  it("displays body content", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue(sampleDocument);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { document: "doc-1" } } as never);
+
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Body"));
+    expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Some document content"));
+  });
+
+  it("opens browser with --web flag", async () => {
+    setupMocks();
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { document: "doc-1", project: "PROJECT", web: true } } as never);
+
+    expect(openUrl).toHaveBeenCalledWith(
+      "https://example.backlog.com/projects/PROJECT/document/doc-1",
+    );
+    expect(consola.info).toHaveBeenCalledWith(
+      "Opening https://example.backlog.com/projects/PROJECT/document/doc-1 in your browser.",
+    );
+    expect(mockClient.getDocument).not.toHaveBeenCalled();
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue(sampleDocument);
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { document: "doc-1", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
+    writeSpy.mockRestore();
+  });
+
+  it("hides tags when none exist", async () => {
+    setupMocks();
+    mockClient.getDocument.mockResolvedValue({ ...sampleDocument, tags: [] });
+
+    const { view } = await import("./view");
+    await view.run?.({ args: { document: "doc-1" } } as never);
+
+    // Tags line should not appear when there are no tags
+    expect(mockClient.getDocument).toHaveBeenCalledWith("doc-1");
+  });
+});

--- a/apps/cli/src/commands/document/view.ts
+++ b/apps/cli/src/commands/document/view.ts
@@ -1,0 +1,103 @@
+import { documentUrl, getClient, openUrl } from "@repo/backlog-utils";
+import { formatDate, outputArgs, outputResult, printDefinitionList } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Display details of a Backlog document.
+
+Shows the document title, metadata, and body content.
+
+Use \`--web\` to open the document in your default browser instead. The
+\`--project\` flag is required when using \`--web\`.`,
+
+  examples: [
+    { description: "View document details", command: "bee document view 12345" },
+    {
+      description: "Open document in browser",
+      command: "bee document view 12345 --web -p PROJECT",
+    },
+    { description: "Output as JSON", command: "bee document view 12345 --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH, ENV_PROJECT],
+  },
+};
+
+const view = withUsage(
+  defineCommand({
+    meta: {
+      name: "view",
+      description: "View a document",
+    },
+    args: {
+      ...outputArgs,
+      document: {
+        type: "positional",
+        description: "Document ID",
+        valueHint: "<DOCUMENT-ID>",
+        required: true,
+      },
+      project: {
+        type: "string",
+        alias: "p",
+        description: "Project ID or project key (required for --web)",
+        default: process.env.BACKLOG_PROJECT,
+      },
+      web: {
+        type: "boolean",
+        alias: "w",
+        description: "Open the document in the browser",
+      },
+    },
+    async run({ args }) {
+      const { client, host } = await getClient();
+
+      if (args.web) {
+        if (!args.project) {
+          consola.error("The --project flag is required when using --web.");
+          process.exit(1);
+        }
+        const url = documentUrl(host, args.project, args.document);
+        await openUrl(url);
+        consola.info(`Opening ${url} in your browser.`);
+        return;
+      }
+
+      const doc = await client.getDocument(args.document);
+
+      outputResult(doc, args, (data) => {
+        consola.log("");
+        consola.log(`  ${data.title}`);
+        consola.log("");
+        printDefinitionList([
+          ["ID", data.id],
+          ["Emoji", data.emoji ?? undefined],
+          ["Tags", data.tags.length > 0 ? data.tags.map((t) => t.name).join(", ") : undefined],
+          ["Created by", data.createdUser?.name ?? "Unknown"],
+          ["Created", formatDate(data.created)],
+          ["Updated by", data.updatedUser?.name ?? "Unknown"],
+          ["Updated", formatDate(data.updated)],
+        ]);
+
+        if (data.plain) {
+          consola.log("");
+          consola.log("  Body:");
+          consola.log(
+            data.plain
+              .split("\n")
+              .map((line) => `    ${line}`)
+              .join("\n"),
+          );
+        }
+
+        consola.log("");
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, view };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -15,6 +15,7 @@ const main = defineCommand({
     auth: () => import("./commands/auth/index").then((m) => m.auth),
     project: () => import("./commands/project/index").then((m) => m.project),
     issue: () => import("./commands/issue/index").then((m) => m.issue),
+    document: () => import("./commands/document/index").then((m) => m.document),
   },
 });
 

--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -61,6 +61,17 @@ export default defineConfig({
                 { label: "project activities", link: "/commands/project/activities" },
               ],
             },
+            {
+              label: "document",
+              items: [
+                { label: "document list", link: "/commands/document/list" },
+                { label: "document view", link: "/commands/document/view" },
+                { label: "document tree", link: "/commands/document/tree" },
+                { label: "document attachments", link: "/commands/document/attachments" },
+                { label: "document create", link: "/commands/document/create" },
+                { label: "document delete", link: "/commands/document/delete" },
+              ],
+            },
           ],
         },
       ],

--- a/packages/backlog-utils/src/url.test.ts
+++ b/packages/backlog-utils/src/url.test.ts
@@ -71,7 +71,7 @@ describe("wikiUrl", () => {
 describe("documentUrl", () => {
   it("builds document URL", () => {
     expect(documentUrl("example.backlog.com", "PROJ", "abc-123")).toBe(
-      "https://example.backlog.com/projects/PROJ/document/abc-123",
+      "https://example.backlog.com/document/PROJ/abc-123",
     );
   });
 });

--- a/packages/backlog-utils/src/url.ts
+++ b/packages/backlog-utils/src/url.ts
@@ -41,7 +41,7 @@ const wikiUrl = (host: string, wikiId: number): string =>
 
 /** Returns the URL for a document page. */
 const documentUrl = (host: string, projectKey: string, documentId: string): string =>
-  buildBacklogUrl(host, `/projects/${projectKey}/document/${documentId}`);
+  buildBacklogUrl(host, `/document/${projectKey}/${documentId}`);
 
 /** Returns the URL for the dashboard. */
 const dashboardUrl = (host: string): string => buildBacklogUrl(host, "/dashboard");

--- a/packages/cli-utils/src/format.ts
+++ b/packages/cli-utils/src/format.ts
@@ -1,3 +1,13 @@
 const formatDate = (dateStr: string): string => dateStr.slice(0, 10);
 
-export { formatDate };
+const formatSize = (bytes: number): string => {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+export { formatDate, formatSize };

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -2,6 +2,6 @@ export { outputArgs, outputResult, pickFields, filterFields } from "./output";
 export { promptRequired, confirmOrExit } from "./prompt";
 export { readStdin } from "./stdin";
 export { splitArg } from "./split-arg";
-export { formatDate } from "./format";
+export { formatDate, formatSize } from "./format";
 export { printTable, type Column, type Row } from "./table";
 export { printDefinitionList, type DefinitionItem } from "./definition-list";


### PR DESCRIPTION
## Summary

- Implement document read commands: `list`, `view`, `tree`, `attachments`
- Implement document write commands: `create`, `delete`
- Add document command group to docs sidebar
- Extract `formatSize` utility to `@repo/cli-utils` for reuse

## Test plan

- [x] All 295 tests pass (31 new document tests)
- [x] Typecheck passes across all packages
- [x] Lint passes with 0 errors/warnings
- [x] `bee document list -p PROJECT` displays document list
- [x] `bee document view <id>` displays document details
- [x] `bee document view <id> -p PROJECT --web` opens browser
- [x] `bee document tree PROJECT` displays tree structure
- [x] `bee document attachments <id>` lists attachments
- [x] `bee document create -p PROJECT -t "Title" -b "Content"` creates document
- [x] `echo "Body" | bee document create -p PROJECT -t "Title" --body -` reads stdin
- [x] `bee document delete <id>` prompts then deletes
- [x] `bee document delete <id> --yes` skips confirmation
- [x] All commands support `--json` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)