### PR TITLE
Replace process.exit() calls with UserError exceptions

### DIFF
--- a/apps/cli/src/commands/api.ts
+++ b/apps/cli/src/commands/api.ts
@@ -1,7 +1,6 @@
 import { type BacklogClient, getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult } from "@repo/cli-utils";
+import { UserError, outputArgs, outputResult } from "@repo/cli-utils";
 import { defineCommand } from "citty";
-import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../lib/command-usage";
 
 const commandUsage: CommandUsage = {
@@ -180,8 +179,7 @@ const buildParams = (fields: string[], rawFields: string[]): Params => {
   for (const pair of fields) {
     const eqIndex = pair.indexOf("=");
     if (eqIndex === -1) {
-      consola.error(`Invalid field format: "${pair}". Expected key=value.`);
-      process.exit(1);
+      throw new UserError(`Invalid field format: "${pair}". Expected key=value.`);
     }
     addParam(pair.slice(0, eqIndex), inferType(pair.slice(eqIndex + 1)));
   }
@@ -189,8 +187,7 @@ const buildParams = (fields: string[], rawFields: string[]): Params => {
   for (const pair of rawFields) {
     const eqIndex = pair.indexOf("=");
     if (eqIndex === -1) {
-      consola.error(`Invalid field format: "${pair}". Expected key=value.`);
-      process.exit(1);
+      throw new UserError(`Invalid field format: "${pair}". Expected key=value.`);
     }
     addParam(pair.slice(0, eqIndex), pair.slice(eqIndex + 1));
   }
@@ -238,8 +235,7 @@ const makeRequest = async (
       return client.delete(endpoint, params);
     }
     default: {
-      consola.error(`Unsupported HTTP method: ${method}`);
-      return process.exit(1);
+      throw new UserError(`Unsupported HTTP method: ${method}`);
     }
   }
 };

--- a/apps/cli/src/commands/auth/login.test.ts
+++ b/apps/cli/src/commands/auth/login.test.ts
@@ -2,7 +2,6 @@ import { exchangeAuthorizationCode, startCallbackServer } from "@repo/backlog-ut
 import { promptRequired } from "@repo/cli-utils";
 import { updateConfig } from "@repo/config";
 import { Backlog, OAuth2 } from "backlog-js";
-import { spyOnProcessExit } from "@repo/test-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -26,7 +25,8 @@ vi.mock("@repo/backlog-utils", () => ({
   openUrl: vi.fn(),
 }));
 
-vi.mock("@repo/cli-utils", () => ({
+vi.mock("@repo/cli-utils", async (importOriginal) => ({
+  ...(await importOriginal()),
   promptRequired: vi.fn(),
   readStdin: vi.fn(),
 }));
@@ -103,34 +103,27 @@ describe("auth login", () => {
       vi.mocked(promptRequired)
         .mockResolvedValueOnce("example.backlog.com")
         .mockResolvedValueOnce("bad-key");
-      const exitSpy = spyOnProcessExit();
 
       const { login } = await import("./login");
-      await login.run?.({
-        args: { method: "api-key" },
-      } as never);
-
-      expect(consola.error).toHaveBeenCalledWith(
+      await expect(
+        login.run?.({
+          args: { method: "api-key" },
+        } as never),
+      ).rejects.toThrow(
         "Authentication failed. Could not connect to example.backlog.com with the provided API key.",
       );
-      expect(exitSpy).toHaveBeenCalledWith(1);
       expect(updateConfig).not.toHaveBeenCalled();
-      exitSpy.mockRestore();
     });
   });
 
   describe("invalid method", () => {
     it("returns error for invalid method", async () => {
-      const exitSpy = spyOnProcessExit();
-
       const { login } = await import("./login");
-      await login.run?.({
-        args: { method: "invalid" },
-      } as never);
-
-      expect(consola.error).toHaveBeenCalledWith('Invalid auth method. Use "api-key" or "oauth".');
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      exitSpy.mockRestore();
+      await expect(
+        login.run?.({
+          args: { method: "invalid" },
+        } as never),
+      ).rejects.toThrow('Invalid auth method. Use "api-key" or "oauth".');
     });
   });
 
@@ -214,7 +207,7 @@ describe("auth login", () => {
       );
     });
 
-    it("calls process.exit(1) when error occurs during callback", async () => {
+    it("throws error when error occurs during callback", async () => {
       const mockStop = vi.fn();
       vi.mocked(startCallbackServer).mockReturnValue({
         port: 5033,
@@ -227,71 +220,58 @@ describe("auth login", () => {
         .mockResolvedValueOnce("example.backlog.com")
         .mockResolvedValueOnce("my-client-id")
         .mockResolvedValueOnce("my-client-secret");
-      const exitSpy = spyOnProcessExit();
 
       const { login } = await import("./login");
-      await login.run?.({
-        args: {
-          method: "oauth",
-          "client-id": "my-client-id",
-          "client-secret": "my-client-secret",
-        },
-      } as never);
-
-      expect(consola.error).toHaveBeenCalledWith(
-        "OAuth authorization failed: OAuth callback timed out after 5 minutes",
-      );
-      expect(exitSpy).toHaveBeenCalledWith(1);
+      await expect(
+        login.run?.({
+          args: {
+            method: "oauth",
+            "client-id": "my-client-id",
+            "client-secret": "my-client-secret",
+          },
+        } as never),
+      ).rejects.toThrow("OAuth authorization failed: OAuth callback timed out after 5 minutes");
       expect(mockStop).toHaveBeenCalled();
-      exitSpy.mockRestore();
     });
 
-    it("calls process.exit(1) when token exchange fails", async () => {
+    it("throws error when token exchange fails", async () => {
       setupOAuthMocks();
       vi.mocked(exchangeAuthorizationCode).mockRejectedValue(new Error("invalid_grant"));
       vi.mocked(promptRequired)
         .mockResolvedValueOnce("example.backlog.com")
         .mockResolvedValueOnce("my-client-id")
         .mockResolvedValueOnce("my-client-secret");
-      const exitSpy = spyOnProcessExit();
 
       const { login } = await import("./login");
-      await login.run?.({
-        args: {
-          method: "oauth",
-          "client-id": "my-client-id",
-          "client-secret": "my-client-secret",
-        },
-      } as never);
-
-      expect(consola.error).toHaveBeenCalledWith(
-        "Failed to exchange authorization code for tokens.",
-      );
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      exitSpy.mockRestore();
+      await expect(
+        login.run?.({
+          args: {
+            method: "oauth",
+            "client-id": "my-client-id",
+            "client-secret": "my-client-secret",
+          },
+        } as never),
+      ).rejects.toThrow("Failed to exchange authorization code for tokens.");
     });
 
-    it("calls process.exit(1) when token verification fails", async () => {
+    it("throws error when token verification fails", async () => {
       setupOAuthMocks();
       mockGetMyself.mockRejectedValue(new Error("Unauthorized"));
       vi.mocked(promptRequired)
         .mockResolvedValueOnce("example.backlog.com")
         .mockResolvedValueOnce("my-client-id")
         .mockResolvedValueOnce("my-client-secret");
-      const exitSpy = spyOnProcessExit();
 
       const { login } = await import("./login");
-      await login.run?.({
-        args: {
-          method: "oauth",
-          "client-id": "my-client-id",
-          "client-secret": "my-client-secret",
-        },
-      } as never);
-
-      expect(consola.error).toHaveBeenCalledWith("Authentication verification failed.");
-      expect(exitSpy).toHaveBeenCalledWith(1);
-      exitSpy.mockRestore();
+      await expect(
+        login.run?.({
+          args: {
+            method: "oauth",
+            "client-id": "my-client-id",
+            "client-secret": "my-client-secret",
+          },
+        } as never),
+      ).rejects.toThrow("Authentication verification failed.");
     });
 
     it("updates OAuth credentials for existing space", async () => {

--- a/apps/cli/src/commands/auth/login.ts
+++ b/apps/cli/src/commands/auth/login.ts
@@ -1,5 +1,5 @@
 import { exchangeAuthorizationCode, openUrl, startCallbackServer } from "@repo/backlog-utils";
-import { promptRequired, readStdin } from "@repo/cli-utils";
+import { UserError, promptRequired, readStdin } from "@repo/cli-utils";
 import { type RcAuth, updateConfig } from "@repo/config";
 import { Backlog, OAuth2 } from "backlog-js";
 import { defineCommand } from "citty";
@@ -65,8 +65,7 @@ const login = withUsage(
       const { method } = args;
 
       if (method !== "api-key" && method !== "oauth") {
-        consola.error('Invalid auth method. Use "api-key" or "oauth".');
-        return process.exit(1);
+        throw new UserError('Invalid auth method. Use "api-key" or "oauth".');
       }
 
       const hostname = await promptRequired("Backlog space hostname:", process.env.BACKLOG_SPACE, {
@@ -97,10 +96,9 @@ const loginWithApiKey = async (
     const client = new Backlog({ host: hostname, apiKey });
     user = await client.getMyself();
   } catch {
-    consola.error(
+    throw new UserError(
       `Authentication failed. Could not connect to ${hostname} with the provided API key.`,
     );
-    return process.exit(1);
   }
 
   saveSpace(hostname, { method: "api-key", apiKey });
@@ -138,10 +136,9 @@ const loginWithOAuth = async (
     code = await callbackServer.waitForCallback(state);
   } catch (error) {
     callbackServer.stop();
-    consola.error(
+    throw new UserError(
       `OAuth authorization failed: ${error instanceof Error ? error.message : String(error)}`,
     );
-    return process.exit(1);
   } finally {
     callbackServer.stop();
   }
@@ -157,8 +154,7 @@ const loginWithOAuth = async (
       redirectUri,
     });
   } catch {
-    consola.error("Failed to exchange authorization code for tokens.");
-    return process.exit(1);
+    throw new UserError("Failed to exchange authorization code for tokens.");
   }
 
   let user;
@@ -166,8 +162,7 @@ const loginWithOAuth = async (
     const client = new Backlog({ host: hostname, accessToken: tokenResponse.access_token });
     user = await client.getMyself();
   } catch {
-    consola.error("Authentication verification failed.");
-    return process.exit(1);
+    throw new UserError("Authentication verification failed.");
   }
 
   saveSpace(hostname, {

--- a/apps/cli/src/commands/auth/logout.test.ts
+++ b/apps/cli/src/commands/auth/logout.test.ts
@@ -1,5 +1,4 @@
 import { loadConfig, removeSpace } from "@repo/config";
-import { spyOnProcessExit } from "@repo/test-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -58,18 +57,12 @@ describe("auth logout", () => {
       throw new Error("not found");
     });
 
-    const exitSpy = spyOnProcessExit();
-
     const { logout } = await import("./logout");
-    await logout.run?.({
-      args: { space: "nonexistent.backlog.com" },
-    } as never);
-
-    expect(consola.error).toHaveBeenCalledWith(
-      'Space "nonexistent.backlog.com" is not configured.',
-    );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    await expect(
+      logout.run?.({
+        args: { space: "nonexistent.backlog.com" },
+      } as never),
+    ).rejects.toThrow('Space "nonexistent.backlog.com" is not configured.');
   });
 
   it("auto-selects and logs out when --space is omitted and one space exists", async () => {

--- a/apps/cli/src/commands/auth/logout.ts
+++ b/apps/cli/src/commands/auth/logout.ts
@@ -1,3 +1,4 @@
+import { UserError } from "@repo/cli-utils";
 import { loadConfig, removeSpace } from "@repo/config";
 import { defineCommand } from "citty";
 import consola from "consola";
@@ -56,10 +57,9 @@ const logout = withUsage(
         if (config.spaces.length === 1) {
           hostname = firstSpace.host;
         } else if (isNoInput()) {
-          consola.error(
+          throw new UserError(
             "Hostname is required. Use --space to provide it in BACKLOG_NO_INPUT mode.",
           );
-          return process.exit(1);
         } else {
           hostname = await consola.prompt("Select a space to log out from:", {
             type: "select",
@@ -67,8 +67,7 @@ const logout = withUsage(
           });
 
           if (typeof hostname !== "string" || !hostname) {
-            consola.error("No space selected.");
-            return process.exit(1);
+            throw new UserError("No space selected.");
           }
         }
       }
@@ -76,8 +75,7 @@ const logout = withUsage(
       try {
         removeSpace(hostname);
       } catch {
-        consola.error(`Space "${hostname}" is not configured.`);
-        return process.exit(1);
+        throw new UserError(`Space "${hostname}" is not configured.`);
       }
 
       consola.success(`Logged out of ${hostname}.`);

--- a/apps/cli/src/commands/auth/refresh.test.ts
+++ b/apps/cli/src/commands/auth/refresh.test.ts
@@ -1,7 +1,6 @@
 import { refreshAccessToken } from "@repo/backlog-utils";
 import { resolveSpace, updateSpaceAuth } from "@repo/config";
 import { Backlog } from "backlog-js";
-import { spyOnProcessExit } from "@repo/test-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -27,18 +26,13 @@ vi.mock("@repo/config", () => ({
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("auth refresh", () => {
-  it("calls process.exit(1) when no space is configured", async () => {
+  it("throws error when no space is configured", async () => {
     vi.mocked(resolveSpace).mockReturnValue(null);
-    const exitSpy = spyOnProcessExit();
 
     const { refresh } = await import("./refresh");
-    await refresh.run?.({ args: {} } as never);
-
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(refresh.run?.({ args: {} } as never)).rejects.toThrow(
       "No space configured. Run `bee auth login` to authenticate.",
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
   });
 
   it("shows error for API key authentication", async () => {
@@ -46,16 +40,11 @@ describe("auth refresh", () => {
       host: "example.backlog.com",
       auth: { method: "api-key" as const, apiKey: "key" },
     });
-    const exitSpy = spyOnProcessExit();
 
     const { refresh } = await import("./refresh");
-    await refresh.run?.({ args: {} } as never);
-
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(refresh.run?.({ args: {} } as never)).rejects.toThrow(
       "Token refresh is only available for OAuth authentication. Current space uses API key.",
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
   });
 
   it("shows error when clientId/clientSecret are missing", async () => {
@@ -67,16 +56,11 @@ describe("auth refresh", () => {
         refreshToken: "refresh",
       },
     });
-    const exitSpy = spyOnProcessExit();
 
     const { refresh } = await import("./refresh");
-    await refresh.run?.({ args: {} } as never);
-
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(refresh.run?.({ args: {} } as never)).rejects.toThrow(
       "Client ID and Client Secret are missing from the stored OAuth configuration. Please re-authenticate with `bee auth login -m oauth`.",
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
   });
 
   it("successfully refreshes token", async () => {
@@ -135,16 +119,11 @@ describe("auth refresh", () => {
       },
     });
     vi.mocked(refreshAccessToken).mockRejectedValue(new Error("invalid_grant"));
-    const exitSpy = spyOnProcessExit();
 
     const { refresh } = await import("./refresh");
-    await refresh.run?.({ args: {} } as never);
-
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(refresh.run?.({ args: {} } as never)).rejects.toThrow(
       "Failed to refresh OAuth token. Please re-authenticate with `bee auth login -m oauth`.",
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
   });
 
   it("shows error when token verification fails after refresh", async () => {
@@ -165,13 +144,10 @@ describe("auth refresh", () => {
       refresh_token: "new-refresh",
     });
     mockGetMyself.mockRejectedValue(new Error("Unauthorized"));
-    const exitSpy = spyOnProcessExit();
 
     const { refresh } = await import("./refresh");
-    await refresh.run?.({ args: {} } as never);
-
-    expect(consola.error).toHaveBeenCalledWith("Token verification failed after refresh.");
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    await expect(refresh.run?.({ args: {} } as never)).rejects.toThrow(
+      "Token verification failed after refresh.",
+    );
   });
 });

--- a/apps/cli/src/commands/auth/refresh.ts
+++ b/apps/cli/src/commands/auth/refresh.ts
@@ -1,4 +1,5 @@
 import { refreshAccessToken } from "@repo/backlog-utils";
+import { UserError } from "@repo/cli-utils";
 import { findSpace, loadConfig, resolveSpace, updateSpaceAuth } from "@repo/config";
 import { Backlog } from "backlog-js";
 import { defineCommand } from "citty";
@@ -43,23 +44,20 @@ const refresh = withUsage(
       const space = args.space ? findSpace(loadConfig().spaces, args.space) : resolveSpace();
 
       if (!space) {
-        consola.error("No space configured. Run `bee auth login` to authenticate.");
-        return process.exit(1);
+        throw new UserError("No space configured. Run `bee auth login` to authenticate.");
       }
 
       if (space.auth.method !== "oauth") {
-        consola.error(
+        throw new UserError(
           "Token refresh is only available for OAuth authentication. Current space uses API key.",
         );
-        return process.exit(1);
       }
 
       const { clientId, clientSecret } = space.auth;
       if (!clientId || !clientSecret) {
-        consola.error(
+        throw new UserError(
           "Client ID and Client Secret are missing from the stored OAuth configuration. Please re-authenticate with `bee auth login -m oauth`.",
         );
-        return process.exit(1);
       }
 
       consola.start(`Refreshing OAuth token for ${space.host}...`);
@@ -72,10 +70,9 @@ const refresh = withUsage(
           refreshToken: space.auth.refreshToken,
         });
       } catch {
-        consola.error(
+        throw new UserError(
           "Failed to refresh OAuth token. Please re-authenticate with `bee auth login -m oauth`.",
         );
-        return process.exit(1);
       }
 
       let user;
@@ -83,8 +80,7 @@ const refresh = withUsage(
         const client = new Backlog({ host: space.host, accessToken: tokenResponse.access_token });
         user = await client.getMyself();
       } catch {
-        consola.error("Token verification failed after refresh.");
-        return process.exit(1);
+        throw new UserError("Token verification failed after refresh.");
       }
 
       updateSpaceAuth(space.host, {

--- a/apps/cli/src/commands/auth/switch.test.ts
+++ b/apps/cli/src/commands/auth/switch.test.ts
@@ -1,5 +1,4 @@
 import { loadConfig, writeConfig } from "@repo/config";
-import { spyOnProcessExit } from "@repo/test-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -36,22 +35,19 @@ describe("auth switch", () => {
     expect(consola.success).toHaveBeenCalledWith("Switched active space to example.backlog.com.");
   });
 
-  it("shows error when space is not found", async () => {
+  it("throws error when space is not found", async () => {
     vi.mocked(loadConfig).mockReturnValue({
       spaces: [],
       defaultSpace: undefined,
       aliases: {},
     });
 
-    const exitSpy = spyOnProcessExit();
-
     const { switchSpace } = await import("./switch");
-    await switchSpace.run?.({
-      args: { space: "missing.backlog.com" },
-    } as never);
-
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    await expect(
+      switchSpace.run?.({
+        args: { space: "missing.backlog.com" },
+      } as never),
+    ).rejects.toThrow();
   });
 
   it("calls writeConfig on successful switch", async () => {

--- a/apps/cli/src/commands/auth/switch.ts
+++ b/apps/cli/src/commands/auth/switch.ts
@@ -1,3 +1,4 @@
+import { UserError } from "@repo/cli-utils";
 import { loadConfig, writeConfig } from "@repo/config";
 import { defineCommand } from "citty";
 import consola from "consola";
@@ -53,15 +54,13 @@ const switchSpace = withUsage(
 
       if (!hostname) {
         if (config.spaces.length === 0) {
-          consola.error("No spaces configured. Run `bee auth login` to add a space.");
-          return process.exit(1);
+          throw new UserError("No spaces configured. Run `bee auth login` to add a space.");
         }
 
         if (isNoInput()) {
-          consola.error(
+          throw new UserError(
             "Hostname is required. Use --space to provide it in BACKLOG_NO_INPUT mode.",
           );
-          return process.exit(1);
         }
 
         const hosts = config.spaces.map((s) => s.host);
@@ -71,18 +70,16 @@ const switchSpace = withUsage(
         });
 
         if (typeof hostname !== "string" || !hostname) {
-          consola.error("No space selected.");
-          return process.exit(1);
+          throw new UserError("No space selected.");
         }
       }
 
       const space = config.spaces.find((s) => s.host === hostname);
 
       if (!space) {
-        consola.error(
+        throw new UserError(
           `Space "${hostname}" not found. Available spaces: ${config.spaces.map((s) => s.host).join(", ")}`,
         );
-        return process.exit(1);
       }
 
       writeConfig({ ...config, defaultSpace: hostname });

--- a/apps/cli/src/commands/auth/token.test.ts
+++ b/apps/cli/src/commands/auth/token.test.ts
@@ -1,6 +1,4 @@
 import { resolveSpace } from "@repo/config";
-import { spyOnProcessExit } from "@repo/test-utils";
-import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@repo/config", () => ({
@@ -8,8 +6,6 @@ vi.mock("@repo/config", () => ({
   loadConfig: vi.fn(),
   resolveSpace: vi.fn(),
 }));
-
-vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("auth token", () => {
   it("outputs API key to stdout", async () => {
@@ -46,20 +42,12 @@ describe("auth token", () => {
     }
   });
 
-  it("calls process.exit(1) when no space is configured", async () => {
+  it("throws error when no space is configured", async () => {
     vi.mocked(resolveSpace).mockReturnValue(null);
-    const exitSpy = spyOnProcessExit();
 
-    try {
-      const { token } = await import("./token");
-      token.run?.({ args: {} } as never);
-
-      expect(consola.error).toHaveBeenCalledWith(
-        "No space configured. Run `bee auth login` to authenticate.",
-      );
-      expect(exitSpy).toHaveBeenCalledWith(1);
-    } finally {
-      exitSpy.mockRestore();
-    }
+    const { token } = await import("./token");
+    expect(() => token.run?.({ args: {} } as never)).toThrow(
+      "No space configured. Run `bee auth login` to authenticate.",
+    );
   });
 });

--- a/apps/cli/src/commands/auth/token.ts
+++ b/apps/cli/src/commands/auth/token.ts
@@ -1,6 +1,6 @@
+import { UserError } from "@repo/cli-utils";
 import { findSpace, loadConfig, resolveSpace } from "@repo/config";
 import { defineCommand } from "citty";
-import consola from "consola";
 import { type CommandUsage, withUsage } from "../../lib/command-usage";
 
 const commandUsage: CommandUsage = {
@@ -46,8 +46,7 @@ const tokenCommand = withUsage(
       const space = args.space ? findSpace(loadConfig().spaces, args.space) : resolveSpace();
 
       if (!space) {
-        consola.error("No space configured. Run `bee auth login` to authenticate.");
-        return process.exit(1);
+        throw new UserError("No space configured. Run `bee auth login` to authenticate.");
       }
 
       const token = space.auth.method === "api-key" ? space.auth.apiKey : space.auth.accessToken;

--- a/apps/cli/src/commands/browse.ts
+++ b/apps/cli/src/commands/browse.ts
@@ -6,6 +6,7 @@ import {
   getClient,
   openOrPrintUrl,
 } from "@repo/backlog-utils";
+import { UserError } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../lib/command-usage";
@@ -128,8 +129,7 @@ const browse = withUsage(
       });
 
       if (!result.ok) {
-        consola.error(result.error);
-        process.exit(1);
+        throw new UserError(result.error);
       }
 
       await openOrPrintUrl(result.url, Boolean(args["no-browser"]), consola);

--- a/apps/cli/src/commands/completion.test.ts
+++ b/apps/cli/src/commands/completion.test.ts
@@ -1,7 +1,4 @@
-import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
-
-vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("completion", () => {
   it("generates bash completion script", async () => {
@@ -45,14 +42,11 @@ describe("completion", () => {
     writeSpy.mockRestore();
   });
 
-  it("shows error for unsupported shell", async () => {
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-
+  it("throws error for unsupported shell", async () => {
     const { completion } = await import("./completion");
-    completion.run?.({ args: { shell: "powershell" } } as never);
 
-    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Unsupported shell"));
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    expect(() => completion.run?.({ args: { shell: "powershell" } } as never)).toThrow(
+      "Unsupported shell",
+    );
   });
 });

--- a/apps/cli/src/commands/completion.ts
+++ b/apps/cli/src/commands/completion.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { UserError } from "@repo/cli-utils";
 import { defineCommand } from "citty";
-import consola from "consola";
 import { type CommandUsage, withUsage } from "../lib/command-usage";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
@@ -61,8 +61,9 @@ const completion = withUsage(
           break;
         }
         default: {
-          consola.error(`Unsupported shell: "${args.shell}". Supported shells: bash, zsh, fish.`);
-          process.exit(1);
+          throw new UserError(
+            `Unsupported shell: "${args.shell}". Supported shells: bash, zsh, fish.`,
+          );
         }
       }
     },

--- a/apps/cli/src/commands/document/view.ts
+++ b/apps/cli/src/commands/document/view.ts
@@ -1,5 +1,11 @@
 import { documentUrl, getClient, openOrPrintUrl } from "@repo/backlog-utils";
-import { formatDate, outputArgs, outputResult, printDefinitionList } from "@repo/cli-utils";
+import {
+  UserError,
+  formatDate,
+  outputArgs,
+  outputResult,
+  printDefinitionList,
+} from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
@@ -53,8 +59,7 @@ const view = withUsage(
 
       if (args.web || args["no-browser"]) {
         if (!args.project) {
-          consola.error("The --project flag is required when using --web.");
-          process.exit(1);
+          throw new UserError("The --project flag is required when using --web.");
         }
         const url = documentUrl(host, args.project, args.document);
         await openOrPrintUrl(url, Boolean(args["no-browser"]), consola);

--- a/apps/cli/src/commands/project/add-user.test.ts
+++ b/apps/cli/src/commands/project/add-user.test.ts
@@ -24,22 +24,14 @@ describe("project add-user", () => {
     expect(consola.success).toHaveBeenCalledWith("Added user John Doe to project TEST.");
   });
 
-  it("shows error when user-id is not a number", async () => {
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-
+  it("throws error when user-id is not a number", async () => {
     const { addUser } = await import("./add-user");
 
     await expect(
       addUser.run?.({
         args: { project: "TEST", "user-id": "invalid" },
       } as never),
-    ).rejects.toThrow("process.exit");
-
-    expect(consola.error).toHaveBeenCalledWith("User ID must be a number.");
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    ).rejects.toThrow("User ID must be a number.");
   });
 
   it("outputs JSON when --json flag is set", async () => {

--- a/apps/cli/src/commands/project/add-user.ts
+++ b/apps/cli/src/commands/project/add-user.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult } from "@repo/cli-utils";
+import { UserError, outputArgs, outputResult } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
@@ -49,8 +49,7 @@ const addUser = withUsage(
     async run({ args }) {
       const userId = Number(args["user-id"]);
       if (Number.isNaN(userId)) {
-        consola.error("User ID must be a number.");
-        return process.exit(1);
+        throw new UserError("User ID must be a number.");
       }
 
       const { client } = await getClient();

--- a/apps/cli/src/commands/project/remove-user.test.ts
+++ b/apps/cli/src/commands/project/remove-user.test.ts
@@ -24,22 +24,14 @@ describe("project remove-user", () => {
     expect(consola.success).toHaveBeenCalledWith("Removed user John Doe from project TEST.");
   });
 
-  it("shows error when user-id is not a number", async () => {
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-
+  it("throws error when user-id is not a number", async () => {
     const { removeUser } = await import("./remove-user");
 
     await expect(
       removeUser.run?.({
         args: { project: "TEST", "user-id": "abc" },
       } as never),
-    ).rejects.toThrow("process.exit");
-
-    expect(consola.error).toHaveBeenCalledWith("User ID must be a number.");
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    ).rejects.toThrow("User ID must be a number.");
   });
 
   it("outputs JSON when --json flag is set", async () => {

--- a/apps/cli/src/commands/project/remove-user.ts
+++ b/apps/cli/src/commands/project/remove-user.ts
@@ -1,5 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
-import { outputArgs, outputResult } from "@repo/cli-utils";
+import { UserError, outputArgs, outputResult } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, ENV_PROJECT, withUsage } from "../../lib/command-usage";
@@ -49,8 +49,7 @@ const removeUser = withUsage(
     async run({ args }) {
       const userId = Number(args["user-id"]);
       if (Number.isNaN(userId)) {
-        consola.error("User ID must be a number.");
-        return process.exit(1);
+        throw new UserError("User ID must be a number.");
       }
 
       const { client } = await getClient();

--- a/apps/cli/src/commands/star/add.test.ts
+++ b/apps/cli/src/commands/star/add.test.ts
@@ -67,29 +67,19 @@ describe("star add", () => {
     expect(consola.success).toHaveBeenCalledWith("Starred pull request comment 222.");
   });
 
-  it("shows error when no option is provided", async () => {
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-
+  it("throws error when no option is provided", async () => {
     const { add } = await import("./add");
-    await add.run?.({ args: {} } as never);
 
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(add.run?.({ args: {} } as never)).rejects.toThrow(
       "Exactly one of --issue, --comment, --wiki, or --pr-comment must be provided.",
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
   });
 
-  it("shows error when multiple options are provided", async () => {
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-
+  it("throws error when multiple options are provided", async () => {
     const { add } = await import("./add");
-    await add.run?.({ args: { issue: "1", comment: "2" } } as never);
 
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(add.run?.({ args: { issue: "1", comment: "2" } } as never)).rejects.toThrow(
       "Only one of --issue, --comment, --wiki, or --pr-comment can be provided at a time.",
     );
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
   });
 });

--- a/apps/cli/src/commands/star/add.ts
+++ b/apps/cli/src/commands/star/add.ts
@@ -1,4 +1,5 @@
 import { getClient } from "@repo/backlog-utils";
+import { UserError } from "@repo/cli-utils";
 import { defineCommand } from "citty";
 import consola from "consola";
 import { type CommandUsage, ENV_AUTH, withUsage } from "../../lib/command-usage";
@@ -54,17 +55,15 @@ const add = withUsage(
       );
 
       if (flags.length === 0) {
-        consola.error(
+        throw new UserError(
           "Exactly one of --issue, --comment, --wiki, or --pr-comment must be provided.",
         );
-        process.exit(1);
       }
 
       if (flags.length > 1) {
-        consola.error(
+        throw new UserError(
           "Only one of --issue, --comment, --wiki, or --pr-comment can be provided at a time.",
         );
-        process.exit(1);
       }
 
       const { client } = await getClient();

--- a/apps/cli/src/commands/team/create.test.ts
+++ b/apps/cli/src/commands/team/create.test.ts
@@ -54,18 +54,16 @@ describe("team create", () => {
     );
   });
 
-  it("shows error and exits when API returns 400 with empty body", async () => {
+  it("throws error when API returns 400 with empty body", async () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("Team");
     const apiError = Object.assign(new Error("Bad Request"), { _status: 400, _body: undefined });
     mockClient.postTeam.mockRejectedValue(apiError);
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const { create } = await import("./create");
-    await create.run?.({ args: { name: "Team" } } as never);
 
-    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Administrator role"));
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    await expect(create.run?.({ args: { name: "Team" } } as never)).rejects.toThrow(
+      "Administrator role",
+    );
   });
 
   it("outputs JSON when --json flag is set", async () => {

--- a/apps/cli/src/commands/team/create.ts
+++ b/apps/cli/src/commands/team/create.ts
@@ -60,10 +60,8 @@ const create = withUsage(
           members: members.length > 0 ? members : undefined,
         });
       } catch (error) {
-        if (!handleTeamWriteError(error)) {
-          throw error;
-        }
-        return;
+        handleTeamWriteError(error);
+        throw error;
       }
 
       outputResult(t, args, (data) => {

--- a/apps/cli/src/commands/team/edit.test.ts
+++ b/apps/cli/src/commands/team/edit.test.ts
@@ -37,17 +37,15 @@ describe("team edit", () => {
     );
   });
 
-  it("shows error and exits when API returns 400 with empty body", async () => {
+  it("throws error when API returns 400 with empty body", async () => {
     const apiError = Object.assign(new Error("Bad Request"), { _status: 400, _body: undefined });
     mockClient.patchTeam.mockRejectedValue(apiError);
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
 
     const { edit } = await import("./edit");
-    await edit.run?.({ args: { team: "1", name: "X" } } as never);
 
-    expect(consola.error).toHaveBeenCalledWith(expect.stringContaining("Administrator role"));
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    exitSpy.mockRestore();
+    await expect(edit.run?.({ args: { team: "1", name: "X" } } as never)).rejects.toThrow(
+      "Administrator role",
+    );
   });
 
   it("outputs JSON when --json flag is set", async () => {

--- a/apps/cli/src/commands/team/edit.ts
+++ b/apps/cli/src/commands/team/edit.ts
@@ -68,10 +68,8 @@ const edit = withUsage(
           members: members.length > 0 ? members : undefined,
         });
       } catch (error) {
-        if (!handleTeamWriteError(error)) {
-          throw error;
-        }
-        return;
+        handleTeamWriteError(error);
+        throw error;
       }
 
       outputResult(t, args, (data) => {

--- a/apps/cli/src/commands/team/warn-team-write-restriction.ts
+++ b/apps/cli/src/commands/team/warn-team-write-restriction.ts
@@ -1,9 +1,8 @@
-import consola from "consola";
+import { UserError } from "@repo/cli-utils";
 
 /**
- * Returns true if the error is a 400 with an empty body (typical of plan
+ * Throws a UserError if the error is a 400 with an empty body (typical of plan
  * restrictions or insufficient permissions for team write operations).
- * Logs a human-readable error message and calls process.exit(1).
  *
  * Returns false for all other errors so the caller can re-throw them.
  */
@@ -11,11 +10,9 @@ export const handleTeamWriteError = (error: unknown): boolean => {
   if (error instanceof Error && "_status" in error) {
     const record = error as unknown as Record<string, unknown>;
     if (record._status === 400 && !record._body) {
-      consola.error(
+      throw new UserError(
         "Team write operations require Administrator role and are not available on new plan spaces.",
       );
-      process.exit(1);
-      return true;
     }
   }
   return false;

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,9 +1,9 @@
 import { handleBacklogApiError } from "@repo/backlog-utils";
 import { UserError, handleValidationError } from "@repo/cli-utils";
 import { defineCommand, runCommand, runMain } from "citty";
+import consola, { LogLevels } from "consola";
 import { showCommandUsage } from "./lib/command-usage";
 import pkg from "../package.json" with { type: "json" };
-import consola from "consola";
 
 const main = defineCommand({
   meta: {
@@ -49,9 +49,12 @@ if (rawArgs.includes("--help") || rawArgs.includes("-h") || rawArgs.includes("--
   try {
     await runCommand(main, { rawArgs });
   } catch (error) {
+    // At debug level or above, always show the full error with stack trace
+    const showStack = consola.level >= LogLevels.debug;
+
     // UserError = expected failure (bad input, missing config, …) → message only
     if (error instanceof UserError) {
-      consola.error(error.message);
+      consola.error(showStack ? error : error.message);
     } else if (!handleBacklogApiError(error, { json: useJson }) && !handleValidationError(error)) {
       // Unrecognised error = unexpected bug → full object (includes stack trace)
       consola.error(error);

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,5 @@
 import { handleBacklogApiError } from "@repo/backlog-utils";
-import { handleValidationError } from "@repo/cli-utils";
+import { UserError, handleValidationError } from "@repo/cli-utils";
 import { defineCommand, runCommand, runMain } from "citty";
 import { showCommandUsage } from "./lib/command-usage";
 import pkg from "../package.json" with { type: "json" };
@@ -49,7 +49,11 @@ if (rawArgs.includes("--help") || rawArgs.includes("-h") || rawArgs.includes("--
   try {
     await runCommand(main, { rawArgs });
   } catch (error) {
-    if (!handleBacklogApiError(error, { json: useJson }) && !handleValidationError(error)) {
+    // UserError = expected failure (bad input, missing config, …) → message only
+    if (error instanceof UserError) {
+      consola.error(error.message);
+    } else if (!handleBacklogApiError(error, { json: useJson }) && !handleValidationError(error)) {
+      // Unrecognised error = unexpected bug → full object (includes stack trace)
       consola.error(error);
     }
     process.exit(1);

--- a/packages/backlog-utils/package.json
+++ b/packages/backlog-utils/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@repo/cli-utils": "workspace:*",
     "@repo/config": "workspace:*",
     "backlog-js": "^0.16.0",
     "consola": "^3.4.2",

--- a/packages/backlog-utils/src/api-error.test.ts
+++ b/packages/backlog-utils/src/api-error.test.ts
@@ -10,6 +10,7 @@ import {
 vi.mock("consola", () => ({
   default: {
     error: vi.fn(),
+    debug: vi.fn(),
   },
 }));
 
@@ -113,20 +114,33 @@ describe("formatBacklogError", () => {
 
 type ErrorBody = { errors: { message: string; code: number; moreInfo: string }[] };
 
+type MockErrorOptions = {
+  url?: string;
+  status?: number;
+};
+
 /**
  * Creates a mock backlog-js BacklogApiError.
- * backlog-js compiles to ES5 with `_name` and `_body` private fields,
+ * backlog-js compiles to ES5 with `_name`, `_body`, `_url`, `_status` private fields,
  * so we replicate that structure for testing.
  */
-const createBacklogApiError = (body: ErrorBody) => {
+const createBacklogApiError = (body: ErrorBody, options?: MockErrorOptions) => {
   const error = new Error("BacklogApiError");
-  Object.assign(error, { _name: "BacklogApiError", _body: body });
+  Object.assign(error, {
+    _name: "BacklogApiError",
+    _body: body,
+    ...(options && { _url: options.url, _status: options.status }),
+  });
   return error;
 };
 
-const createBacklogAuthError = (body: ErrorBody) => {
+const createBacklogAuthError = (body: ErrorBody, options?: MockErrorOptions) => {
   const error = new Error("BacklogAuthError");
-  Object.assign(error, { _name: "BacklogAuthError", _body: body });
+  Object.assign(error, {
+    _name: "BacklogAuthError",
+    _body: body,
+    ...(options && { _url: options.url, _status: options.status }),
+  });
   return error;
 };
 
@@ -189,6 +203,53 @@ describe("handleBacklogApiError", () => {
     expect(consola.error).not.toHaveBeenCalled();
     expect(stderrWrite).toHaveBeenCalledWith(`${JSON.stringify(body)}\n`);
 
+    stderrWrite.mockRestore();
+  });
+
+  test("logs request URL and HTTP status via debug", () => {
+    const error = createBacklogApiError(
+      { errors: [{ message: "No such project.", code: 6, moreInfo: "" }] },
+      { url: "https://example.backlog.com/api/v2/projects/TEST", status: 404 },
+    );
+
+    handleBacklogApiError(error, { json: false });
+
+    expect(consola.debug).toHaveBeenCalledWith(
+      "Request URL: https://example.backlog.com/api/v2/projects/TEST",
+    );
+    expect(consola.debug).toHaveBeenCalledWith("HTTP status: 404");
+  });
+
+  test("does not log debug details when error has no URL or status", () => {
+    const error = createBacklogApiError({
+      errors: [{ message: "No such project.", code: 6, moreInfo: "" }],
+    });
+
+    handleBacklogApiError(error, { json: false });
+
+    expect(consola.debug).not.toHaveBeenCalled();
+  });
+
+  test("does not log debug details for plain error body", () => {
+    const error = {
+      errors: [{ message: "No such project.", code: 6, moreInfo: "" }],
+    };
+
+    handleBacklogApiError(error, { json: false });
+
+    expect(consola.debug).not.toHaveBeenCalled();
+  });
+
+  test("does not log debug details in json mode", () => {
+    const stderrWrite = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    const error = createBacklogApiError(
+      { errors: [{ message: "Forbidden.", code: 5, moreInfo: "" }] },
+      { url: "https://example.backlog.com/api/v2/projects/TEST", status: 403 },
+    );
+
+    handleBacklogApiError(error, { json: true });
+
+    expect(consola.debug).not.toHaveBeenCalled();
     stderrWrite.mockRestore();
   });
 });

--- a/packages/backlog-utils/src/api-error.ts
+++ b/packages/backlog-utils/src/api-error.ts
@@ -71,6 +71,21 @@ const extractBacklogErrorBody = (error: unknown): unknown => {
 };
 
 /**
+ * Extracts debug details (URL, HTTP status) from a backlog-js error.
+ * backlog-js stores these in private `_url` / `_status` fields.
+ */
+const extractDebugDetails = (error: unknown): { url?: string; status?: number } => {
+  if (!(error instanceof Error)) {
+    return {};
+  }
+  const record = error as unknown as Record<string, unknown>;
+  return {
+    url: typeof record._url === "string" ? record._url : undefined,
+    status: typeof record._status === "number" ? record._status : undefined,
+  };
+};
+
+/**
  * Handles Backlog API error responses thrown by backlog-js.
  * Returns true if the error was a Backlog API error and was handled.
  */
@@ -89,6 +104,15 @@ const handleBacklogApiError = (error: unknown, options: { json: boolean }): bool
   for (const line of formatBacklogError(errorBody)) {
     consola.error(line);
   }
+
+  const details = extractDebugDetails(error);
+  if (details.url) {
+    consola.debug(`Request URL: ${details.url}`);
+  }
+  if (details.status !== undefined) {
+    consola.debug(`HTTP status: ${details.status}`);
+  }
+
   return true;
 };
 

--- a/packages/backlog-utils/src/client.test.ts
+++ b/packages/backlog-utils/src/client.test.ts
@@ -1,4 +1,3 @@
-import { spyOnProcessExit } from "@repo/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getClient } from "./client";
 import { Backlog } from "backlog-js";
@@ -97,24 +96,16 @@ describe("getClient", () => {
     expect(result.host).toBe("env.backlog.com");
   });
 
-  it("calls process.exit(1) when BACKLOG_API_KEY set but no BACKLOG_SPACE", async () => {
+  it("throws error when BACKLOG_API_KEY set but no BACKLOG_SPACE", async () => {
     vi.mocked(resolveSpace).mockReturnValue(null);
     process.env.BACKLOG_API_KEY = "env-api-key";
-    const mockExit = spyOnProcessExit();
 
-    await getClient();
-
-    expect(mockExit).toHaveBeenCalledWith(1);
-    mockExit.mockRestore();
+    await expect(async () => getClient()).rejects.toThrow("No space configured");
   });
 
-  it("calls process.exit(1) when no space and no env vars configured", async () => {
+  it("throws error when no space and no env vars configured", async () => {
     vi.mocked(resolveSpace).mockReturnValue(null);
-    const mockExit = spyOnProcessExit();
 
-    await getClient();
-
-    expect(mockExit).toHaveBeenCalledWith(1);
-    mockExit.mockRestore();
+    await expect(async () => getClient()).rejects.toThrow("No space configured");
   });
 });

--- a/packages/backlog-utils/src/client.ts
+++ b/packages/backlog-utils/src/client.ts
@@ -1,3 +1,4 @@
+import { UserError } from "@repo/cli-utils";
 import { Backlog, Error as BacklogErrors } from "backlog-js";
 import { refreshAccessToken } from "./oauth";
 import { formatResetTime } from "./rate-limit";
@@ -49,8 +50,7 @@ const getClient = async (): Promise<{
     return { client, host: envHost };
   }
 
-  consola.error("No space configured. Run `bee auth login` to authenticate.");
-  return process.exit(1);
+  throw new UserError("No space configured. Run `bee auth login` to authenticate.");
 };
 
 /**
@@ -71,18 +71,23 @@ const createOAuthClient = (
   let currentClient = new Backlog({ host, accessToken: oauthAuth.accessToken });
   let refreshPromise: Promise<boolean> | null = null;
 
-  const refreshTokenIfNeeded = async (): Promise<boolean> => {
+  const refreshTokenIfNeeded = async (): Promise<void> => {
     if (refreshPromise) {
-      return refreshPromise;
+      const result = await refreshPromise;
+      if (!result) {
+        throw new UserError(
+          "OAuth session has expired. Run `bee auth login -m oauth` to re-authenticate.",
+        );
+      }
+      return;
     }
 
     const { clientId, clientSecret, refreshToken } = oauthAuth;
 
     if (!clientId || !clientSecret || !refreshToken) {
-      consola.error(
+      throw new UserError(
         "OAuth credentials are incomplete. Run `bee auth login -m oauth` to re-authenticate.",
       );
-      return false;
     }
 
     refreshPromise = (async () => {
@@ -110,16 +115,17 @@ const createOAuthClient = (
         consola.success("Token refreshed successfully.");
         return true;
       } catch {
-        consola.error(
-          "OAuth session has expired. Run `bee auth login -m oauth` to re-authenticate.",
-        );
         return false;
       }
     })();
 
     const result = await refreshPromise;
     refreshPromise = null;
-    return result;
+    if (!result) {
+      throw new UserError(
+        "OAuth session has expired. Run `bee auth login -m oauth` to re-authenticate.",
+      );
+    }
   };
 
   const proxy = new Proxy(currentClient, {
@@ -135,10 +141,7 @@ const createOAuthClient = (
           handleRateLimitError(error);
 
           if (error instanceof BacklogErrors.BacklogAuthError && error.status === 401) {
-            const refreshed = await refreshTokenIfNeeded();
-            if (!refreshed) {
-              process.exit(1);
-            }
+            await refreshTokenIfNeeded();
             // Retry with the new client
             const retryValue = Reflect.get(currentClient, prop, receiver);
             return await (retryValue as (...a: unknown[]) => unknown).apply(currentClient, args);
@@ -159,7 +162,7 @@ const handleRateLimitError = (error: unknown): void => {
     const resetMessage = resetEpoch
       ? `Rate limit resets at ${formatResetTime(Number(resetEpoch))}.`
       : "Please wait and try again later.";
-    throw new Error(`API rate limit exceeded. ${resetMessage}`);
+    throw new UserError(`API rate limit exceeded. ${resetMessage}`);
   }
 };
 

--- a/packages/cli-utils/src/index.ts
+++ b/packages/cli-utils/src/index.ts
@@ -6,3 +6,4 @@ export { formatDate, formatSize } from "./format";
 export { printTable, type Column, type Row } from "./table";
 export { printDefinitionList, type DefinitionItem } from "./definition-list";
 export { handleValidationError } from "./validation-error";
+export { UserError } from "./user-error";

--- a/packages/cli-utils/src/prompt.test.ts
+++ b/packages/cli-utils/src/prompt.test.ts
@@ -1,4 +1,3 @@
-import { spyOnProcessExit } from "@repo/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import consola from "consola";
 import { confirmOrExit, promptRequired } from "./prompt";
@@ -20,15 +19,9 @@ describe("promptRequired", () => {
     expect(consola.prompt).not.toHaveBeenCalled();
   });
 
-  it("exits with error when existing value is an empty string", async () => {
-    const mockExit = spyOnProcessExit();
-
-    await promptRequired("Label:", "");
-
-    expect(consola.error).toHaveBeenCalledWith("Label is required.");
-    expect(mockExit).toHaveBeenCalledWith(1);
+  it("throws error when existing value is an empty string", async () => {
+    await expect(promptRequired("Label:", "")).rejects.toThrow("Label is required.");
     expect(consola.prompt).not.toHaveBeenCalled();
-    mockExit.mockRestore();
   });
 
   it("shows prompt when no existing value is provided", async () => {
@@ -47,15 +40,10 @@ describe("promptRequired", () => {
     expect(result).toBe("prompted");
   });
 
-  it("calls process.exit(1) when prompt input is empty", async () => {
+  it("throws error when prompt input is empty", async () => {
     vi.mocked(consola.prompt).mockResolvedValue("" as never);
-    const mockExit = spyOnProcessExit();
 
-    await promptRequired("Label:");
-
-    expect(consola.error).toHaveBeenCalledWith("Label is required.");
-    expect(mockExit).toHaveBeenCalledWith(1);
-    mockExit.mockRestore();
+    await expect(promptRequired("Label:")).rejects.toThrow("Label is required.");
   });
 
   it("passes options to consola.prompt", async () => {
@@ -89,12 +77,8 @@ describe("promptRequired", () => {
 
   it("strips trailing colon from label for error message", async () => {
     vi.mocked(consola.prompt).mockResolvedValue("" as never);
-    const mockExit = spyOnProcessExit();
 
-    await promptRequired("Project key:");
-
-    expect(consola.error).toHaveBeenCalledWith("Project key is required.");
-    mockExit.mockRestore();
+    await expect(promptRequired("Project key:")).rejects.toThrow("Project key is required.");
   });
 
   it("returns existing value without prompting in --no-input mode", async () => {
@@ -105,18 +89,13 @@ describe("promptRequired", () => {
     expect(consola.prompt).not.toHaveBeenCalled();
   });
 
-  it("exits with error when value is missing in --no-input mode", async () => {
+  it("throws error when value is missing in --no-input mode", async () => {
     process.env.BACKLOG_NO_INPUT = "1";
-    const mockExit = spyOnProcessExit();
 
-    await promptRequired("Project key:");
-
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(promptRequired("Project key:")).rejects.toThrow(
       "Project key is required. Use arguments to provide it in BACKLOG_NO_INPUT mode.",
     );
-    expect(mockExit).toHaveBeenCalledWith(1);
     expect(consola.prompt).not.toHaveBeenCalled();
-    mockExit.mockRestore();
   });
 });
 
@@ -176,17 +155,12 @@ describe("confirmOrExit", () => {
     expect(consola.prompt).not.toHaveBeenCalled();
   });
 
-  it("exits with error when skipConfirm is not specified in --no-input mode", async () => {
+  it("throws error when skipConfirm is not specified in --no-input mode", async () => {
     process.env.BACKLOG_NO_INPUT = "1";
-    const mockExit = spyOnProcessExit();
 
-    await confirmOrExit("Are you sure?");
-
-    expect(consola.error).toHaveBeenCalledWith(
+    await expect(confirmOrExit("Are you sure?")).rejects.toThrow(
       "Confirmation required. Use --yes to skip in BACKLOG_NO_INPUT mode.",
     );
-    expect(mockExit).toHaveBeenCalledWith(1);
     expect(consola.prompt).not.toHaveBeenCalled();
-    mockExit.mockRestore();
   });
 });

--- a/packages/cli-utils/src/prompt.ts
+++ b/packages/cli-utils/src/prompt.ts
@@ -1,4 +1,5 @@
 import consola from "consola";
+import { UserError } from "./user-error";
 
 const isNoInput = (): boolean => process.env.BACKLOG_NO_INPUT === "1";
 
@@ -11,15 +12,13 @@ const promptRequired = async (
     if (existing) {
       return existing;
     }
-    consola.error(`${label.replace(/:$/, "")} is required.`);
-    return process.exit(1);
+    throw new UserError(`${label.replace(/:$/, "")} is required.`);
   }
 
   if (isNoInput()) {
-    consola.error(
+    throw new UserError(
       `${label.replace(/:$/, "")} is required. Use arguments to provide it in BACKLOG_NO_INPUT mode.`,
     );
-    return process.exit(1);
   }
 
   const displayLabel = options?.valueHint ? label.replace(/:$/, ` ${options.valueHint}:`) : label;
@@ -28,8 +27,7 @@ const promptRequired = async (
   const value = await consola.prompt(displayLabel, { type: "text", ...promptOptions });
 
   if (typeof value !== "string" || !value) {
-    consola.error(`${label.replace(/:$/, "")} is required.`);
-    return process.exit(1);
+    throw new UserError(`${label.replace(/:$/, "")} is required.`);
   }
 
   return value;
@@ -41,8 +39,7 @@ const confirmOrExit = async (message: string, skipConfirm?: boolean): Promise<bo
   }
 
   if (isNoInput()) {
-    consola.error("Confirmation required. Use --yes to skip in BACKLOG_NO_INPUT mode.");
-    return process.exit(1);
+    throw new UserError("Confirmation required. Use --yes to skip in BACKLOG_NO_INPUT mode.");
   }
 
   const confirmed = await consola.prompt(message, { type: "confirm" });

--- a/packages/cli-utils/src/user-error.ts
+++ b/packages/cli-utils/src/user-error.ts
@@ -1,0 +1,16 @@
+/**
+ * An error representing a known, expected failure condition.
+ *
+ * UserError is for "normal" errors — invalid input, missing configuration,
+ * failed authentication, etc. The global error handler prints only the
+ * message (via `consola.error`) with **no stack trace**.
+ *
+ * Any error that is NOT a UserError (and not a handled API/validation error)
+ * is treated as an unexpected bug and printed with the full stack trace.
+ */
+export class UserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UserError";
+  }
+}

--- a/packages/cli-utils/src/validation-error.test.ts
+++ b/packages/cli-utils/src/validation-error.test.ts
@@ -54,4 +54,17 @@ describe("handleValidationError", () => {
     expect(consola.debug).toHaveBeenCalledWith(expect.stringContaining("name:"));
     expect(consola.debug).toHaveBeenCalledWith(expect.stringContaining("age:"));
   });
+
+  it("logs raw error via consola.debug", () => {
+    const schema = v.object({ name: v.string() });
+    const result = v.safeParse(schema, { name: 123 });
+    if (result.success) {
+      throw new Error("Expected validation to fail");
+    }
+    const valiError = new v.ValiError(result.issues);
+
+    handleValidationError(valiError);
+
+    expect(consola.debug).toHaveBeenCalledWith("Raw error:", valiError);
+  });
 });

--- a/packages/cli-utils/src/validation-error.ts
+++ b/packages/cli-utils/src/validation-error.ts
@@ -27,5 +27,7 @@ export const handleValidationError = (error: unknown): boolean => {
     consola.debug(`  (other): ${flat.other.join(", ")}`);
   }
 
+  consola.debug("Raw error:", error);
+
   return true;
 };

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@repo/cli-utils": "workspace:*",
     "consola": "^3.4.2",
     "rc9": "^2.1.2",
     "valibot": "^1.0.0"

--- a/packages/config/src/config.test.ts
+++ b/packages/config/src/config.test.ts
@@ -41,18 +41,12 @@ describe("loadConfig", () => {
     expect(config.defaultSpace).toBeUndefined();
   });
 
-  it("exits process when config validation fails", () => {
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
-
+  it("throws error when config validation fails", () => {
     mockReadUser.mockReturnValue({
       spaces: [{ host: "invalid", auth: { method: "bad" } }],
     });
 
-    loadConfig();
-
-    expect(exitSpy).toHaveBeenCalledWith(1);
-
-    exitSpy.mockRestore();
+    expect(() => loadConfig()).toThrow("Configuration Error:");
   });
 });
 

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -1,5 +1,5 @@
+import { UserError } from "@repo/cli-utils";
 import * as v from "valibot";
-import consola from "consola";
 import { readUser, writeUser } from "rc9";
 import { type Rc, RcSchema } from "./schema";
 
@@ -10,11 +10,8 @@ const loadConfig = (): Rc => {
   const result = v.safeParse(RcSchema, raw);
 
   if (!result.success) {
-    consola.error("Configuration Error:");
-    for (const issue of result.issues) {
-      consola.error(issue.message);
-    }
-    process.exit(1);
+    const details = result.issues.map((issue) => issue.message).join("\n");
+    throw new UserError(`Configuration Error:\n${details}`);
   }
 
   return result.output;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
 
   packages/backlog-utils:
     dependencies:
+      '@repo/cli-utils':
+        specifier: workspace:*
+        version: link:../cli-utils
       '@repo/config':
         specifier: workspace:*
         version: link:../config
@@ -153,6 +156,9 @@ importers:
 
   packages/config:
     dependencies:
+      '@repo/cli-utils':
+        specifier: workspace:*
+        version: link:../cli-utils
       consola:
         specifier: ^3.4.2
         version: 3.4.2


### PR DESCRIPTION
## Summary

This PR replaces all `process.exit(1)` calls with throwing `UserError` exceptions throughout the codebase. This enables proper error handling and testing by allowing errors to propagate through the call stack instead of terminating the process.

### Key Changes

1. **New `UserError` class** (`packages/cli-utils/src/user-error.ts`): A custom error class for expected, user-facing failures (invalid input, missing configuration, authentication errors, etc.). The global error handler prints only the message without a stack trace.

2. **Updated error handling in core modules**:
   - `packages/cli-utils/src/prompt.ts`: `promptRequired()` and `confirmOrExit()` now throw `UserError` instead of calling `process.exit(1)`
   - `packages/backlog-utils/src/client.ts`: `getClient()` and OAuth token refresh logic now throw `UserError` for configuration/auth failures
   - `packages/config/src/config.ts`: Config validation now throws `UserError` instead of exiting

3. **Updated command implementations** to throw `UserError` for validation and authentication failures:
   - `apps/cli/src/commands/auth/login.ts`
   - `apps/cli/src/commands/auth/logout.ts`
   - `apps/cli/src/commands/auth/refresh.ts`
   - `apps/cli/src/commands/auth/switch.ts`
   - `apps/cli/src/commands/auth/token.ts`
   - `apps/cli/src/commands/api.ts`
   - `apps/cli/src/commands/browse.ts`
   - `apps/cli/src/commands/completion.ts`
   - `apps/cli/src/commands/star/add.ts`
   - `apps/cli/src/commands/document/view.ts`
   - `apps/cli/src/commands/project/add-user.ts`
   - `apps/cli/src/commands/project/remove-user.ts`
   - `apps/cli/src/commands/team/create.ts`
   - `apps/cli/src/commands/team/edit.ts`
   - `apps/cli/src/commands/team/warn-team-write-restriction.ts`

4. **Updated global error handler** (`apps/cli/src/index.ts`): Now catches `UserError` and handles it appropriately without stack traces.

5. **Updated test suite**: Removed `spyOnProcessExit()` mocks and replaced `process.exit()` assertions with `expect().rejects.toThrow()` patterns. Updated mock setup to use `importOriginal()` for proper module mocking.

### Benefits

- **Testability**: Errors can now be caught and asserted in tests without mocking `process.exit()`
- **Error handling**: Proper error propagation allows for better error recovery and handling
- **Cleaner code**: Removes the need for `process.exit()` calls scattered throughout the codebase
- **Better separation of concerns**: Error handling is centralized in the global error handler

## Test plan

All existing unit tests have been updated to verify that the correct errors are thrown. The test suite now uses standard Jest/Vitest error assertion patterns (`expect().rejects.toThrow()`) instead of mocking process exit. CI tests pass with the updated error handling.

https://claude.ai/code/session_01GMWado1nPZeWd4q49RA2j9