### PR TITLE
fix: detect piped stdin instead of parsing `-` flag value

### DIFF
--- a/apps/cli/src/commands/document/create.test.ts
+++ b/apps/cli/src/commands/document/create.test.ts
@@ -1,4 +1,4 @@
-import { promptRequired, readStdin } from "@repo/cli-utils";
+import { promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,7 +14,7 @@ vi.mock("@repo/backlog-utils", () => ({
 vi.mock("@repo/cli-utils", async (importOriginal) => ({
   ...(await importOriginal()),
   promptRequired: vi.fn(),
-  readStdin: vi.fn(),
+  resolveStdinArg: vi.fn((v: string | undefined) => Promise.resolve(v)),
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
@@ -56,9 +56,9 @@ describe("document create", () => {
     expect(promptRequired).toHaveBeenCalledWith("Title:", undefined);
   });
 
-  it("reads body from stdin when --body is -", async () => {
+  it("reads body from stdin when piped", async () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("100").mockResolvedValueOnce("Title");
-    vi.mocked(readStdin).mockResolvedValue("Stdin content");
+    vi.mocked(resolveStdinArg).mockResolvedValueOnce("Stdin content");
     mockClient.addDocument.mockResolvedValue({
       id: "3",
       title: "Title",
@@ -66,10 +66,10 @@ describe("document create", () => {
 
     const { create } = await import("./create");
     await create.run?.({
-      args: { project: "100", title: "Title", body: "-" },
+      args: { project: "100", title: "Title", body: "" },
     } as never);
 
-    expect(readStdin).toHaveBeenCalled();
+    expect(resolveStdinArg).toHaveBeenCalledWith("");
     expect(mockClient.addDocument).toHaveBeenCalledWith(
       expect.objectContaining({
         content: "Stdin content",

--- a/apps/cli/src/commands/document/create.ts
+++ b/apps/cli/src/commands/document/create.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult, promptRequired, readStdin } from "@repo/cli-utils";
+import { outputArgs, outputResult, promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
@@ -11,7 +11,7 @@ const commandUsage: CommandUsage = {
 Requires a project and title. When run interactively, omitted required
 fields will be prompted.
 
-Use \`--body -\` to read content from standard input.`,
+When input is piped, it is used as the body automatically.`,
 
   examples: [
     {
@@ -20,7 +20,7 @@ Use \`--body -\` to read content from standard input.`,
     },
     {
       description: "Create a document from stdin",
-      command: 'echo "Content" | bee document create -p PROJECT -t "Notes" --body -',
+      command: 'echo "Content" | bee document create -p PROJECT -t "Notes"',
     },
     {
       description: "Create a child document",
@@ -82,7 +82,7 @@ const create = withUsage(
 
       const [projectId] = await resolveProjectIds(client, [project]);
 
-      const body = args.body === "-" ? await readStdin() : args.body;
+      const body = await resolveStdinArg(args.body);
 
       const doc = await client.addDocument({
         projectId,

--- a/apps/cli/src/commands/issue/comment.test.ts
+++ b/apps/cli/src/commands/issue/comment.test.ts
@@ -1,4 +1,4 @@
-import { readStdin } from "@repo/cli-utils";
+import { resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -12,7 +12,7 @@ vi.mock("@repo/backlog-utils", () => ({
 
 vi.mock("@repo/cli-utils", async (importOriginal) => ({
   ...(await importOriginal()),
-  readStdin: vi.fn(),
+  resolveStdinArg: vi.fn((v: string | undefined) => Promise.resolve(v)),
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
@@ -31,14 +31,14 @@ describe("issue comment", () => {
     expect(consola.success).toHaveBeenCalledWith("Added comment to TEST-1");
   });
 
-  it("reads body from stdin when body is -", async () => {
-    vi.mocked(readStdin).mockResolvedValue("Stdin content");
+  it("reads body from stdin when piped", async () => {
+    vi.mocked(resolveStdinArg).mockResolvedValueOnce("Stdin content");
     mockClient.postIssueComments.mockResolvedValue({ id: 2, content: "Stdin content" });
 
     const { comment } = await import("./comment");
-    await comment.run?.({ args: { issue: "TEST-1", body: "-" } } as never);
+    await comment.run?.({ args: { issue: "TEST-1", body: "" } } as never);
 
-    expect(readStdin).toHaveBeenCalled();
+    expect(resolveStdinArg).toHaveBeenCalledWith("");
     expect(mockClient.postIssueComments).toHaveBeenCalledWith("TEST-1", {
       content: "Stdin content",
       notifiedUserId: [],

--- a/apps/cli/src/commands/issue/comment.ts
+++ b/apps/cli/src/commands/issue/comment.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult, readStdin, splitArg } from "@repo/cli-utils";
+import { outputArgs, outputResult, resolveStdinArg, splitArg } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import * as v from "valibot";
@@ -8,7 +8,8 @@ import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage"
 const commandUsage: CommandUsage = {
   long: `Add a comment to a Backlog issue.
 
-The comment body is required. Use \`-b -\` to read the body from stdin.`,
+The comment body is required. When input is piped, it is used as the body
+automatically.`,
 
   examples: [
     {
@@ -17,7 +18,7 @@ The comment body is required. Use \`-b -\` to read the body from stdin.`,
     },
     {
       description: "Add a comment from stdin",
-      command: 'echo "Comment body" | bee issue comment PROJECT-123 -b -',
+      command: 'echo "Comment body" | bee issue comment PROJECT-123',
     },
     {
       description: "Add a comment and notify users",
@@ -47,7 +48,7 @@ const comment = withUsage(
       body: {
         type: "string",
         alias: "b",
-        description: "Comment body. Use - to read from stdin.",
+        description: "Comment body",
         required: true,
       },
       notify: {
@@ -58,7 +59,7 @@ const comment = withUsage(
     async run({ args }) {
       const { client } = await getClient();
 
-      const content = args.body === "-" ? await readStdin() : args.body;
+      const content = (await resolveStdinArg(args.body)) ?? args.body;
       const notifiedUserId = splitArg(args.notify, v.number());
 
       const result = await client.postIssueComments(args.issue, {

--- a/apps/cli/src/commands/pr/comment.ts
+++ b/apps/cli/src/commands/pr/comment.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult, readStdin, splitArg } from "@repo/cli-utils";
+import { outputArgs, outputResult, resolveStdinArg, splitArg } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import * as v from "valibot";
@@ -14,7 +14,8 @@ import {
 const commandUsage: CommandUsage = {
   long: `Add a comment to a Backlog pull request.
 
-The comment body is required. Use \`-b -\` to read the body from stdin.`,
+The comment body is required. When input is piped, it is used as the body
+automatically.`,
 
   examples: [
     {
@@ -23,7 +24,7 @@ The comment body is required. Use \`-b -\` to read the body from stdin.`,
     },
     {
       description: "Add a comment from stdin",
-      command: 'echo "Comment body" | bee pr comment 42 -p PROJECT -R repo -b -',
+      command: 'echo "Comment body" | bee pr comment 42 -p PROJECT -R repo',
     },
     {
       description: "Add a comment and notify users",
@@ -67,7 +68,7 @@ const comment = withUsage(
       body: {
         type: "string",
         alias: "b",
-        description: "Comment body. Use - to read from stdin.",
+        description: "Comment body",
         required: true,
       },
       notify: {
@@ -79,7 +80,7 @@ const comment = withUsage(
       const { client } = await getClient();
 
       const prNumber = Number(args.number);
-      const content = args.body === "-" ? await readStdin() : args.body;
+      const content = (await resolveStdinArg(args.body)) ?? args.body;
       const notifiedUserId = splitArg(args.notify, v.number());
 
       const result = await client.postPullRequestComments(args.project, args.repo, prNumber, {

--- a/apps/cli/src/commands/wiki/create.test.ts
+++ b/apps/cli/src/commands/wiki/create.test.ts
@@ -1,4 +1,4 @@
-import { promptRequired, readStdin } from "@repo/cli-utils";
+import { promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,7 +14,7 @@ vi.mock("@repo/backlog-utils", () => ({
 vi.mock("@repo/cli-utils", async (importOriginal) => ({
   ...(await importOriginal()),
   promptRequired: vi.fn(),
-  readStdin: vi.fn(),
+  resolveStdinArg: vi.fn((v: string | undefined) => Promise.resolve(v)),
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
@@ -37,16 +37,16 @@ describe("wiki create", () => {
     expect(consola.success).toHaveBeenCalledWith("Created wiki page 1: My Page");
   });
 
-  it("reads body from stdin when --body is -", async () => {
+  it("reads body from stdin when piped", async () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("TEST").mockResolvedValueOnce("My Page");
-    vi.mocked(readStdin).mockResolvedValue("Stdin content");
+    vi.mocked(resolveStdinArg).mockResolvedValueOnce("Stdin content");
     mockClient.getProjects.mockResolvedValue([{ id: 100, projectKey: "TEST" }]);
     mockClient.postWiki.mockResolvedValue({ id: 1, name: "My Page" });
 
     const { create } = await import("./create");
-    await create.run?.({ args: { project: "TEST", name: "My Page", body: "-" } } as never);
+    await create.run?.({ args: { project: "TEST", name: "My Page", body: "" } } as never);
 
-    expect(readStdin).toHaveBeenCalled();
+    expect(resolveStdinArg).toHaveBeenCalledWith("");
     expect(mockClient.postWiki).toHaveBeenCalledWith(
       expect.objectContaining({ content: "Stdin content" }),
     );

--- a/apps/cli/src/commands/wiki/create.ts
+++ b/apps/cli/src/commands/wiki/create.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult, promptRequired, readStdin } from "@repo/cli-utils";
+import { outputArgs, outputResult, promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
@@ -8,8 +8,8 @@ import { resolveProjectIds } from "../../lib/resolve-project";
 const commandUsage: CommandUsage = {
   long: `Create a new Backlog wiki page.
 
-Requires a project, page name, and body content. Use \`--body -\` to read
-body content from stdin.`,
+Requires a project, page name, and body content. When input is piped,
+it is used as the body automatically.`,
 
   examples: [
     {
@@ -18,7 +18,7 @@ body content from stdin.`,
     },
     {
       description: "Create a wiki page from stdin",
-      command: 'echo "Body" | bee wiki create -p PROJECT -n "Name" -b -',
+      command: 'echo "Body" | bee wiki create -p PROJECT -n "Name"',
     },
     {
       description: "Create and notify",
@@ -53,7 +53,7 @@ const create = withUsage(
       body: {
         type: "string",
         alias: "b",
-        description: "Wiki page content. Use - to read from stdin.",
+        description: "Wiki page content",
       },
       notify: {
         type: "boolean",
@@ -65,7 +65,7 @@ const create = withUsage(
 
       const project = await promptRequired("Project:", args.project);
       const name = await promptRequired("Page name:", args.name);
-      const body = args.body === "-" ? await readStdin() : (args.body ?? "");
+      const body = (await resolveStdinArg(args.body)) ?? "";
 
       const [projectId] = await resolveProjectIds(client, [project]);
 

--- a/apps/cli/src/commands/wiki/edit.test.ts
+++ b/apps/cli/src/commands/wiki/edit.test.ts
@@ -1,4 +1,4 @@
-import { readStdin } from "@repo/cli-utils";
+import { resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -12,7 +12,7 @@ vi.mock("@repo/backlog-utils", () => ({
 
 vi.mock("@repo/cli-utils", async (importOriginal) => ({
   ...(await importOriginal()),
-  readStdin: vi.fn(),
+  resolveStdinArg: vi.fn((v: string | undefined) => Promise.resolve(v)),
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
@@ -45,14 +45,14 @@ describe("wiki edit", () => {
     });
   });
 
-  it("reads body from stdin when --body is -", async () => {
-    vi.mocked(readStdin).mockResolvedValue("Stdin content");
+  it("reads body from stdin when piped", async () => {
+    vi.mocked(resolveStdinArg).mockResolvedValueOnce("Stdin content");
     mockClient.patchWiki.mockResolvedValue({ id: 123, name: "Page" });
 
     const { edit } = await import("./edit");
-    await edit.run?.({ args: { wiki: "123", body: "-" } } as never);
+    await edit.run?.({ args: { wiki: "123", body: "" } } as never);
 
-    expect(readStdin).toHaveBeenCalled();
+    expect(resolveStdinArg).toHaveBeenCalledWith("");
     expect(mockClient.patchWiki).toHaveBeenCalledWith(
       123,
       expect.objectContaining({ content: "Stdin content" }),

--- a/apps/cli/src/commands/wiki/edit.ts
+++ b/apps/cli/src/commands/wiki/edit.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult, readStdin } from "@repo/cli-utils";
+import { outputArgs, outputResult, resolveStdinArg } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
@@ -8,7 +8,8 @@ const commandUsage: CommandUsage = {
   long: `Update an existing Backlog wiki page.
 
 Only the specified fields will be updated. Fields that are not provided
-will remain unchanged. Use \`--body -\` to read body content from stdin.`,
+will remain unchanged. When input is piped, it is used as the body
+automatically.`,
 
   examples: [
     {
@@ -21,7 +22,7 @@ will remain unchanged. Use \`--body -\` to read body content from stdin.`,
     },
     {
       description: "Update body from stdin",
-      command: 'echo "New content" | bee wiki edit 12345 -b -',
+      command: 'echo "New content" | bee wiki edit 12345',
     },
   ],
 
@@ -52,7 +53,7 @@ const edit = withUsage(
       body: {
         type: "string",
         alias: "b",
-        description: "New content of the wiki page. Use - to read from stdin.",
+        description: "New content of the wiki page",
       },
       notify: {
         type: "boolean",
@@ -62,7 +63,7 @@ const edit = withUsage(
     async run({ args }) {
       const { client } = await getClient();
 
-      const content = args.body === "-" ? await readStdin() : args.body;
+      const content = await resolveStdinArg(args.body);
 
       const wiki = await client.patchWiki(Number(args.wiki), {
         name: args.name,

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -1,6 +1,6 @@
 export { outputArgs, outputResult, pickFields, filterFields } from "./output";
 export { promptRequired, confirmOrExit } from "./prompt";
-export { readStdin } from "./stdin";
+export { readStdin, resolveStdinArg } from "./stdin";
 export { splitArg } from "./split-arg";
 export { formatDate, formatSize } from "./format";
 export { printTable, type Column, type Row } from "./table";

--- a/packages/cli-utils/src/stdin.test.ts
+++ b/packages/cli-utils/src/stdin.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { readStdin } from "./stdin";
+import { readStdin, resolveStdinArg } from "./stdin";
 
 /**
  * Create a mock async iterable that yields the given buffers,
@@ -51,5 +51,52 @@ describe("readStdin", () => {
 
     const result = await readStdin();
     expect(result).toBe("single chunk");
+  });
+});
+
+describe("resolveStdinArg", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reads stdin when value is empty and stdin is piped", async () => {
+    const mock = createMockStdin([Buffer.from("piped content")]);
+    Object.defineProperty(mock, "isTTY", { value: undefined });
+    vi.spyOn(process, "stdin", "get").mockReturnValue(mock);
+
+    const result = await resolveStdinArg("");
+    expect(result).toBe("piped content");
+  });
+
+  it("reads stdin when value is undefined and stdin is piped", async () => {
+    const mock = createMockStdin([Buffer.from("piped content")]);
+    Object.defineProperty(mock, "isTTY", { value: undefined });
+    vi.spyOn(process, "stdin", "get").mockReturnValue(mock);
+
+    const result = await resolveStdinArg(undefined);
+    expect(result).toBe("piped content");
+  });
+
+  it("returns the value as-is when it is a non-empty string", async () => {
+    const result = await resolveStdinArg("explicit body");
+    expect(result).toBe("explicit body");
+  });
+
+  it("returns undefined when value is undefined and stdin is TTY", async () => {
+    const mock = createMockStdin([]);
+    Object.defineProperty(mock, "isTTY", { value: true });
+    vi.spyOn(process, "stdin", "get").mockReturnValue(mock);
+
+    const result = await resolveStdinArg(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it("returns empty string when value is empty and stdin is TTY", async () => {
+    const mock = createMockStdin([]);
+    Object.defineProperty(mock, "isTTY", { value: true });
+    vi.spyOn(process, "stdin", "get").mockReturnValue(mock);
+
+    const result = await resolveStdinArg("");
+    expect(result).toBe("");
   });
 });

--- a/packages/cli-utils/src/stdin.ts
+++ b/packages/cli-utils/src/stdin.ts
@@ -5,4 +5,17 @@ const readStdin = async (): Promise<string> => {
   return content.trim();
 };
 
-export { readStdin };
+/**
+ * Resolve a flag value that supports reading from stdin.
+ *
+ * Returns the stdin content when the flag value is falsy (empty or
+ * omitted) and stdin is piped. Otherwise returns the original value.
+ */
+const resolveStdinArg = async (value: string | undefined): Promise<string | undefined> => {
+  if (!value && !process.stdin.isTTY) {
+    return readStdin();
+  }
+  return value;
+};
+
+export { readStdin, resolveStdinArg };


### PR DESCRIPTION
## Summary

- Add `resolveStdinArg` utility to `@repo/cli-utils` that automatically reads from stdin when the flag value is falsy and stdin is piped (`!process.stdin.isTTY`)
- Replace `args.body === "-"` pattern with `resolveStdinArg(args.body)` in all 5 affected commands (issue comment, pr comment, wiki create, wiki edit, document create)
- Update help text and examples to reflect the new piped stdin convention (no more `-b -` needed)

## Test plan

- [x] All 426 existing tests pass
- [x] Typecheck passes
- [x] New `resolveStdinArg` unit tests cover: piped stdin with empty/undefined value, non-empty value passthrough, TTY stdin fallback

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)