### PR TITLE
Standardize user-facing messages and CLI command references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,43 @@ View commands support `--web` to open the resource in a browser. Build the URL (
 
 Use `resolveStdinArg(value)` for flags that accept piped input (e.g., `--body`). Returns stdin content when the flag is empty and stdin is piped, otherwise returns the original value.
 
+## User-Facing Message Conventions
+
+### consola method usage
+
+- **`consola.success()`** — action completion (create, update, delete, login, etc.)
+- **`consola.info()`** — informational (e.g., "No results found.", "Opening ... in browser.")
+- **`consola.error()`** — errors and validation failures
+- **`consola.start()`** — progress indicator for async operations (e.g., "Access token expired. Refreshing...")
+- **`consola.log()`** — raw output (tables, spacing)
+
+### Success message format
+
+CRUD and action messages follow two patterns depending on the resource type:
+
+| Resource type                                                               | Pattern                               | Example                         |
+| --------------------------------------------------------------------------- | ------------------------------------- | ------------------------------- |
+| ID-based (category, status, milestone, webhook, issue-type, team, document) | `<Verb> <resource> <name> (ID: <id>)` | `Created category Bug (ID: 5)`  |
+| Key-based (issue, project, PR, wiki)                                        | `<Verb> <resource> <key>: <name>`     | `Created issue PROJ-1: Fix bug` |
+
+- Use past tense verbs: Created, Updated, Deleted, Added, Removed, Starred, Closed, Reopened, etc.
+- Do not quote or backtick resource names/IDs in success messages.
+
+### "No results" messages
+
+All list commands use the pattern: `consola.info("No <plural> found.")` (e.g., `"No issues found."`, `"No statuses found."`).
+
+### Error messages
+
+- Quote invalid user input with double quotes: `` `Invalid field format: "${pair}". Expected key=value.` ``
+- Reference CLI commands with backticks: ``Run `bee auth login` to authenticate.``
+- Always use `bee` as the CLI command name (never `bl` or other aliases).
+
+### String formatting
+
+- Always use template literals (backticks) for messages containing variables — never string concatenation with `+`.
+- Use `consola` methods — never `console.log` / `console.error`.
+
 ## Test Conventions
 
 - **Test titles**: Always in English. Use `verb + condition` pattern (e.g., `"shows error when X"`, `"calls Y when Z"`).

--- a/apps/cli/src/commands/document/create.test.ts
+++ b/apps/cli/src/commands/document/create.test.ts
@@ -40,7 +40,7 @@ describe("document create", () => {
         content: "Content here",
       }),
     );
-    expect(consola.success).toHaveBeenCalledWith("Created document: Meeting Notes");
+    expect(consola.success).toHaveBeenCalledWith("Created document Meeting Notes (ID: 1)");
   });
 
   it("prompts for required fields when not provided", async () => {

--- a/apps/cli/src/commands/document/create.ts
+++ b/apps/cli/src/commands/document/create.ts
@@ -89,7 +89,7 @@ const create = withUsage(
       });
 
       outputResult(doc, args, (data) => {
-        consola.success(`Created document: ${data.title}`);
+        consola.success(`Created document ${data.title} (ID: ${data.id})`);
       });
     },
   }),

--- a/apps/cli/src/commands/document/delete.test.ts
+++ b/apps/cli/src/commands/document/delete.test.ts
@@ -30,7 +30,7 @@ describe("document delete", () => {
       undefined,
     );
     expect(mockClient.deleteDocument).toHaveBeenCalledWith("12345");
-    expect(consola.success).toHaveBeenCalledWith("Deleted document: My Doc");
+    expect(consola.success).toHaveBeenCalledWith("Deleted document My Doc (ID: 1)");
   });
 
   it("skips confirmation with --yes flag", async () => {

--- a/apps/cli/src/commands/document/delete.ts
+++ b/apps/cli/src/commands/document/delete.ts
@@ -61,7 +61,7 @@ const deleteDocument = withUsage(
       const doc = await client.deleteDocument(args.document);
 
       outputResult(doc, args, (data) => {
-        consola.success(`Deleted document: ${data.title}`);
+        consola.success(`Deleted document ${data.title} (ID: ${data.id})`);
       });
     },
   }),

--- a/packages/backlog-utils/src/client.ts
+++ b/packages/backlog-utils/src/client.ts
@@ -49,7 +49,7 @@ const getClient = async (): Promise<{
     return { client, host: envHost };
   }
 
-  consola.error("No space configured. Run `bl auth login` to authenticate.");
+  consola.error("No space configured. Run `bee auth login` to authenticate.");
   return process.exit(1);
 };
 
@@ -80,7 +80,7 @@ const createOAuthClient = (
 
     if (!clientId || !clientSecret || !refreshToken) {
       consola.error(
-        "OAuth credentials are incomplete. Run `bl auth login -m oauth` to re-authenticate.",
+        "OAuth credentials are incomplete. Run `bee auth login -m oauth` to re-authenticate.",
       );
       return false;
     }
@@ -111,7 +111,7 @@ const createOAuthClient = (
         return true;
       } catch {
         consola.error(
-          "OAuth session has expired. Run `bl auth login -m oauth` to re-authenticate.",
+          "OAuth session has expired. Run `bee auth login -m oauth` to re-authenticate.",
         );
         return false;
       }


### PR DESCRIPTION
## Summary

This PR establishes and implements consistent conventions for user-facing messages across the CLI. Changes include:

1. **Added comprehensive message conventions documentation** in `CLAUDE.md`:
   - `consola` method usage guidelines (success, info, error, start, log)
   - Success message format patterns for ID-based vs key-based resources
   - "No results" message conventions
   - Error message formatting rules
   - String formatting best practices (template literals, consola methods)

2. **Updated CLI command references** from `bl` to `bee` in error messages across the codebase to match the actual CLI command name.

3. **Standardized document command success messages** to follow the ID-based resource pattern:
   - Changed from `"Created document: <title>"` to `"Created document <title> (ID: <id>)"`
   - Applied to both `create` and `delete` commands
   - Updated corresponding test expectations

These changes ensure consistency in user messaging and align the codebase with the documented conventions for future development.

## Test plan

Existing unit tests in `document/create.test.ts` and `document/delete.test.ts` have been updated to verify the new message format. All tests pass with the updated expectations.

https://claude.ai/code/session_016SqqWJgPf3o3H7MZYyAoBi