### PR TITLE
feat: add issue count, pr count, issue attachments, star remove commands and extend comment commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,9 @@ vite.config.ts.timestamp-*
 # Claude Code plans
 .claude/plans/
 
+# Git worktrees
+.worktrees/
+
 # Lefthook local overrides
 lefthook-local.yml
 

--- a/apps/cli/src/commands/issue/attachments.test.ts
+++ b/apps/cli/src/commands/issue/attachments.test.ts
@@ -1,0 +1,64 @@
+import { printTable } from "@repo/cli-utils";
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getIssueAttachments: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+  printTable: vi.fn(),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("issue attachments", () => {
+  it("lists attachments for an issue", async () => {
+    mockClient.getIssueAttachments.mockResolvedValue([
+      {
+        id: 1,
+        name: "file.png",
+        size: 1024,
+        createdUser: { name: "Alice" },
+        created: "2025-01-01T00:00:00Z",
+      },
+    ]);
+    const { attachments } = await import("./attachments");
+    await attachments.run?.({ args: { issue: "TEST-1" } } as never);
+    expect(mockClient.getIssueAttachments).toHaveBeenCalledWith("TEST-1");
+    expect(printTable).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.arrayContaining([expect.objectContaining({ header: "NAME", value: "file.png" })]),
+      ]),
+    );
+  });
+
+  it("shows message when no attachments found", async () => {
+    mockClient.getIssueAttachments.mockResolvedValue([]);
+    const { attachments } = await import("./attachments");
+    await attachments.run?.({ args: { issue: "TEST-1" } } as never);
+    expect(consola.info).toHaveBeenCalledWith("No attachments found.");
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getIssueAttachments.mockResolvedValue([
+      {
+        id: 1,
+        name: "file.png",
+        size: 1024,
+        createdUser: { name: "Alice" },
+        created: "2025-01-01T00:00:00Z",
+      },
+    ]);
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const { attachments } = await import("./attachments");
+    await attachments.run?.({ args: { issue: "TEST-1", json: "" } } as never);
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("file.png"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/issue/attachments.ts
+++ b/apps/cli/src/commands/issue/attachments.ts
@@ -1,0 +1,70 @@
+import { getClient } from "@repo/backlog-utils";
+import {
+  type Row,
+  formatDate,
+  formatSize,
+  outputArgs,
+  outputResult,
+  printTable,
+} from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `List attachments of a Backlog issue.
+
+Shows file name, size, creator, and creation date.`,
+
+  examples: [
+    { description: "List attachments", command: "bee issue attachments PROJECT-123" },
+    { description: "Output as JSON", command: "bee issue attachments PROJECT-123 --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH],
+  },
+};
+
+const attachments = withUsage(
+  defineCommand({
+    meta: {
+      name: "attachments",
+      description: "List issue attachments",
+    },
+    args: {
+      ...outputArgs,
+      issue: {
+        type: "positional",
+        description: "Issue ID or issue key",
+        valueHint: "<PROJECT-123>",
+        required: true,
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const files = await client.getIssueAttachments(args.issue);
+
+      outputResult(files, args, (data) => {
+        if (data.length === 0) {
+          consola.info("No attachments found.");
+          return;
+        }
+
+        const rows: Row[] = data.map((file) => [
+          { header: "ID", value: String(file.id) },
+          { header: "NAME", value: file.name },
+          { header: "SIZE", value: formatSize(file.size) },
+          { header: "CREATED BY", value: file.createdUser?.name ?? "Unknown" },
+          { header: "CREATED", value: formatDate(file.created) },
+        ]);
+
+        printTable(rows);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, attachments };

--- a/apps/cli/src/commands/issue/comment.test.ts
+++ b/apps/cli/src/commands/issue/comment.test.ts
@@ -1,9 +1,13 @@
-import { resolveStdinArg } from "@repo/cli-utils";
+import { confirmOrExit, printTable, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
 const mockClient = {
   postIssueComments: vi.fn(),
+  getIssueComments: vi.fn(),
+  getMyself: vi.fn(),
+  patchIssueComment: vi.fn(),
+  deleteIssueComment: vi.fn(),
 };
 
 vi.mock("@repo/backlog-utils", () => ({
@@ -13,6 +17,8 @@ vi.mock("@repo/backlog-utils", () => ({
 vi.mock("@repo/cli-utils", async (importOriginal) => ({
   ...(await importOriginal()),
   resolveStdinArg: vi.fn((v: string | undefined) => Promise.resolve(v)),
+  confirmOrExit: vi.fn(),
+  printTable: vi.fn(),
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
@@ -67,5 +73,102 @@ describe("issue comment", () => {
 
     expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Hello"));
     writeSpy.mockRestore();
+  });
+
+  it("lists comments with --list flag", async () => {
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 1, content: "Hello", createdUser: { name: "Alice" }, created: "2025-01-01T00:00:00Z" },
+    ]);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({ args: { issue: "TEST-1", list: true } } as never);
+
+    expect(mockClient.getIssueComments).toHaveBeenCalledWith("TEST-1", { order: "asc" });
+    expect(printTable).toHaveBeenCalled();
+  });
+
+  it("shows message when no comments found with --list", async () => {
+    mockClient.getIssueComments.mockResolvedValue([]);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({ args: { issue: "TEST-1", list: true } } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No comments found.");
+  });
+
+  it("edits last comment with --edit-last flag", async () => {
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 10, content: "Other", createdUser: { id: 999 } },
+      { id: 20, content: "My comment", createdUser: { id: 1 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+    mockClient.patchIssueComment.mockResolvedValue({ id: 20, content: "Updated" });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: { issue: "TEST-1", "edit-last": true, body: "Updated" },
+    } as never);
+
+    expect(mockClient.patchIssueComment).toHaveBeenCalledWith("TEST-1", 20, {
+      content: "Updated",
+    });
+    expect(consola.success).toHaveBeenCalledWith("Updated comment on TEST-1");
+  });
+
+  it("shows error when no own comment found with --edit-last", async () => {
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 10, content: "Other", createdUser: { id: 999 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: { issue: "TEST-1", "edit-last": true, body: "Updated" },
+    } as never);
+
+    expect(consola.error).toHaveBeenCalledWith("No comment by you was found on TEST-1.");
+  });
+
+  it("deletes last comment with --delete-last flag", async () => {
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 20, content: "My comment", createdUser: { id: 1 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    mockClient.deleteIssueComment.mockResolvedValue({ id: 20 });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({ args: { issue: "TEST-1", "delete-last": true } } as never);
+
+    expect(confirmOrExit).toHaveBeenCalled();
+    expect(mockClient.deleteIssueComment).toHaveBeenCalledWith("TEST-1", 20);
+    expect(consola.success).toHaveBeenCalledWith("Deleted comment on TEST-1");
+  });
+
+  it("skips confirmation with --yes flag on delete", async () => {
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 20, content: "My comment", createdUser: { id: 1 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+    vi.mocked(confirmOrExit).mockResolvedValue(true);
+    mockClient.deleteIssueComment.mockResolvedValue({ id: 20 });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({ args: { issue: "TEST-1", "delete-last": true, yes: true } } as never);
+
+    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+  });
+
+  it("cancels delete when user declines", async () => {
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 20, content: "My comment", createdUser: { id: 1 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+    vi.mocked(confirmOrExit).mockResolvedValue(false);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({ args: { issue: "TEST-1", "delete-last": true } } as never);
+
+    expect(mockClient.deleteIssueComment).not.toHaveBeenCalled();
   });
 });

--- a/apps/cli/src/commands/issue/comment.ts
+++ b/apps/cli/src/commands/issue/comment.ts
@@ -1,5 +1,14 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult, resolveStdinArg, splitArg } from "@repo/cli-utils";
+import {
+  type Row,
+  confirmOrExit,
+  formatDate,
+  outputArgs,
+  outputResult,
+  printTable,
+  resolveStdinArg,
+  splitArg,
+} from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import * as v from "valibot";
@@ -9,8 +18,12 @@ import * as commonArgs from "../../lib/common-args";
 const commandUsage: CommandUsage = {
   long: `Add a comment to a Backlog issue.
 
-The comment body is required. When input is piped, it is used as the body
-automatically.`,
+The comment body is required when adding a comment. When input is piped,
+it is used as the body automatically.
+
+Use \`--list\` to list all comments on an issue.
+Use \`--edit-last\` to edit your most recent comment.
+Use \`--delete-last\` to delete your most recent comment.`,
 
   examples: [
     {
@@ -21,9 +34,14 @@ automatically.`,
       description: "Add a comment from stdin",
       command: 'echo "Comment body" | bee issue comment PROJECT-123',
     },
+    { description: "List all comments", command: "bee issue comment PROJECT-123 --list" },
     {
-      description: "Add a comment and notify users",
-      command: 'bee issue comment PROJECT-123 -b "FYI" --notify 12345,67890',
+      description: "Edit your last comment",
+      command: 'bee issue comment PROJECT-123 --edit-last -b "Updated text"',
+    },
+    {
+      description: "Delete your last comment",
+      command: "bee issue comment PROJECT-123 --delete-last --yes",
     },
   ],
 
@@ -50,14 +68,106 @@ const comment = withUsage(
         type: "string",
         alias: "b",
         description: "Comment body",
-        required: true,
       },
       notify: commonArgs.notify,
+      list: {
+        type: "boolean",
+        description: "List comments on the issue",
+      },
+      "edit-last": {
+        type: "boolean",
+        description: "Edit your most recent comment",
+      },
+      "delete-last": {
+        type: "boolean",
+        description: "Delete your most recent comment",
+      },
+      yes: {
+        type: "boolean",
+        description: "Skip confirmation prompt for delete",
+      },
     },
     async run({ args }) {
       const { client } = await getClient();
 
+      if (args.list) {
+        const comments = await client.getIssueComments(args.issue, { order: "asc" });
+
+        outputResult(comments, args, (data) => {
+          const filtered = data.filter((c) => c.content);
+          if (filtered.length === 0) {
+            consola.info("No comments found.");
+            return;
+          }
+
+          const rows: Row[] = filtered.map((c) => [
+            { header: "ID", value: String(c.id) },
+            { header: "AUTHOR", value: c.createdUser.name },
+            { header: "DATE", value: formatDate(c.created) },
+            { header: "CONTENT", value: c.content! },
+          ]);
+
+          printTable(rows);
+        });
+        return;
+      }
+
+      if (args["edit-last"]) {
+        const myself = await client.getMyself();
+        const comments = await client.getIssueComments(args.issue, { order: "desc" });
+        const myComment = comments.find((c) => c.createdUser.id === myself.id);
+
+        if (!myComment) {
+          consola.error(`No comment by you was found on ${args.issue}.`);
+          return;
+        }
+
+        const content = (await resolveStdinArg(args.body)) ?? args.body;
+        if (!content) {
+          consola.error("Comment body is required. Use --body or pipe input.");
+          return;
+        }
+
+        const result = await client.patchIssueComment(args.issue, myComment.id, { content });
+
+        outputResult(result, args, () => {
+          consola.success(`Updated comment on ${args.issue}`);
+        });
+        return;
+      }
+
+      if (args["delete-last"]) {
+        const myself = await client.getMyself();
+        const comments = await client.getIssueComments(args.issue, { order: "desc" });
+        const myComment = comments.find((c) => c.createdUser.id === myself.id);
+
+        if (!myComment) {
+          consola.error(`No comment by you was found on ${args.issue}.`);
+          return;
+        }
+
+        const confirmed = await confirmOrExit(
+          `Are you sure you want to delete your comment on ${args.issue}?`,
+          args.yes,
+        );
+        if (!confirmed) {
+          return;
+        }
+
+        const result = await client.deleteIssueComment(args.issue, myComment.id);
+
+        outputResult(result, args, () => {
+          consola.success(`Deleted comment on ${args.issue}`);
+        });
+        return;
+      }
+
+      // Default: add comment
       const content = (await resolveStdinArg(args.body)) ?? args.body;
+      if (!content) {
+        consola.error("Comment body is required. Use --body or pipe input.");
+        return;
+      }
       const notifiedUserId = splitArg(args.notify, v.number());
 
       const result = await client.postIssueComments(args.issue, {

--- a/apps/cli/src/commands/issue/count.test.ts
+++ b/apps/cli/src/commands/issue/count.test.ts
@@ -1,0 +1,54 @@
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getIssuesCount: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+  resolveProjectIds: vi.fn((_: unknown, ids: string[]) => Promise.resolve(ids)),
+  PRIORITY_NAMES: ["high", "normal", "low"],
+  PriorityId: { high: 2, normal: 3, low: 4 },
+}));
+
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("issue count", () => {
+  it("outputs issue count", async () => {
+    mockClient.getIssuesCount.mockResolvedValue({ count: 42 });
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { project: "TEST" } } as never);
+
+    expect(mockClient.getIssuesCount).toHaveBeenCalled();
+    expect(consola.log).toHaveBeenCalledWith(42);
+  });
+
+  it("passes filter parameters", async () => {
+    mockClient.getIssuesCount.mockResolvedValue({ count: 5 });
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { project: "TEST", keyword: "bug" } } as never);
+
+    expect(mockClient.getIssuesCount).toHaveBeenCalledWith(
+      expect.objectContaining({ keyword: "bug" }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getIssuesCount.mockResolvedValue({ count: 42 });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    const { count } = await import("./count");
+    await count.run?.({ args: { project: "TEST", json: "" } } as never);
+
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("42"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/issue/count.ts
+++ b/apps/cli/src/commands/issue/count.ts
@@ -1,0 +1,129 @@
+import { PRIORITY_NAMES, PriorityId, getClient, resolveProjectIds } from "@repo/backlog-utils";
+import { outputArgs, outputResult, splitArg } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import * as v from "valibot";
+import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
+import * as commonArgs from "../../lib/common-args";
+
+const commandUsage: CommandUsage = {
+  long: `Count issues matching the given filter criteria.
+
+Accepts the same filter flags as \`bee issue list\`. Outputs a plain number
+by default, or a JSON object with \`--json\`.`,
+
+  examples: [
+    { description: "Count all issues in a project", command: "bee issue count -p PROJECT" },
+    {
+      description: "Count open bugs assigned to you",
+      command: 'bee issue count -p PROJECT -a @me -k "bug"',
+    },
+    { description: "Output as JSON", command: "bee issue count -p PROJECT --json" },
+  ],
+
+  annotations: {
+    environment: [...ENV_AUTH, ENV_PROJECT],
+  },
+};
+
+const count = withUsage(
+  defineCommand({
+    meta: {
+      name: "count",
+      description: "Count issues",
+    },
+    args: {
+      ...outputArgs,
+      project: {
+        ...commonArgs.project,
+        description: "Project ID or project key (comma-separated for multiple)",
+      },
+      assignee: commonArgs.assigneeList,
+      status: {
+        type: "string",
+        alias: "S",
+        description: "Status ID (comma-separated for multiple)",
+      },
+      priority: {
+        type: "string",
+        alias: "P",
+        description: "Priority name (comma-separated for multiple)",
+        valueHint: `{${PRIORITY_NAMES.join("|")}}`,
+      },
+      keyword: commonArgs.keyword,
+      "created-since": {
+        type: "string",
+        description: "Show issues created on or after this date",
+        valueHint: "<yyyy-MM-dd>",
+      },
+      "created-until": {
+        type: "string",
+        description: "Show issues created on or before this date",
+        valueHint: "<yyyy-MM-dd>",
+      },
+      "updated-since": {
+        type: "string",
+        description: "Show issues updated on or after this date",
+        valueHint: "<yyyy-MM-dd>",
+      },
+      "updated-until": {
+        type: "string",
+        description: "Show issues updated on or before this date",
+        valueHint: "<yyyy-MM-dd>",
+      },
+      "due-since": {
+        type: "string",
+        description: "Show issues due on or after this date",
+        valueHint: "<yyyy-MM-dd>",
+      },
+      "due-until": {
+        type: "string",
+        description: "Show issues due on or before this date",
+        valueHint: "<yyyy-MM-dd>",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const projectId = await resolveProjectIds(client, splitArg(args.project, v.string()));
+      const assigneeId = splitArg(args.assignee, v.number());
+      const statusId = splitArg(args.status, v.number());
+      const priorityId = args.priority
+        ? args.priority
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .map((name) => {
+              const id = PriorityId[name.toLowerCase()];
+              if (id === undefined) {
+                throw new Error(
+                  `Unknown priority "${name}". Valid values: ${PRIORITY_NAMES.join(", ")}`,
+                );
+              }
+              return id;
+            })
+        : [];
+
+      const result = await client.getIssuesCount({
+        projectId,
+        assigneeId,
+        statusId,
+        priorityId,
+        keyword: args.keyword,
+        createdSince: args["created-since"],
+        createdUntil: args["created-until"],
+        updatedSince: args["updated-since"],
+        updatedUntil: args["updated-until"],
+        dueDateSince: args["due-since"],
+        dueDateUntil: args["due-until"],
+      });
+
+      outputResult(result, args, (data) => {
+        consola.log(data.count);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, count };

--- a/apps/cli/src/commands/issue/index.ts
+++ b/apps/cli/src/commands/issue/index.ts
@@ -13,7 +13,9 @@ export const issue = defineCommand({
     edit: () => import("./edit").then((m) => m.edit),
     close: () => import("./close").then((m) => m.close),
     reopen: () => import("./reopen").then((m) => m.reopen),
+    attachments: () => import("./attachments").then((m) => m.attachments),
     comment: () => import("./comment").then((m) => m.comment),
+    count: () => import("./count").then((m) => m.count),
     delete: () => import("./delete").then((m) => m.deleteIssue),
   },
 });

--- a/apps/cli/src/commands/pr/comment.test.ts
+++ b/apps/cli/src/commands/pr/comment.test.ts
@@ -1,57 +1,153 @@
+import { printTable, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
 const mockClient = {
   postPullRequestComments: vi.fn(),
+  getPullRequestComments: vi.fn(),
+  getMyself: vi.fn(),
+  patchPullRequestComments: vi.fn(),
 };
 
 vi.mock("@repo/backlog-utils", () => ({
   getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
 }));
 
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+  resolveStdinArg: vi.fn((v: string | undefined) => Promise.resolve(v)),
+  printTable: vi.fn(),
+}));
+
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("pr comment", () => {
   it("adds a comment to a pull request", async () => {
-    mockClient.postPullRequestComments.mockResolvedValue({ id: 1, content: "Great work!" });
+    mockClient.postPullRequestComments.mockResolvedValue({ id: 1, content: "LGTM" });
 
     const { comment } = await import("./comment");
     await comment.run?.({
-      args: { number: "42", project: "PROJ", repo: "repo", body: "Great work!" },
+      args: { number: "42", project: "TEST", repo: "my-repo", body: "LGTM" },
     } as never);
 
-    expect(mockClient.postPullRequestComments).toHaveBeenCalledWith("PROJ", "repo", 42, {
-      content: "Great work!",
+    expect(mockClient.postPullRequestComments).toHaveBeenCalledWith("TEST", "my-repo", 42, {
+      content: "LGTM",
       notifiedUserId: [],
     });
     expect(consola.success).toHaveBeenCalledWith("Added comment to pull request #42");
   });
 
-  it("adds a comment with notified users", async () => {
-    mockClient.postPullRequestComments.mockResolvedValue({ id: 2, content: "FYI" });
+  it("reads body from stdin when piped", async () => {
+    vi.mocked(resolveStdinArg).mockResolvedValueOnce("Stdin content");
+    mockClient.postPullRequestComments.mockResolvedValue({ id: 2, content: "Stdin content" });
 
     const { comment } = await import("./comment");
     await comment.run?.({
-      args: { number: "42", project: "PROJ", repo: "repo", body: "FYI", notify: "111,222" },
+      args: { number: "42", project: "TEST", repo: "my-repo", body: "" },
     } as never);
 
-    expect(mockClient.postPullRequestComments).toHaveBeenCalledWith("PROJ", "repo", 42, {
+    expect(resolveStdinArg).toHaveBeenCalledWith("");
+    expect(mockClient.postPullRequestComments).toHaveBeenCalledWith("TEST", "my-repo", 42, {
+      content: "Stdin content",
+      notifiedUserId: [],
+    });
+  });
+
+  it("adds a comment with notified users", async () => {
+    mockClient.postPullRequestComments.mockResolvedValue({ id: 3, content: "FYI" });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: { number: "42", project: "TEST", repo: "my-repo", body: "FYI", notify: "111,222" },
+    } as never);
+
+    expect(mockClient.postPullRequestComments).toHaveBeenCalledWith("TEST", "my-repo", 42, {
       content: "FYI",
       notifiedUserId: [111, 222],
     });
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    mockClient.postPullRequestComments.mockResolvedValue({ id: 1, content: "Comment" });
-
+    mockClient.postPullRequestComments.mockResolvedValue({ id: 1, content: "LGTM" });
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 
     const { comment } = await import("./comment");
     await comment.run?.({
-      args: { number: "42", project: "PROJ", repo: "repo", body: "Comment", json: "" },
+      args: { number: "42", project: "TEST", repo: "my-repo", body: "LGTM", json: "" },
     } as never);
 
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Comment"));
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("LGTM"));
     writeSpy.mockRestore();
+  });
+
+  it("lists comments with --list flag", async () => {
+    mockClient.getPullRequestComments.mockResolvedValue([
+      { id: 1, content: "Hello", createdUser: { name: "Alice" }, created: "2025-01-01T00:00:00Z" },
+    ]);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: { number: "42", project: "TEST", repo: "my-repo", list: true },
+    } as never);
+
+    expect(mockClient.getPullRequestComments).toHaveBeenCalledWith("TEST", "my-repo", 42, {
+      order: "asc",
+    });
+    expect(printTable).toHaveBeenCalled();
+  });
+
+  it("shows message when no comments found with --list", async () => {
+    mockClient.getPullRequestComments.mockResolvedValue([]);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: { number: "42", project: "TEST", repo: "my-repo", list: true },
+    } as never);
+
+    expect(consola.info).toHaveBeenCalledWith("No comments found.");
+  });
+
+  it("edits last comment with --edit-last flag", async () => {
+    mockClient.getPullRequestComments.mockResolvedValue([
+      { id: 20, content: "My comment", createdUser: { id: 1 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+    mockClient.patchPullRequestComments.mockResolvedValue({ id: 20, content: "Updated" });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: {
+        number: "42",
+        project: "TEST",
+        repo: "my-repo",
+        "edit-last": true,
+        body: "Updated",
+      },
+    } as never);
+
+    expect(mockClient.patchPullRequestComments).toHaveBeenCalledWith("TEST", "my-repo", 42, 20, {
+      content: "Updated",
+    });
+    expect(consola.success).toHaveBeenCalledWith("Updated comment on pull request #42");
+  });
+
+  it("shows error when no own comment found with --edit-last", async () => {
+    mockClient.getPullRequestComments.mockResolvedValue([
+      { id: 10, content: "Other", createdUser: { id: 999 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: {
+        number: "42",
+        project: "TEST",
+        repo: "my-repo",
+        "edit-last": true,
+        body: "Updated",
+      },
+    } as never);
+
+    expect(consola.error).toHaveBeenCalledWith("No comment by you was found on pull request #42.");
   });
 });

--- a/apps/cli/src/commands/pr/comment.ts
+++ b/apps/cli/src/commands/pr/comment.ts
@@ -1,5 +1,13 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult, resolveStdinArg, splitArg } from "@repo/cli-utils";
+import {
+  type Row,
+  formatDate,
+  outputArgs,
+  outputResult,
+  printTable,
+  resolveStdinArg,
+  splitArg,
+} from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import * as v from "valibot";
@@ -15,8 +23,11 @@ import * as commonArgs from "../../lib/common-args";
 const commandUsage: CommandUsage = {
   long: `Add a comment to a Backlog pull request.
 
-The comment body is required. When input is piped, it is used as the body
-automatically.`,
+The comment body is required when adding a comment. When input is piped,
+it is used as the body automatically.
+
+Use \`--list\` to list all comments on a pull request.
+Use \`--edit-last\` to edit your most recent comment.`,
 
   examples: [
     {
@@ -27,9 +38,10 @@ automatically.`,
       description: "Add a comment from stdin",
       command: 'echo "Comment body" | bee pr comment 42 -p PROJECT -R repo',
     },
+    { description: "List all comments", command: "bee pr comment 42 -p PROJECT -R repo --list" },
     {
-      description: "Add a comment and notify users",
-      command: 'bee pr comment 42 -p PROJECT -R repo -b "FYI" --notify 12345,67890',
+      description: "Edit your last comment",
+      command: 'bee pr comment 42 -p PROJECT -R repo --edit-last -b "Updated"',
     },
   ],
 
@@ -58,15 +70,83 @@ const comment = withUsage(
         type: "string",
         alias: "b",
         description: "Comment body",
-        required: true,
       },
       notify: commonArgs.notify,
+      list: {
+        type: "boolean",
+        description: "List comments on the pull request",
+      },
+      "edit-last": {
+        type: "boolean",
+        description: "Edit your most recent comment",
+      },
     },
     async run({ args }) {
       const { client } = await getClient();
-
       const prNumber = Number(args.number);
+
+      if (args.list) {
+        const comments = await client.getPullRequestComments(args.project, args.repo, prNumber, {
+          order: "asc",
+        });
+
+        outputResult(comments, args, (data) => {
+          const filtered = data.filter((c) => c.content);
+          if (filtered.length === 0) {
+            consola.info("No comments found.");
+            return;
+          }
+
+          const rows: Row[] = filtered.map((c) => [
+            { header: "ID", value: String(c.id) },
+            { header: "AUTHOR", value: c.createdUser.name },
+            { header: "DATE", value: formatDate(c.created) },
+            { header: "CONTENT", value: c.content! },
+          ]);
+
+          printTable(rows);
+        });
+        return;
+      }
+
+      if (args["edit-last"]) {
+        const myself = await client.getMyself();
+        const comments = await client.getPullRequestComments(args.project, args.repo, prNumber, {
+          order: "desc",
+        });
+        const myComment = comments.find((c) => c.createdUser.id === myself.id);
+
+        if (!myComment) {
+          consola.error(`No comment by you was found on pull request #${args.number}.`);
+          return;
+        }
+
+        const content = (await resolveStdinArg(args.body)) ?? args.body;
+        if (!content) {
+          consola.error("Comment body is required. Use --body or pipe input.");
+          return;
+        }
+
+        const result = await client.patchPullRequestComments(
+          args.project,
+          args.repo,
+          prNumber,
+          myComment.id,
+          { content },
+        );
+
+        outputResult(result, args, () => {
+          consola.success(`Updated comment on pull request #${args.number}`);
+        });
+        return;
+      }
+
+      // Default: add comment
       const content = (await resolveStdinArg(args.body)) ?? args.body;
+      if (!content) {
+        consola.error("Comment body is required. Use --body or pipe input.");
+        return;
+      }
       const notifiedUserId = splitArg(args.notify, v.number());
 
       const result = await client.postPullRequestComments(args.project, args.repo, prNumber, {

--- a/apps/cli/src/commands/pr/count.test.ts
+++ b/apps/cli/src/commands/pr/count.test.ts
@@ -1,0 +1,52 @@
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  getPullRequestsCount: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+  PR_STATUS_NAMES: ["open", "closed", "merged"],
+  PrStatusName: { open: 1, closed: 2, merged: 3 },
+}));
+
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("pr count", () => {
+  it("outputs pull request count", async () => {
+    mockClient.getPullRequestsCount.mockResolvedValue({ count: 10 });
+    const { count } = await import("./count");
+    await count.run?.({ args: { project: "TEST", repo: "my-repo" } } as never);
+    expect(mockClient.getPullRequestsCount).toHaveBeenCalledWith(
+      "TEST",
+      "my-repo",
+      expect.any(Object),
+    );
+    expect(consola.log).toHaveBeenCalledWith(10);
+  });
+
+  it("passes status filter", async () => {
+    mockClient.getPullRequestsCount.mockResolvedValue({ count: 3 });
+    const { count } = await import("./count");
+    await count.run?.({ args: { project: "TEST", repo: "my-repo", status: "open" } } as never);
+    expect(mockClient.getPullRequestsCount).toHaveBeenCalledWith(
+      "TEST",
+      "my-repo",
+      expect.objectContaining({ statusId: [1] }),
+    );
+  });
+
+  it("outputs JSON when --json flag is set", async () => {
+    mockClient.getPullRequestsCount.mockResolvedValue({ count: 10 });
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const { count } = await import("./count");
+    await count.run?.({ args: { project: "TEST", repo: "my-repo", json: "" } } as never);
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("10"));
+    writeSpy.mockRestore();
+  });
+});

--- a/apps/cli/src/commands/pr/count.ts
+++ b/apps/cli/src/commands/pr/count.ts
@@ -1,0 +1,95 @@
+import { PR_STATUS_NAMES, PrStatusName, getClient } from "@repo/backlog-utils";
+import { outputArgs, outputResult, splitArg } from "@repo/cli-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import * as v from "valibot";
+import {
+  type CommandUsage,
+  ENV_AUTH,
+  ENV_PROJECT,
+  ENV_REPO,
+  withUsage,
+} from "../../lib/command-usage";
+import * as commonArgs from "../../lib/common-args";
+
+const commandUsage: CommandUsage = {
+  long: `Count pull requests in a Backlog repository.
+
+Accepts the same status filter as \`bee pr list\`. Outputs a plain number
+by default, or a JSON object with \`--json\`.`,
+  examples: [
+    { description: "Count all pull requests", command: "bee pr count -p PROJECT -R repo" },
+    {
+      description: "Count open pull requests",
+      command: "bee pr count -p PROJECT -R repo --status open",
+    },
+    { description: "Output as JSON", command: "bee pr count -p PROJECT -R repo --json" },
+  ],
+  annotations: { environment: [...ENV_AUTH, ENV_PROJECT, ENV_REPO] },
+};
+
+const count = withUsage(
+  defineCommand({
+    meta: {
+      name: "count",
+      description: "Count pull requests",
+    },
+    args: {
+      ...outputArgs,
+      project: { ...commonArgs.project, required: true },
+      repo: commonArgs.repo,
+      status: {
+        type: "string",
+        alias: "S",
+        description: "Status name (comma-separated for multiple)",
+        valueHint: `{${PR_STATUS_NAMES.join("|")}}`,
+      },
+      assignee: commonArgs.assigneeList,
+      issue: {
+        type: "string",
+        description: "Issue ID (comma-separated for multiple)",
+      },
+      "created-user": {
+        type: "string",
+        description: "Created user ID (comma-separated for multiple)",
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+
+      const statusId = args.status
+        ? args.status
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean)
+            .map((name) => {
+              const id = PrStatusName[name.toLowerCase()];
+              if (id === undefined) {
+                throw new Error(
+                  `Unknown status "${name}". Valid values: ${PR_STATUS_NAMES.join(", ")}`,
+                );
+              }
+              return id;
+            })
+        : undefined;
+
+      const assigneeId = splitArg(args.assignee, v.number());
+      const issueId = splitArg(args.issue, v.number());
+      const createdUserId = splitArg(args["created-user"], v.number());
+
+      const result = await client.getPullRequestsCount(args.project, args.repo, {
+        statusId,
+        assigneeId: assigneeId.length > 0 ? assigneeId : undefined,
+        issueId: issueId.length > 0 ? issueId : undefined,
+        createdUserId: createdUserId.length > 0 ? createdUserId : undefined,
+      });
+
+      outputResult(result, args, (data) => {
+        consola.log(data.count);
+      });
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, count };

--- a/apps/cli/src/commands/pr/index.ts
+++ b/apps/cli/src/commands/pr/index.ts
@@ -13,5 +13,6 @@ export const pr = defineCommand({
     create: () => import("./create").then((m) => m.create),
     edit: () => import("./edit").then((m) => m.edit),
     comment: () => import("./comment").then((m) => m.comment),
+    count: () => import("./count").then((m) => m.count),
   },
 });

--- a/apps/cli/src/commands/star/index.ts
+++ b/apps/cli/src/commands/star/index.ts
@@ -9,5 +9,6 @@ export const star = defineCommand({
     add: () => import("./add").then((m) => m.add),
     list: () => import("./list").then((m) => m.list),
     count: () => import("./count").then((m) => m.count),
+    remove: () => import("./remove").then((m) => m.remove),
   },
 });

--- a/apps/cli/src/commands/star/remove.test.ts
+++ b/apps/cli/src/commands/star/remove.test.ts
@@ -1,0 +1,22 @@
+import consola from "consola";
+import { describe, expect, it, vi } from "vitest";
+
+const mockClient = {
+  removeStar: vi.fn(),
+};
+
+vi.mock("@repo/backlog-utils", () => ({
+  getClient: vi.fn(() => Promise.resolve({ client: mockClient, host: "example.backlog.com" })),
+}));
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+describe("star remove", () => {
+  it("removes a star by ID", async () => {
+    mockClient.removeStar.mockResolvedValue(undefined);
+    const { remove } = await import("./remove");
+    await remove.run?.({ args: { star: "12345" } } as never);
+    expect(mockClient.removeStar).toHaveBeenCalledWith(12_345);
+    expect(consola.success).toHaveBeenCalledWith("Removed star 12345.");
+  });
+});

--- a/apps/cli/src/commands/star/remove.ts
+++ b/apps/cli/src/commands/star/remove.ts
@@ -1,0 +1,34 @@
+import { getClient } from "@repo/backlog-utils";
+import { defineCommand } from "citty";
+import consola from "consola";
+import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
+
+const commandUsage: CommandUsage = {
+  long: `Remove a star.
+
+Use \`bee star list\` to find star IDs.`,
+  examples: [{ description: "Remove a star", command: "bee star remove 12345" }],
+  annotations: { environment: [...ENV_AUTH] },
+};
+
+const remove = withUsage(
+  defineCommand({
+    meta: { name: "remove", description: "Remove a star" },
+    args: {
+      star: {
+        type: "positional",
+        description: "Star ID",
+        valueHint: "<number>",
+        required: true,
+      },
+    },
+    async run({ args }) {
+      const { client } = await getClient();
+      await client.removeStar(Number(args.star));
+      consola.success(`Removed star ${args.star}.`);
+    },
+  }),
+  commandUsage,
+);
+
+export { commandUsage, remove };


### PR DESCRIPTION
## Summary

- Add `issue count` command to count issues with filter support
- Add `pr count` command to count pull requests with filter support
- Add `issue attachments` command to list issue attachments
- Add `star remove` command to remove a star by ID
- Extend `issue comment` with `--list`, `--edit-last`, `--delete-last`, `--yes` flags (gh CLI style)
- Extend `pr comment` with `--list`, `--edit-last` flags (gh CLI style)

## Test plan

### Automated tests

- [x] All 22 new tests pass (590 total, up from 568)
- [x] TypeScript type check passes across all packages
- [x] Pre-commit hooks (oxlint, oxfmt) pass on all commits
- [x] Docs sidebar auto-generated from `commandUsage` exports

### Manual testing (simochee.backlog.com)

**`issue count`**
- [x] `bee issue count -p PLAY_GROUND` → `22`
- [x] `bee issue count -p PLAY_GROUND --json` → `{"count":22}`
- [x] `bee issue count -p PLAY_GROUND -k "テスト"` → `7` (keyword filter)

**`pr count`**
- [x] `bee pr count -p PLAY_GROUND -R depends-pulls` → `3`
- [x] `bee pr count -p PLAY_GROUND -R depends-pulls --status open` → `2` (status filter)
- [x] `bee pr count -p PLAY_GROUND -R depends-pulls --json` → `{"count":3}`

**`issue attachments`**
- [x] `bee issue attachments PLAY_GROUND-29` → "No attachments found." (empty state)
- [ ] Table display with attachments (no issue with attachments found on test instance)

**`star remove`**
- [x] `bee star remove 54679823` → "Removed star 54679823."
- [x] Verified star count decreased by 1 via `bee star list`

**`issue comment --list`**
- [x] No comments → "No comments found."
- [x] After adding comment → table with ID, AUTHOR, DATE, CONTENT columns

**`issue comment --edit-last`**
- [x] Edit succeeded → "Updated comment on PLAY_GROUND-27"
- [x] Verified content changed via `--list`

**`issue comment --delete-last`**
- [x] `--delete-last --yes` → "Deleted comment on PLAY_GROUND-27"
- [x] Verified comment removed via `--list`
- [ ] Confirmation prompt without `--yes` (not testable in non-interactive environment)

**`pr comment --list`**
- [x] No comments → "No comments found."
- [x] After adding comment → table with ID, AUTHOR, DATE, CONTENT columns

**`pr comment --edit-last`**
- [x] Edit succeeded → "Updated comment on pull request #3"
- [x] Verified content changed via `--list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)