### PR TITLE
Refactor test utilities and improve test consistency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,7 @@ All list commands use the pattern: `consola.info("No <plural> found.")` (e.g., `
 - **Mock at package boundaries** — mock entire packages (`@repo/backlog-utils`, `@repo/config`, etc.), not internal functions. Each package is independently tested; CLI command tests trust the package interface.
 - **CLI command tests verify side-effect composition** — assert which functions were called, in what order, and with what arguments. Actual network I/O and file I/O belong in package-level or E2E tests.
 - **Cover both happy path and error paths** — each command should have tests for success, auth/config failures, and edge cases (e.g., empty state, already-existing resources).
+- **Error path tests must exercise actual branching logic** — test explicit `throw`, `consola.error()`, or early `return` branches in the implementation. Do not write tests that only verify default error propagation (e.g., testing that an `await` without `try/catch` propagates a rejection is testing JavaScript, not the command).
 - **Extract shared mock setup into helper functions** — when multiple tests in the same `describe` need the same mock state, use a named setup function (e.g., `setupOAuthMocks()`).
 
 ## Code Conventions (enforced by oxlint)

--- a/apps/cli/src/commands/api.test.ts
+++ b/apps/cli/src/commands/api.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   get: vi.fn(),
@@ -18,14 +19,12 @@ describe("api", () => {
   it("makes GET request by default", async () => {
     mockClient.get.mockResolvedValue({ id: 1, name: "test" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    await expectStdoutContaining(async () => {
+      const { api } = await import("./api");
+      await api.run?.({ args: { endpoint: "/users/myself" } } as never);
 
-    const { api } = await import("./api");
-    await api.run?.({ args: { endpoint: "/users/myself" } } as never);
-
-    expect(mockClient.get).toHaveBeenCalledWith("/users/myself", {});
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining('"name"'));
-    writeSpy.mockRestore();
+      expect(mockClient.get).toHaveBeenCalledWith("/users/myself", {});
+    }, '"name"');
   });
 
   it("normalizes endpoint with /api/v2 prefix", async () => {

--- a/apps/cli/src/commands/auth/token.test.ts
+++ b/apps/cli/src/commands/auth/token.test.ts
@@ -1,6 +1,5 @@
 import { resolveSpace } from "@repo/config";
 import { describe, expect, it, vi } from "vitest";
-import { expectStdoutContaining } from "@repo/test-utils";
 
 vi.mock("@repo/config", () => ({
   findSpace: vi.fn(),

--- a/apps/cli/src/commands/auth/token.test.ts
+++ b/apps/cli/src/commands/auth/token.test.ts
@@ -1,5 +1,6 @@
 import { resolveSpace } from "@repo/config";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 vi.mock("@repo/config", () => ({
   findSpace: vi.fn(),

--- a/apps/cli/src/commands/category/create.test.ts
+++ b/apps/cli/src/commands/category/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postCategories: vi.fn(),
@@ -44,12 +45,9 @@ describe("category create", () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("Bug");
     mockClient.postCategories.mockResolvedValue({ id: 1, name: "Bug" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({ args: { project: "TEST", name: "Bug", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Bug"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({ args: { project: "TEST", name: "Bug", json: "" } } as never);
+    }, "Bug");
   });
 });

--- a/apps/cli/src/commands/category/delete.test.ts
+++ b/apps/cli/src/commands/category/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteCategories: vi.fn(),
@@ -56,14 +57,11 @@ describe("category delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteCategories.mockResolvedValue({ id: 1, name: "Bug" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteCategory } = await import("./delete");
-    await deleteCategory.run?.({
-      args: { category: "1", project: "TEST", yes: true, json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Bug"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteCategory } = await import("./delete");
+      await deleteCategory.run?.({
+        args: { category: "1", project: "TEST", yes: true, json: "" },
+      } as never);
+    }, "Bug");
   });
 });

--- a/apps/cli/src/commands/category/delete.test.ts
+++ b/apps/cli/src/commands/category/delete.test.ts
@@ -41,7 +41,10 @@ describe("category delete", () => {
     const { deleteCategory } = await import("./delete");
     await deleteCategory.run?.({ args: { category: "1", project: "TEST", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete category 1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/category/edit.test.ts
+++ b/apps/cli/src/commands/category/edit.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchCategories: vi.fn(),
@@ -43,12 +44,11 @@ describe("category edit", () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("Name");
     mockClient.patchCategories.mockResolvedValue({ id: 1, name: "Name" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({ args: { category: "1", project: "TEST", name: "Name", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Name"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({
+        args: { category: "1", project: "TEST", name: "Name", json: "" },
+      } as never);
+    }, "Name");
   });
 });

--- a/apps/cli/src/commands/category/list.test.ts
+++ b/apps/cli/src/commands/category/list.test.ts
@@ -49,11 +49,4 @@ describe("category list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Bug");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getCategories.mockRejectedValue(new Error("Not Found"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
-  });
 });

--- a/apps/cli/src/commands/category/list.test.ts
+++ b/apps/cli/src/commands/category/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getCategories: vi.fn(),
@@ -43,12 +44,9 @@ describe("category list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getCategories.mockResolvedValue(sampleCategories);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Bug"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "Bug");
   });
 });

--- a/apps/cli/src/commands/category/list.test.ts
+++ b/apps/cli/src/commands/category/list.test.ts
@@ -49,4 +49,11 @@ describe("category list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Bug");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getCategories.mockRejectedValue(new Error("Not Found"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
+  });
 });

--- a/apps/cli/src/commands/completion.test.ts
+++ b/apps/cli/src/commands/completion.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 describe("completion", () => {
   it("generates bash completion script", async () => {

--- a/apps/cli/src/commands/completion.test.ts
+++ b/apps/cli/src/commands/completion.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { expectStdoutContaining } from "@repo/test-utils";
 
 describe("completion", () => {
   it("generates bash completion script", async () => {

--- a/apps/cli/src/commands/dashboard.test.ts
+++ b/apps/cli/src/commands/dashboard.test.ts
@@ -115,11 +115,4 @@ describe("dashboard", () => {
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("No assigned issues"));
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getMyself.mockRejectedValue(new Error("Unauthorized"));
-
-    const { dashboard } = await import("./dashboard");
-    await expect(dashboard.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
-  });
 });

--- a/apps/cli/src/commands/dashboard.test.ts
+++ b/apps/cli/src/commands/dashboard.test.ts
@@ -1,6 +1,7 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getMyself: vi.fn(),
@@ -97,13 +98,10 @@ describe("dashboard", () => {
     mockClient.getIssues.mockResolvedValue(sampleIssues);
     mockClient.getProjects.mockResolvedValue(sampleProjects);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { dashboard } = await import("./dashboard");
-    await dashboard.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Test User"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { dashboard } = await import("./dashboard");
+      await dashboard.run?.({ args: { json: "" } } as never);
+    }, "Test User");
   });
 
   it("shows empty message when no assigned issues", async () => {

--- a/apps/cli/src/commands/dashboard.test.ts
+++ b/apps/cli/src/commands/dashboard.test.ts
@@ -115,4 +115,11 @@ describe("dashboard", () => {
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("No assigned issues"));
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getMyself.mockRejectedValue(new Error("Unauthorized"));
+
+    const { dashboard } = await import("./dashboard");
+    await expect(dashboard.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
+  });
 });

--- a/apps/cli/src/commands/document/attachments.test.ts
+++ b/apps/cli/src/commands/document/attachments.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -11,13 +10,6 @@ vi.mock("@repo/backlog-utils", () => ({
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
-
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
 
 const sampleAttachments = [
   {
@@ -38,7 +30,6 @@ const sampleAttachments = [
 
 describe("document attachments", () => {
   it("displays attachment list in tabular format", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue({
       id: "doc-1",
       attachments: sampleAttachments,
@@ -55,7 +46,6 @@ describe("document attachments", () => {
   });
 
   it("shows message when no attachments found", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue({
       id: "doc-1",
       attachments: [],
@@ -68,7 +58,6 @@ describe("document attachments", () => {
   });
 
   it("formats file sizes correctly", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue({
       id: "doc-1",
       attachments: [
@@ -105,7 +94,6 @@ describe("document attachments", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue({
       id: "doc-1",
       attachments: sampleAttachments,

--- a/apps/cli/src/commands/document/attachments.test.ts
+++ b/apps/cli/src/commands/document/attachments.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getDocument: vi.fn(),
@@ -99,12 +100,9 @@ describe("document attachments", () => {
       attachments: sampleAttachments,
     });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { attachments } = await import("./attachments");
-    await attachments.run?.({ args: { document: "doc-1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("report.pdf"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { attachments } = await import("./attachments");
+      await attachments.run?.({ args: { document: "doc-1", json: "" } } as never);
+    }, "report.pdf");
   });
 });

--- a/apps/cli/src/commands/document/create.test.ts
+++ b/apps/cli/src/commands/document/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   addDocument: vi.fn(),
@@ -112,14 +113,11 @@ describe("document create", () => {
       title: "Title",
     });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({
-      args: { project: "100", title: "Title", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Title"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({
+        args: { project: "100", title: "Title", json: "" },
+      } as never);
+    }, "Title");
   });
 });

--- a/apps/cli/src/commands/document/delete.test.ts
+++ b/apps/cli/src/commands/document/delete.test.ts
@@ -41,7 +41,10 @@ describe("document delete", () => {
     const { deleteDocument } = await import("./delete");
     await deleteDocument.run?.({ args: { document: "12345", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete document 12345? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/document/delete.test.ts
+++ b/apps/cli/src/commands/document/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteDocument: vi.fn(),
@@ -56,12 +57,9 @@ describe("document delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteDocument.mockResolvedValue({ id: "1", title: "My Doc" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteDocument } = await import("./delete");
-    await deleteDocument.run?.({ args: { document: "12345", yes: true, json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("My Doc"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteDocument } = await import("./delete");
+      await deleteDocument.run?.({ args: { document: "12345", yes: true, json: "" } } as never);
+    }, "My Doc");
   });
 });

--- a/apps/cli/src/commands/document/list.test.ts
+++ b/apps/cli/src/commands/document/list.test.ts
@@ -113,4 +113,13 @@ describe("document list", () => {
       await list.run?.({ args: { project: "PROJECT", json: "" } } as never);
     }, "doc-1");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getDocuments.mockRejectedValue(new Error("API error"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "PROJECT" } } as never)).rejects.toThrow(
+      "API error",
+    );
+  });
 });

--- a/apps/cli/src/commands/document/list.test.ts
+++ b/apps/cli/src/commands/document/list.test.ts
@@ -14,13 +14,6 @@ vi.mock("@repo/backlog-utils", async (importOriginal) => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 const sampleDocuments = [
   {
     id: "doc-1",
@@ -56,7 +49,6 @@ const sampleDocuments = [
 
 describe("document list", () => {
   it("displays document list in tabular format", async () => {
-    setupMocks();
     mockClient.getDocuments.mockResolvedValue(sampleDocuments);
 
     const { list } = await import("./list");
@@ -71,7 +63,6 @@ describe("document list", () => {
   });
 
   it("shows message when no documents found", async () => {
-    setupMocks();
     mockClient.getDocuments.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -81,7 +72,6 @@ describe("document list", () => {
   });
 
   it("passes keyword query parameter", async () => {
-    setupMocks();
     mockClient.getDocuments.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -93,7 +83,6 @@ describe("document list", () => {
   });
 
   it("passes sort and order parameters", async () => {
-    setupMocks();
     mockClient.getDocuments.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -105,7 +94,6 @@ describe("document list", () => {
   });
 
   it("passes count and offset parameters", async () => {
-    setupMocks();
     mockClient.getDocuments.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -117,7 +105,6 @@ describe("document list", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getDocuments.mockResolvedValue(sampleDocuments);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/document/list.test.ts
+++ b/apps/cli/src/commands/document/list.test.ts
@@ -113,13 +113,4 @@ describe("document list", () => {
       await list.run?.({ args: { project: "PROJECT", json: "" } } as never);
     }, "doc-1");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getDocuments.mockRejectedValue(new Error("API error"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "PROJECT" } } as never)).rejects.toThrow(
-      "API error",
-    );
-  });
 });

--- a/apps/cli/src/commands/document/list.test.ts
+++ b/apps/cli/src/commands/document/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getDocuments: vi.fn(),
@@ -107,12 +108,9 @@ describe("document list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getDocuments.mockResolvedValue(sampleDocuments);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "PROJECT", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "PROJECT", json: "" } } as never);
+    }, "doc-1");
   });
 });

--- a/apps/cli/src/commands/document/tree.test.ts
+++ b/apps/cli/src/commands/document/tree.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -11,13 +10,6 @@ vi.mock("@repo/backlog-utils", () => ({
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
-
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
 
 const sampleTree = {
   projectId: "100",
@@ -47,7 +39,6 @@ const sampleTree = {
 
 describe("document tree", () => {
   it("displays tree structure", async () => {
-    setupMocks();
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
     const { tree } = await import("./tree");
@@ -60,7 +51,6 @@ describe("document tree", () => {
   });
 
   it("displays emoji in tree nodes", async () => {
-    setupMocks();
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
     const { tree } = await import("./tree");
@@ -70,7 +60,6 @@ describe("document tree", () => {
   });
 
   it("shows message when no documents found", async () => {
-    setupMocks();
     mockClient.getDocumentTree.mockResolvedValue({
       projectId: "100",
       activeTree: { id: "root", children: [] },
@@ -83,7 +72,6 @@ describe("document tree", () => {
   });
 
   it("shows message when activeTree is undefined", async () => {
-    setupMocks();
     mockClient.getDocumentTree.mockResolvedValue({
       projectId: "100",
     });
@@ -95,7 +83,6 @@ describe("document tree", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -108,7 +95,6 @@ describe("document tree", () => {
   });
 
   it("renders tree connectors correctly", async () => {
-    setupMocks();
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
     const { tree } = await import("./tree");

--- a/apps/cli/src/commands/document/tree.test.ts
+++ b/apps/cli/src/commands/document/tree.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getDocumentTree: vi.fn(),
@@ -85,13 +86,10 @@ describe("document tree", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { tree } = await import("./tree");
-    await tree.run?.({ args: { project: "PROJECT", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { tree } = await import("./tree");
+      await tree.run?.({ args: { project: "PROJECT", json: "" } } as never);
+    }, "doc-1");
   });
 
   it("renders tree connectors correctly", async () => {

--- a/apps/cli/src/commands/document/view.test.ts
+++ b/apps/cli/src/commands/document/view.test.ts
@@ -1,6 +1,7 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getDocument: vi.fn(),
@@ -82,13 +83,10 @@ describe("document view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getDocument.mockResolvedValue(sampleDocument);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { document: "doc-1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("doc-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { document: "doc-1", json: "" } } as never);
+    }, "doc-1");
   });
 
   it("hides tags when none exist", async () => {

--- a/apps/cli/src/commands/document/view.test.ts
+++ b/apps/cli/src/commands/document/view.test.ts
@@ -1,4 +1,4 @@
-import { getClient, openOrPrintUrl } from "@repo/backlog-utils";
+import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -18,13 +18,6 @@ vi.mock("@repo/backlog-utils", () => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 const sampleDocument = {
   id: "doc-1",
   projectId: 100,
@@ -43,7 +36,6 @@ const sampleDocument = {
 
 describe("document view", () => {
   it("displays document details", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue(sampleDocument);
 
     const { view } = await import("./view");
@@ -57,7 +49,6 @@ describe("document view", () => {
   });
 
   it("displays emoji when present", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue(sampleDocument);
 
     const { view } = await import("./view");
@@ -67,7 +58,6 @@ describe("document view", () => {
   });
 
   it("displays body content", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue(sampleDocument);
 
     const { view } = await import("./view");
@@ -78,8 +68,6 @@ describe("document view", () => {
   });
 
   it("opens browser with --web flag", async () => {
-    setupMocks();
-
     const { view } = await import("./view");
     await view.run?.({ args: { document: "doc-1", project: "PROJECT", web: true } } as never);
 
@@ -92,7 +80,6 @@ describe("document view", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue(sampleDocument);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
@@ -105,7 +92,6 @@ describe("document view", () => {
   });
 
   it("hides tags when none exist", async () => {
-    setupMocks();
     mockClient.getDocument.mockResolvedValue({ ...sampleDocument, tags: [] });
 
     const { view } = await import("./view");

--- a/apps/cli/src/commands/document/view.test.ts
+++ b/apps/cli/src/commands/document/view.test.ts
@@ -99,4 +99,13 @@ describe("document view", () => {
     const allCalls = vi.mocked(consola.log).mock.calls.map((c) => c[0]);
     expect(allCalls.every((c) => !String(c).includes("Tags"))).toBe(true);
   });
+
+  it("throws error when --web used without --project", async () => {
+    const { view } = await import("./view");
+    await expect(
+      view.run?.({
+        args: { document: "123", web: true },
+      } as never),
+    ).rejects.toThrow("The --project flag is required when using --web.");
+  });
 });

--- a/apps/cli/src/commands/document/view.test.ts
+++ b/apps/cli/src/commands/document/view.test.ts
@@ -95,7 +95,8 @@ describe("document view", () => {
     const { view } = await import("./view");
     await view.run?.({ args: { document: "doc-1" } } as never);
 
-    // Tags line should not appear when there are no tags
     expect(mockClient.getDocument).toHaveBeenCalledWith("doc-1");
+    const allCalls = vi.mocked(consola.log).mock.calls.map((c) => c[0]);
+    expect(allCalls.every((c) => !String(c).includes("Tags"))).toBe(true);
   });
 });

--- a/apps/cli/src/commands/issue-type/create.test.ts
+++ b/apps/cli/src/commands/issue-type/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postIssueType: vi.fn(),
@@ -48,14 +49,11 @@ describe("issue-type create", () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("Bug");
     mockClient.postIssueType.mockResolvedValue({ id: 1, name: "Bug", color: "#e30000" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({
-      args: { project: "TEST", name: "Bug", color: "#e30000", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Bug"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({
+        args: { project: "TEST", name: "Bug", color: "#e30000", json: "" },
+      } as never);
+    }, "Bug");
   });
 });

--- a/apps/cli/src/commands/issue-type/delete.test.ts
+++ b/apps/cli/src/commands/issue-type/delete.test.ts
@@ -47,7 +47,10 @@ describe("issue-type delete", () => {
       args: { issueType: "1", project: "TEST", "substitute-issue-type-id": "2", yes: true },
     } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete issue type 1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/issue-type/delete.test.ts
+++ b/apps/cli/src/commands/issue-type/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteIssueType: vi.fn(),
@@ -64,20 +65,17 @@ describe("issue-type delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteIssueType.mockResolvedValue({ id: 1, name: "Bug", color: "#e30000" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteIssueType } = await import("./delete");
-    await deleteIssueType.run?.({
-      args: {
-        issueType: "1",
-        project: "TEST",
-        "substitute-issue-type-id": "2",
-        yes: true,
-        json: "",
-      },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Bug"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteIssueType } = await import("./delete");
+      await deleteIssueType.run?.({
+        args: {
+          issueType: "1",
+          project: "TEST",
+          "substitute-issue-type-id": "2",
+          yes: true,
+          json: "",
+        },
+      } as never);
+    }, "Bug");
   });
 });

--- a/apps/cli/src/commands/issue-type/edit.test.ts
+++ b/apps/cli/src/commands/issue-type/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchIssueType: vi.fn(),
@@ -42,12 +43,11 @@ describe("issue-type edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchIssueType.mockResolvedValue({ id: 1, name: "Bug", color: "#e30000" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({ args: { issueType: "1", project: "TEST", name: "Bug", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Bug"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({
+        args: { issueType: "1", project: "TEST", name: "Bug", json: "" },
+      } as never);
+    }, "Bug");
   });
 });

--- a/apps/cli/src/commands/issue-type/list.test.ts
+++ b/apps/cli/src/commands/issue-type/list.test.ts
@@ -58,4 +58,11 @@ describe("issue-type list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Bug");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getIssueTypes.mockRejectedValue(new Error("Not Found"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
+  });
 });

--- a/apps/cli/src/commands/issue-type/list.test.ts
+++ b/apps/cli/src/commands/issue-type/list.test.ts
@@ -58,11 +58,4 @@ describe("issue-type list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Bug");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getIssueTypes.mockRejectedValue(new Error("Not Found"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
-  });
 });

--- a/apps/cli/src/commands/issue-type/list.test.ts
+++ b/apps/cli/src/commands/issue-type/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getIssueTypes: vi.fn(),
@@ -52,12 +53,9 @@ describe("issue-type list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getIssueTypes.mockResolvedValue(sampleIssueTypes);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Bug"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "Bug");
   });
 });

--- a/apps/cli/src/commands/issue/attachments.test.ts
+++ b/apps/cli/src/commands/issue/attachments.test.ts
@@ -56,10 +56,9 @@ describe("issue attachments", () => {
         created: "2025-01-01T00:00:00Z",
       },
     ]);
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    const { attachments } = await import("./attachments");
-    await attachments.run?.({ args: { issue: "TEST-1", json: "" } } as never);
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("file.png"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { attachments } = await import("./attachments");
+      await attachments.run?.({ args: { issue: "TEST-1", json: "" } } as never);
+    }, "file.png");
   });
 });

--- a/apps/cli/src/commands/issue/attachments.test.ts
+++ b/apps/cli/src/commands/issue/attachments.test.ts
@@ -1,6 +1,7 @@
 import { printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getIssueAttachments: vi.fn(),

--- a/apps/cli/src/commands/issue/close.test.ts
+++ b/apps/cli/src/commands/issue/close.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchIssue: vi.fn(),
@@ -67,12 +68,9 @@ describe("issue close", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchIssue.mockResolvedValue({ issueKey: "TEST-1", summary: "Title" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { close } = await import("./close");
-    await close.run?.({ args: { issue: "TEST-1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { close } = await import("./close");
+      await close.run?.({ args: { issue: "TEST-1", json: "" } } as never);
+    }, "TEST-1");
   });
 });

--- a/apps/cli/src/commands/issue/comment.test.ts
+++ b/apps/cli/src/commands/issue/comment.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit, printTable, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postIssueComments: vi.fn(),
@@ -66,13 +67,10 @@ describe("issue comment", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.postIssueComments.mockResolvedValue({ id: 1, content: "Hello" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { comment } = await import("./comment");
-    await comment.run?.({ args: { issue: "TEST-1", body: "Hello", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Hello"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { comment } = await import("./comment");
+      await comment.run?.({ args: { issue: "TEST-1", body: "Hello", json: "" } } as never);
+    }, "Hello");
   });
 
   it("lists comments with --list flag", async () => {

--- a/apps/cli/src/commands/issue/comment.test.ts
+++ b/apps/cli/src/commands/issue/comment.test.ts
@@ -172,4 +172,47 @@ describe("issue comment", () => {
 
     expect(mockClient.deleteIssueComment).not.toHaveBeenCalled();
   });
+
+  it("shows error when body is missing for add comment", async () => {
+    vi.mocked(resolveStdinArg).mockResolvedValueOnce(undefined);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({ args: { issue: "TEST-1" } } as never);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      "Comment body is required. Use --body or pipe input.",
+    );
+    expect(mockClient.postIssueComments).not.toHaveBeenCalled();
+  });
+
+  it("shows error when body is missing with --edit-last", async () => {
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 20, content: "My comment", createdUser: { id: 1 } },
+    ]);
+    vi.mocked(resolveStdinArg).mockResolvedValueOnce(undefined);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: { issue: "TEST-1", "edit-last": true },
+    } as never);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      "Comment body is required. Use --body or pipe input.",
+    );
+    expect(mockClient.patchIssueComment).not.toHaveBeenCalled();
+  });
+
+  it("shows error when no own comment found with --delete-last", async () => {
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+    mockClient.getIssueComments.mockResolvedValue([
+      { id: 10, content: "Other", createdUser: { id: 999 } },
+    ]);
+
+    const { comment } = await import("./comment");
+    await comment.run?.({ args: { issue: "TEST-1", "delete-last": true } } as never);
+
+    expect(consola.error).toHaveBeenCalledWith("No comment by you was found on TEST-1.");
+    expect(mockClient.deleteIssueComment).not.toHaveBeenCalled();
+  });
 });

--- a/apps/cli/src/commands/issue/comment.test.ts
+++ b/apps/cli/src/commands/issue/comment.test.ts
@@ -154,7 +154,10 @@ describe("issue comment", () => {
     const { comment } = await import("./comment");
     await comment.run?.({ args: { issue: "TEST-1", "delete-last": true, yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete your comment on TEST-1?",
+      true,
+    );
   });
 
   it("cancels delete when user declines", async () => {

--- a/apps/cli/src/commands/issue/count.test.ts
+++ b/apps/cli/src/commands/issue/count.test.ts
@@ -49,4 +49,13 @@ describe("issue count", () => {
       await count.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "42");
   });
+
+  it("throws error for unknown priority name", async () => {
+    const { count } = await import("./count");
+    await expect(
+      count.run?.({
+        args: { project: "TEST", priority: "invalid" },
+      } as never),
+    ).rejects.toThrow('Unknown priority "invalid". Valid values: high, normal, low');
+  });
 });

--- a/apps/cli/src/commands/issue/count.test.ts
+++ b/apps/cli/src/commands/issue/count.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getIssuesCount: vi.fn(),
@@ -43,12 +44,9 @@ describe("issue count", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getIssuesCount.mockResolvedValue({ count: 42 });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { count } = await import("./count");
-    await count.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("42"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { count } = await import("./count");
+      await count.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "42");
   });
 });

--- a/apps/cli/src/commands/issue/create.test.ts
+++ b/apps/cli/src/commands/issue/create.test.ts
@@ -182,4 +182,19 @@ describe("issue create", () => {
       } as never);
     }, "TEST-4");
   });
+
+  it("throws error for unknown priority name", async () => {
+    vi.mocked(promptRequired)
+      .mockResolvedValueOnce("TEST")
+      .mockResolvedValueOnce("test")
+      .mockResolvedValueOnce("1")
+      .mockResolvedValueOnce("invalid");
+
+    const { create } = await import("./create");
+    await expect(
+      create.run?.({
+        args: { project: "TEST", summary: "test", priority: "invalid" },
+      } as never),
+    ).rejects.toThrow('Unknown priority "invalid". Valid values: high, normal, low');
+  });
 });

--- a/apps/cli/src/commands/issue/create.test.ts
+++ b/apps/cli/src/commands/issue/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postIssue: vi.fn(),
@@ -174,14 +175,11 @@ describe("issue create", () => {
       summary: "Title",
     });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({
-      args: { project: "100", title: "Title", type: "1", priority: "normal", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-4"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({
+        args: { project: "100", title: "Title", type: "1", priority: "normal", json: "" },
+      } as never);
+    }, "TEST-4");
   });
 });

--- a/apps/cli/src/commands/issue/delete.test.ts
+++ b/apps/cli/src/commands/issue/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteIssue: vi.fn(),
@@ -56,12 +57,9 @@ describe("issue delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteIssue.mockResolvedValue({ issueKey: "TEST-1", summary: "Title" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteIssue } = await import("./delete");
-    await deleteIssue.run?.({ args: { issue: "TEST-1", yes: true, json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteIssue } = await import("./delete");
+      await deleteIssue.run?.({ args: { issue: "TEST-1", yes: true, json: "" } } as never);
+    }, "TEST-1");
   });
 });

--- a/apps/cli/src/commands/issue/delete.test.ts
+++ b/apps/cli/src/commands/issue/delete.test.ts
@@ -41,7 +41,10 @@ describe("issue delete", () => {
     const { deleteIssue } = await import("./delete");
     await deleteIssue.run?.({ args: { issue: "TEST-1", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete issue TEST-1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/issue/edit.test.ts
+++ b/apps/cli/src/commands/issue/edit.test.ts
@@ -80,4 +80,13 @@ describe("issue edit", () => {
       await edit.run?.({ args: { issue: "TEST-1", title: "Title", json: "" } } as never);
     }, "TEST-1");
   });
+
+  it("throws error for unknown priority name", async () => {
+    const { edit } = await import("./edit");
+    await expect(
+      edit.run?.({
+        args: { issue: "TEST-1", priority: "invalid" },
+      } as never),
+    ).rejects.toThrow('Unknown priority "invalid". Valid values: high, normal, low');
+  });
 });

--- a/apps/cli/src/commands/issue/edit.test.ts
+++ b/apps/cli/src/commands/issue/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchIssue: vi.fn(),
@@ -74,12 +75,9 @@ describe("issue edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchIssue.mockResolvedValue({ issueKey: "TEST-1", summary: "Title" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({ args: { issue: "TEST-1", title: "Title", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({ args: { issue: "TEST-1", title: "Title", json: "" } } as never);
+    }, "TEST-1");
   });
 });

--- a/apps/cli/src/commands/issue/list.test.ts
+++ b/apps/cli/src/commands/issue/list.test.ts
@@ -107,4 +107,11 @@ describe("issue list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "PROJ-1");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getIssues.mockRejectedValue(new Error("API error"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("API error");
+  });
 });

--- a/apps/cli/src/commands/issue/list.test.ts
+++ b/apps/cli/src/commands/issue/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getIssues: vi.fn(),
@@ -101,12 +102,9 @@ describe("issue list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getIssues.mockResolvedValue(sampleIssues);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { json: "" } } as never);
+    }, "PROJ-1");
   });
 });

--- a/apps/cli/src/commands/issue/list.test.ts
+++ b/apps/cli/src/commands/issue/list.test.ts
@@ -14,13 +14,6 @@ vi.mock("@repo/backlog-utils", async (importOriginal) => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 const sampleIssues = [
   {
     issueKey: "PROJ-1",
@@ -42,7 +35,6 @@ const sampleIssues = [
 
 describe("issue list", () => {
   it("displays issue list in tabular format", async () => {
-    setupMocks();
     mockClient.getIssues.mockResolvedValue(sampleIssues);
 
     const { list } = await import("./list");
@@ -56,7 +48,6 @@ describe("issue list", () => {
   });
 
   it("shows message when no issues found", async () => {
-    setupMocks();
     mockClient.getIssues.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -66,7 +57,6 @@ describe("issue list", () => {
   });
 
   it("shows Unassigned for issues without assignee", async () => {
-    setupMocks();
     mockClient.getIssues.mockResolvedValue([sampleIssues[1]]);
 
     const { list } = await import("./list");
@@ -76,7 +66,6 @@ describe("issue list", () => {
   });
 
   it("passes project query parameter", async () => {
-    setupMocks();
     mockClient.getIssues.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -88,7 +77,6 @@ describe("issue list", () => {
   });
 
   it("passes assignee query parameter", async () => {
-    setupMocks();
     mockClient.getIssues.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -100,7 +88,6 @@ describe("issue list", () => {
   });
 
   it("passes keyword query parameter", async () => {
-    setupMocks();
     mockClient.getIssues.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -112,7 +99,6 @@ describe("issue list", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getIssues.mockResolvedValue(sampleIssues);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/issue/list.test.ts
+++ b/apps/cli/src/commands/issue/list.test.ts
@@ -107,11 +107,4 @@ describe("issue list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "PROJ-1");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getIssues.mockRejectedValue(new Error("API error"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("API error");
-  });
 });

--- a/apps/cli/src/commands/issue/reopen.test.ts
+++ b/apps/cli/src/commands/issue/reopen.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchIssue: vi.fn(),
@@ -54,12 +55,9 @@ describe("issue reopen", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchIssue.mockResolvedValue({ issueKey: "TEST-1", summary: "Title" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { reopen } = await import("./reopen");
-    await reopen.run?.({ args: { issue: "TEST-1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { reopen } = await import("./reopen");
+      await reopen.run?.({ args: { issue: "TEST-1", json: "" } } as never);
+    }, "TEST-1");
   });
 });

--- a/apps/cli/src/commands/issue/status.test.ts
+++ b/apps/cli/src/commands/issue/status.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getMyself: vi.fn(),
@@ -59,12 +60,9 @@ describe("issue status", () => {
       { issueKey: "PROJ-1", summary: "Test", status: { name: "Open" } },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { status } = await import("./status");
-    await status.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { status } = await import("./status");
+      await status.run?.({ args: { json: "" } } as never);
+    }, "PROJ-1");
   });
 });

--- a/apps/cli/src/commands/issue/status.test.ts
+++ b/apps/cli/src/commands/issue/status.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -13,13 +12,6 @@ vi.mock("@repo/backlog-utils", () => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 const sampleUser = {
   id: 100,
   name: "Alice",
@@ -27,7 +19,6 @@ const sampleUser = {
 
 describe("issue status", () => {
   it("displays issues grouped by status", async () => {
-    setupMocks();
     mockClient.getMyself.mockResolvedValue(sampleUser);
     mockClient.getIssues.mockResolvedValue([
       { issueKey: "PROJ-1", summary: "Open issue", status: { name: "Open" } },
@@ -53,7 +44,6 @@ describe("issue status", () => {
   });
 
   it("shows message when no issues assigned", async () => {
-    setupMocks();
     mockClient.getMyself.mockResolvedValue(sampleUser);
     mockClient.getIssues.mockResolvedValue([]);
 
@@ -64,7 +54,6 @@ describe("issue status", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getMyself.mockResolvedValue(sampleUser);
     mockClient.getIssues.mockResolvedValue([
       { issueKey: "PROJ-1", summary: "Test", status: { name: "Open" } },

--- a/apps/cli/src/commands/issue/view.test.ts
+++ b/apps/cli/src/commands/issue/view.test.ts
@@ -1,6 +1,7 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getIssue: vi.fn(),
@@ -106,12 +107,9 @@ describe("issue view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getIssue.mockResolvedValue(sampleIssue);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { issue: "PROJ-1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { issue: "PROJ-1", json: "" } } as never);
+    }, "PROJ-1");
   });
 });

--- a/apps/cli/src/commands/issue/view.test.ts
+++ b/apps/cli/src/commands/issue/view.test.ts
@@ -1,4 +1,4 @@
-import { getClient, openOrPrintUrl } from "@repo/backlog-utils";
+import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -15,13 +15,6 @@ vi.mock("@repo/backlog-utils", () => ({
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
-
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
 
 const sampleIssue = {
   id: 1,
@@ -46,7 +39,6 @@ const sampleIssue = {
 
 describe("issue view", () => {
   it("displays issue details", async () => {
-    setupMocks();
     mockClient.getIssue.mockResolvedValue(sampleIssue);
 
     const { view } = await import("./view");
@@ -62,7 +54,6 @@ describe("issue view", () => {
   });
 
   it("shows Unassigned for issues without assignee", async () => {
-    setupMocks();
     mockClient.getIssue.mockResolvedValue({ ...sampleIssue, assignee: null });
 
     const { view } = await import("./view");
@@ -72,7 +63,6 @@ describe("issue view", () => {
   });
 
   it("displays description when present", async () => {
-    setupMocks();
     mockClient.getIssue.mockResolvedValue(sampleIssue);
 
     const { view } = await import("./view");
@@ -83,7 +73,6 @@ describe("issue view", () => {
   });
 
   it("fetches and displays comments with --comments flag", async () => {
-    setupMocks();
     mockClient.getIssue.mockResolvedValue(sampleIssue);
     mockClient.getIssueComments.mockResolvedValue([
       {
@@ -103,8 +92,6 @@ describe("issue view", () => {
   });
 
   it("opens browser with --web flag", async () => {
-    setupMocks();
-
     const { view } = await import("./view");
     await view.run?.({ args: { issue: "PROJ-1", web: true } } as never);
 
@@ -117,7 +104,6 @@ describe("issue view", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getIssue.mockResolvedValue(sampleIssue);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/milestone/create.test.ts
+++ b/apps/cli/src/commands/milestone/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postVersions: vi.fn(),
@@ -69,12 +70,9 @@ describe("milestone create", () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("v1.0.0");
     mockClient.postVersions.mockResolvedValue({ id: 1, name: "v1.0.0" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({ args: { project: "TEST", name: "v1.0.0", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("v1.0.0"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({ args: { project: "TEST", name: "v1.0.0", json: "" } } as never);
+    }, "v1.0.0");
   });
 });

--- a/apps/cli/src/commands/milestone/delete.test.ts
+++ b/apps/cli/src/commands/milestone/delete.test.ts
@@ -41,7 +41,10 @@ describe("milestone delete", () => {
     const { deleteMilestone } = await import("./delete");
     await deleteMilestone.run?.({ args: { milestone: "1", project: "TEST", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete milestone 1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/milestone/delete.test.ts
+++ b/apps/cli/src/commands/milestone/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteVersions: vi.fn(),
@@ -56,14 +57,11 @@ describe("milestone delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteVersions.mockResolvedValue({ id: 1, name: "v1.0.0" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteMilestone } = await import("./delete");
-    await deleteMilestone.run?.({
-      args: { milestone: "1", project: "TEST", yes: true, json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("v1.0.0"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteMilestone } = await import("./delete");
+      await deleteMilestone.run?.({
+        args: { milestone: "1", project: "TEST", yes: true, json: "" },
+      } as never);
+    }, "v1.0.0");
   });
 });

--- a/apps/cli/src/commands/milestone/edit.test.ts
+++ b/apps/cli/src/commands/milestone/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchVersions: vi.fn(),
@@ -65,14 +66,11 @@ describe("milestone edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchVersions.mockResolvedValue({ id: 1, name: "v1.0.0" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({
-      args: { milestone: "1", project: "TEST", name: "v1.0.0", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("v1.0.0"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({
+        args: { milestone: "1", project: "TEST", name: "v1.0.0", json: "" },
+      } as never);
+    }, "v1.0.0");
   });
 });

--- a/apps/cli/src/commands/milestone/list.test.ts
+++ b/apps/cli/src/commands/milestone/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getVersions: vi.fn(),
@@ -66,12 +67,9 @@ describe("milestone list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getVersions.mockResolvedValue(sampleMilestones);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("v1.0.0"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "v1.0.0");
   });
 });

--- a/apps/cli/src/commands/milestone/list.test.ts
+++ b/apps/cli/src/commands/milestone/list.test.ts
@@ -72,11 +72,4 @@ describe("milestone list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "v1.0.0");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getVersions.mockRejectedValue(new Error("Not Found"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
-  });
 });

--- a/apps/cli/src/commands/milestone/list.test.ts
+++ b/apps/cli/src/commands/milestone/list.test.ts
@@ -72,4 +72,11 @@ describe("milestone list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "v1.0.0");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getVersions.mockRejectedValue(new Error("Not Found"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
+  });
 });

--- a/apps/cli/src/commands/notification/count.test.ts
+++ b/apps/cli/src/commands/notification/count.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getNotificationsCount: vi.fn(),
@@ -69,12 +70,9 @@ describe("notification count", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getNotificationsCount.mockResolvedValue({ count: 42 });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { count } = await import("./count");
-    await count.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("42"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { count } = await import("./count");
+      await count.run?.({ args: { json: "" } } as never);
+    }, "42");
   });
 });

--- a/apps/cli/src/commands/notification/list.test.ts
+++ b/apps/cli/src/commands/notification/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getNotifications: vi.fn(),
@@ -102,12 +103,9 @@ describe("notification list", () => {
       },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { json: "" } } as never);
+    }, "PROJ-1");
   });
 });

--- a/apps/cli/src/commands/notification/read-all.test.ts
+++ b/apps/cli/src/commands/notification/read-all.test.ts
@@ -23,4 +23,11 @@ describe("notification read-all", () => {
     expect(mockClient.resetNotificationsMarkAsRead).toHaveBeenCalled();
     expect(consola.success).toHaveBeenCalledWith("Marked all notifications as read.");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.resetNotificationsMarkAsRead.mockRejectedValue(new Error("Unauthorized"));
+
+    const { readAll } = await import("./read-all");
+    await expect(readAll.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
+  });
 });

--- a/apps/cli/src/commands/notification/read-all.test.ts
+++ b/apps/cli/src/commands/notification/read-all.test.ts
@@ -23,11 +23,4 @@ describe("notification read-all", () => {
     expect(mockClient.resetNotificationsMarkAsRead).toHaveBeenCalled();
     expect(consola.success).toHaveBeenCalledWith("Marked all notifications as read.");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.resetNotificationsMarkAsRead.mockRejectedValue(new Error("Unauthorized"));
-
-    const { readAll } = await import("./read-all");
-    await expect(readAll.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
-  });
 });

--- a/apps/cli/src/commands/notification/read.test.ts
+++ b/apps/cli/src/commands/notification/read.test.ts
@@ -23,4 +23,20 @@ describe("notification read", () => {
     expect(mockClient.markAsReadNotification).toHaveBeenCalledWith(12_345);
     expect(consola.success).toHaveBeenCalledWith("Marked notification 12345 as read.");
   });
+
+  it("converts string ID to number", async () => {
+    mockClient.markAsReadNotification.mockResolvedValue(undefined);
+
+    const { read } = await import("./read");
+    await read.run?.({ args: { id: "99" } } as never);
+
+    expect(mockClient.markAsReadNotification).toHaveBeenCalledWith(99);
+  });
+
+  it("propagates API errors", async () => {
+    mockClient.markAsReadNotification.mockRejectedValue(new Error("Not found"));
+
+    const { read } = await import("./read");
+    await expect(read.run?.({ args: { id: "999" } } as never)).rejects.toThrow("Not found");
+  });
 });

--- a/apps/cli/src/commands/notification/read.test.ts
+++ b/apps/cli/src/commands/notification/read.test.ts
@@ -32,11 +32,4 @@ describe("notification read", () => {
 
     expect(mockClient.markAsReadNotification).toHaveBeenCalledWith(99);
   });
-
-  it("propagates API errors", async () => {
-    mockClient.markAsReadNotification.mockRejectedValue(new Error("Not found"));
-
-    const { read } = await import("./read");
-    await expect(read.run?.({ args: { id: "999" } } as never)).rejects.toThrow("Not found");
-  });
 });

--- a/apps/cli/src/commands/pr/comment.test.ts
+++ b/apps/cli/src/commands/pr/comment.test.ts
@@ -1,6 +1,7 @@
 import { printTable, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postPullRequestComments: vi.fn(),
@@ -69,15 +70,12 @@ describe("pr comment", () => {
 
   it("outputs JSON when --json flag is set", async () => {
     mockClient.postPullRequestComments.mockResolvedValue({ id: 1, content: "LGTM" });
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { comment } = await import("./comment");
-    await comment.run?.({
-      args: { number: "42", project: "TEST", repo: "my-repo", body: "LGTM", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("LGTM"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { comment } = await import("./comment");
+      await comment.run?.({
+        args: { number: "42", project: "TEST", repo: "my-repo", body: "LGTM", json: "" },
+      } as never);
+    }, "LGTM");
   });
 
   it("lists comments with --list flag", async () => {

--- a/apps/cli/src/commands/pr/comment.test.ts
+++ b/apps/cli/src/commands/pr/comment.test.ts
@@ -129,6 +129,38 @@ describe("pr comment", () => {
     expect(consola.success).toHaveBeenCalledWith("Updated comment on pull request #42");
   });
 
+  it("shows error when body is missing with --edit-last", async () => {
+    mockClient.getPullRequestComments.mockResolvedValue([
+      { id: 20, content: "My comment", createdUser: { id: 1 } },
+    ]);
+    mockClient.getMyself.mockResolvedValue({ id: 1 });
+
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: {
+        number: "42",
+        project: "TEST",
+        repo: "my-repo",
+        "edit-last": true,
+      },
+    } as never);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      "Comment body is required. Use --body or pipe input.",
+    );
+  });
+
+  it("shows error when body is missing for add comment", async () => {
+    const { comment } = await import("./comment");
+    await comment.run?.({
+      args: { number: "42", project: "TEST", repo: "my-repo" },
+    } as never);
+
+    expect(consola.error).toHaveBeenCalledWith(
+      "Comment body is required. Use --body or pipe input.",
+    );
+  });
+
   it("shows error when no own comment found with --edit-last", async () => {
     mockClient.getPullRequestComments.mockResolvedValue([
       { id: 10, content: "Other", createdUser: { id: 999 } },

--- a/apps/cli/src/commands/pr/comments.test.ts
+++ b/apps/cli/src/commands/pr/comments.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getPullRequestComments: vi.fn(),
@@ -66,14 +67,11 @@ describe("pr comments", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getPullRequestComments.mockResolvedValue(sampleComments);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { comments } = await import("./comments");
-    await comments.run?.({
-      args: { number: "42", project: "PROJ", repo: "repo", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Looks good!"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { comments } = await import("./comments");
+      await comments.run?.({
+        args: { number: "42", project: "PROJ", repo: "repo", json: "" },
+      } as never);
+    }, "Looks good!");
   });
 });

--- a/apps/cli/src/commands/pr/comments.test.ts
+++ b/apps/cli/src/commands/pr/comments.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -11,13 +10,6 @@ vi.mock("@repo/backlog-utils", () => ({
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
-
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
 
 const sampleComments = [
   {
@@ -36,7 +28,6 @@ const sampleComments = [
 
 describe("pr comments", () => {
   it("displays pull request comments", async () => {
-    setupMocks();
     mockClient.getPullRequestComments.mockResolvedValue(sampleComments);
 
     const { comments } = await import("./comments");
@@ -53,7 +44,6 @@ describe("pr comments", () => {
   });
 
   it("shows message when no comments found", async () => {
-    setupMocks();
     mockClient.getPullRequestComments.mockResolvedValue([]);
 
     const { comments } = await import("./comments");
@@ -63,7 +53,6 @@ describe("pr comments", () => {
   });
 
   it("filters out comments without content", async () => {
-    setupMocks();
     mockClient.getPullRequestComments.mockResolvedValue([
       { id: 1, content: "", createdUser: { name: "Alice" }, created: "2025-01-01T00:00:00Z" },
     ]);
@@ -75,7 +64,6 @@ describe("pr comments", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getPullRequestComments.mockResolvedValue(sampleComments);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/pr/count.test.ts
+++ b/apps/cli/src/commands/pr/count.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getPullRequestsCount: vi.fn(),

--- a/apps/cli/src/commands/pr/count.test.ts
+++ b/apps/cli/src/commands/pr/count.test.ts
@@ -49,4 +49,13 @@ describe("pr count", () => {
       await count.run?.({ args: { project: "TEST", repo: "my-repo", json: "" } } as never);
     }, "10");
   });
+
+  it("throws error for unknown status name", async () => {
+    const { count } = await import("./count");
+    await expect(
+      count.run?.({
+        args: { repo: "my-repo", status: "invalid" },
+      } as never),
+    ).rejects.toThrow('Unknown status "invalid". Valid values: open, closed, merged');
+  });
 });

--- a/apps/cli/src/commands/pr/count.test.ts
+++ b/apps/cli/src/commands/pr/count.test.ts
@@ -44,10 +44,9 @@ describe("pr count", () => {
 
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getPullRequestsCount.mockResolvedValue({ count: 10 });
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    const { count } = await import("./count");
-    await count.run?.({ args: { project: "TEST", repo: "my-repo", json: "" } } as never);
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("10"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { count } = await import("./count");
+      await count.run?.({ args: { project: "TEST", repo: "my-repo", json: "" } } as never);
+    }, "10");
   });
 });

--- a/apps/cli/src/commands/pr/create.test.ts
+++ b/apps/cli/src/commands/pr/create.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -20,16 +19,8 @@ vi.mock("@repo/cli-utils", async (importOriginal) => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 describe("pr create", () => {
   it("creates a pull request with required fields", async () => {
-    setupMocks();
     mockClient.postPullRequest.mockResolvedValue({ number: 1, summary: "Add feature" });
 
     const { create } = await import("./create");
@@ -58,7 +49,6 @@ describe("pr create", () => {
   });
 
   it("creates a pull request with assignee @me", async () => {
-    setupMocks();
     mockClient.getMyself.mockResolvedValue({ id: 99 });
     mockClient.postPullRequest.mockResolvedValue({ number: 2, summary: "Title" });
 
@@ -83,7 +73,6 @@ describe("pr create", () => {
   });
 
   it("creates a pull request with related issue", async () => {
-    setupMocks();
     mockClient.postPullRequest.mockResolvedValue({ number: 3, summary: "Title" });
 
     const { create } = await import("./create");
@@ -107,7 +96,6 @@ describe("pr create", () => {
   });
 
   it("resolves issue key to issue ID", async () => {
-    setupMocks();
     mockClient.getIssue.mockResolvedValue({ id: 789 });
     mockClient.postPullRequest.mockResolvedValue({ number: 4, summary: "Title" });
 
@@ -133,7 +121,6 @@ describe("pr create", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.postPullRequest.mockResolvedValue({ number: 1, summary: "Add feature" });
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/pr/create.test.ts
+++ b/apps/cli/src/commands/pr/create.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postPullRequest: vi.fn(),
@@ -123,22 +124,19 @@ describe("pr create", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.postPullRequest.mockResolvedValue({ number: 1, summary: "Add feature" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({
-      args: {
-        project: "PROJ",
-        repo: "repo",
-        base: "main",
-        head: "feature",
-        title: "Add feature",
-        body: "Details",
-        json: "",
-      },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Add feature"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({
+        args: {
+          project: "PROJ",
+          repo: "repo",
+          base: "main",
+          head: "feature",
+          title: "Add feature",
+          body: "Details",
+          json: "",
+        },
+      } as never);
+    }, "Add feature");
   });
 });

--- a/apps/cli/src/commands/pr/edit.test.ts
+++ b/apps/cli/src/commands/pr/edit.test.ts
@@ -91,6 +91,24 @@ describe("pr edit", () => {
     );
   });
 
+  it("resolves @me to current user ID for assignee", async () => {
+    mockClient.getMyself.mockResolvedValue({ id: 99 });
+    mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "Title" });
+
+    const { edit } = await import("./edit");
+    await edit.run?.({
+      args: { number: "42", project: "PROJ", repo: "repo", assignee: "@me" },
+    } as never);
+
+    expect(mockClient.getMyself).toHaveBeenCalled();
+    expect(mockClient.patchPullRequest).toHaveBeenCalledWith(
+      "PROJ",
+      "repo",
+      42,
+      expect.objectContaining({ assigneeId: 99 }),
+    );
+  });
+
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "Title" });
 

--- a/apps/cli/src/commands/pr/edit.test.ts
+++ b/apps/cli/src/commands/pr/edit.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -15,16 +14,8 @@ vi.mock("@repo/backlog-utils", async (importOriginal) => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 describe("pr edit", () => {
   it("updates pull request summary", async () => {
-    setupMocks();
     mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "New title" });
 
     const { edit } = await import("./edit");
@@ -44,7 +35,6 @@ describe("pr edit", () => {
   });
 
   it("updates pull request with a comment", async () => {
-    setupMocks();
     mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "Title" });
 
     const { edit } = await import("./edit");
@@ -67,7 +57,6 @@ describe("pr edit", () => {
   });
 
   it("updates pull request with notified users", async () => {
-    setupMocks();
     mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "Title" });
 
     const { edit } = await import("./edit");
@@ -84,7 +73,6 @@ describe("pr edit", () => {
   });
 
   it("resolves issue key to issue ID", async () => {
-    setupMocks();
     mockClient.getIssue.mockResolvedValue({ id: 789 });
     mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "Title" });
 
@@ -103,7 +91,6 @@ describe("pr edit", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "Title" });
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/pr/edit.test.ts
+++ b/apps/cli/src/commands/pr/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchPullRequest: vi.fn(),
@@ -93,14 +94,11 @@ describe("pr edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchPullRequest.mockResolvedValue({ number: 42, summary: "Title" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({
-      args: { number: "42", project: "PROJ", repo: "repo", title: "Title", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Title"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({
+        args: { number: "42", project: "PROJ", repo: "repo", title: "Title", json: "" },
+      } as never);
+    }, "Title");
   });
 });

--- a/apps/cli/src/commands/pr/list.test.ts
+++ b/apps/cli/src/commands/pr/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getPullRequests: vi.fn(),
@@ -96,12 +97,9 @@ describe("pr list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getPullRequests.mockResolvedValue(samplePullRequests);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "PROJ", repo: "repo", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Add feature A"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "PROJ", repo: "repo", json: "" } } as never);
+    }, "Add feature A");
   });
 });

--- a/apps/cli/src/commands/pr/list.test.ts
+++ b/apps/cli/src/commands/pr/list.test.ts
@@ -13,13 +13,6 @@ vi.mock("@repo/backlog-utils", async (importOriginal) => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 const samplePullRequests = [
   {
     number: 1,
@@ -37,7 +30,6 @@ const samplePullRequests = [
 
 describe("pr list", () => {
   it("displays pull request list in tabular format", async () => {
-    setupMocks();
     mockClient.getPullRequests.mockResolvedValue(samplePullRequests);
 
     const { list } = await import("./list");
@@ -51,7 +43,6 @@ describe("pr list", () => {
   });
 
   it("shows message when no pull requests found", async () => {
-    setupMocks();
     mockClient.getPullRequests.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -61,7 +52,6 @@ describe("pr list", () => {
   });
 
   it("shows Unassigned for pull requests without assignee", async () => {
-    setupMocks();
     mockClient.getPullRequests.mockResolvedValue([samplePullRequests[1]]);
 
     const { list } = await import("./list");
@@ -71,7 +61,6 @@ describe("pr list", () => {
   });
 
   it("passes status filter parameter", async () => {
-    setupMocks();
     mockClient.getPullRequests.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -85,8 +74,6 @@ describe("pr list", () => {
   });
 
   it("throws error for unknown status name", async () => {
-    setupMocks();
-
     const { list } = await import("./list");
     await expect(
       list.run?.({ args: { project: "PROJ", repo: "repo", status: "invalid" } } as never),
@@ -94,7 +81,6 @@ describe("pr list", () => {
   });
 
   it("passes assignee filter parameter", async () => {
-    setupMocks();
     mockClient.getPullRequests.mockResolvedValue([]);
 
     const { list } = await import("./list");
@@ -108,7 +94,6 @@ describe("pr list", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getPullRequests.mockResolvedValue(samplePullRequests);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/pr/status.test.ts
+++ b/apps/cli/src/commands/pr/status.test.ts
@@ -1,4 +1,3 @@
-import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -14,14 +13,6 @@ vi.mock("@repo/backlog-utils", async (importOriginal) => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-  mockClient.getMyself.mockResolvedValue({ id: 1, name: "Alice" });
-};
-
 const samplePullRequests = [
   { number: 1, summary: "Add feature A", status: { id: 1, name: "Open" } },
   { number: 2, summary: "Fix bug B", status: { id: 1, name: "Open" } },
@@ -30,7 +21,7 @@ const samplePullRequests = [
 
 describe("pr status", () => {
   it("displays pull requests grouped by status", async () => {
-    setupMocks();
+    mockClient.getMyself.mockResolvedValue({ id: 1, name: "Alice" });
     mockClient.getPullRequests.mockResolvedValue(samplePullRequests);
 
     const { status } = await import("./status");
@@ -48,7 +39,7 @@ describe("pr status", () => {
   });
 
   it("shows message when no pull requests assigned", async () => {
-    setupMocks();
+    mockClient.getMyself.mockResolvedValue({ id: 1, name: "Alice" });
     mockClient.getPullRequests.mockResolvedValue([]);
 
     const { status } = await import("./status");
@@ -58,7 +49,7 @@ describe("pr status", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
+    mockClient.getMyself.mockResolvedValue({ id: 1, name: "Alice" });
     mockClient.getPullRequests.mockResolvedValue(samplePullRequests);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/pr/status.test.ts
+++ b/apps/cli/src/commands/pr/status.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getMyself: vi.fn(),
@@ -52,12 +53,9 @@ describe("pr status", () => {
     mockClient.getMyself.mockResolvedValue({ id: 1, name: "Alice" });
     mockClient.getPullRequests.mockResolvedValue(samplePullRequests);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { status } = await import("./status");
-    await status.run?.({ args: { project: "PROJ", repo: "repo", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Alice"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { status } = await import("./status");
+      await status.run?.({ args: { project: "PROJ", repo: "repo", json: "" } } as never);
+    }, "Alice");
   });
 });

--- a/apps/cli/src/commands/pr/view.test.ts
+++ b/apps/cli/src/commands/pr/view.test.ts
@@ -1,6 +1,7 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getPullRequest: vi.fn(),
@@ -83,12 +84,11 @@ describe("pr view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getPullRequest.mockResolvedValue(samplePullRequest);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { number: "42", project: "PROJ", repo: "repo", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Add feature A"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({
+        args: { number: "42", project: "PROJ", repo: "repo", json: "" },
+      } as never);
+    }, "Add feature A");
   });
 });

--- a/apps/cli/src/commands/pr/view.test.ts
+++ b/apps/cli/src/commands/pr/view.test.ts
@@ -91,4 +91,13 @@ describe("pr view", () => {
       } as never);
     }, "Add feature A");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getPullRequest.mockRejectedValue(new Error("Not Found"));
+
+    const { view } = await import("./view");
+    await expect(
+      view.run?.({ args: { number: "42", project: "PROJ", repo: "repo" } } as never),
+    ).rejects.toThrow("Not Found");
+  });
 });

--- a/apps/cli/src/commands/pr/view.test.ts
+++ b/apps/cli/src/commands/pr/view.test.ts
@@ -1,4 +1,4 @@
-import { getClient, openOrPrintUrl } from "@repo/backlog-utils";
+import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
 
@@ -18,13 +18,6 @@ vi.mock("@repo/backlog-utils", () => ({
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-const setupMocks = () => {
-  vi.mocked(getClient).mockResolvedValue({
-    client: mockClient as never,
-    host: "example.backlog.com",
-  });
-};
-
 const samplePullRequest = {
   id: 1,
   number: 42,
@@ -43,7 +36,6 @@ const samplePullRequest = {
 
 describe("pr view", () => {
   it("displays pull request details", async () => {
-    setupMocks();
     mockClient.getPullRequest.mockResolvedValue(samplePullRequest);
 
     const { view } = await import("./view");
@@ -58,7 +50,6 @@ describe("pr view", () => {
   });
 
   it("shows Unassigned for pull requests without assignee", async () => {
-    setupMocks();
     mockClient.getPullRequest.mockResolvedValue({ ...samplePullRequest, assignee: null });
 
     const { view } = await import("./view");
@@ -68,7 +59,6 @@ describe("pr view", () => {
   });
 
   it("displays description when present", async () => {
-    setupMocks();
     mockClient.getPullRequest.mockResolvedValue(samplePullRequest);
 
     const { view } = await import("./view");
@@ -79,8 +69,6 @@ describe("pr view", () => {
   });
 
   it("opens browser with --web flag", async () => {
-    setupMocks();
-
     const { view } = await import("./view");
     await view.run?.({ args: { number: "42", project: "PROJ", repo: "repo", web: true } } as never);
 
@@ -93,7 +81,6 @@ describe("pr view", () => {
   });
 
   it("outputs JSON when --json flag is set", async () => {
-    setupMocks();
     mockClient.getPullRequest.mockResolvedValue(samplePullRequest);
 
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);

--- a/apps/cli/src/commands/pr/view.test.ts
+++ b/apps/cli/src/commands/pr/view.test.ts
@@ -91,13 +91,4 @@ describe("pr view", () => {
       } as never);
     }, "Add feature A");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getPullRequest.mockRejectedValue(new Error("Not Found"));
-
-    const { view } = await import("./view");
-    await expect(
-      view.run?.({ args: { number: "42", project: "PROJ", repo: "repo" } } as never),
-    ).rejects.toThrow("Not Found");
-  });
 });

--- a/apps/cli/src/commands/project/activities.test.ts
+++ b/apps/cli/src/commands/project/activities.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getProjectActivities: vi.fn(),
@@ -91,12 +92,9 @@ describe("project activities", () => {
       },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { activities } = await import("./activities");
-    await activities.run?.({ args: { project: "PROJ1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Test"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { activities } = await import("./activities");
+      await activities.run?.({ args: { project: "PROJ1", json: "" } } as never);
+    }, "Test");
   });
 });

--- a/apps/cli/src/commands/project/add-user.test.ts
+++ b/apps/cli/src/commands/project/add-user.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postProjectUser: vi.fn(),
@@ -37,14 +38,11 @@ describe("project add-user", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.postProjectUser.mockResolvedValue({ id: 12_345, name: "John Doe" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { addUser } = await import("./add-user");
-    await addUser.run?.({
-      args: { project: "TEST", "user-id": "12345", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("John Doe"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { addUser } = await import("./add-user");
+      await addUser.run?.({
+        args: { project: "TEST", "user-id": "12345", json: "" },
+      } as never);
+    }, "John Doe");
   });
 });

--- a/apps/cli/src/commands/project/create.test.ts
+++ b/apps/cli/src/commands/project/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postProject: vi.fn(),
@@ -95,12 +96,9 @@ describe("project create", () => {
       textFormattingRule: "markdown",
     });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({ args: { key: "TEST", name: "Test", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({ args: { key: "TEST", name: "Test", json: "" } } as never);
+    }, "TEST");
   });
 });

--- a/apps/cli/src/commands/project/delete.test.ts
+++ b/apps/cli/src/commands/project/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteProject: vi.fn(),
@@ -56,12 +57,9 @@ describe("project delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteProject.mockResolvedValue({ projectKey: "TEST", name: "Test Project" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteProject } = await import("./delete");
-    await deleteProject.run?.({ args: { project: "TEST", yes: true, json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteProject } = await import("./delete");
+      await deleteProject.run?.({ args: { project: "TEST", yes: true, json: "" } } as never);
+    }, "TEST");
   });
 });

--- a/apps/cli/src/commands/project/delete.test.ts
+++ b/apps/cli/src/commands/project/delete.test.ts
@@ -41,7 +41,10 @@ describe("project delete", () => {
     const { deleteProject } = await import("./delete");
     await deleteProject.run?.({ args: { project: "TEST", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete project TEST? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/project/edit.test.ts
+++ b/apps/cli/src/commands/project/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchProject: vi.fn(),
@@ -54,12 +55,9 @@ describe("project edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchProject.mockResolvedValue({ projectKey: "TEST", name: "Test" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({ args: { project: "TEST", name: "Test", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({ args: { project: "TEST", name: "Test", json: "" } } as never);
+    }, "TEST");
   });
 });

--- a/apps/cli/src/commands/project/list.test.ts
+++ b/apps/cli/src/commands/project/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getProjects: vi.fn(),
@@ -63,12 +64,9 @@ describe("project list", () => {
       { projectKey: "PROJ1", name: "Project One", archived: false },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { json: "" } } as never);
+    }, "PROJ1");
   });
 });

--- a/apps/cli/src/commands/project/list.test.ts
+++ b/apps/cli/src/commands/project/list.test.ts
@@ -69,11 +69,4 @@ describe("project list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "PROJ1");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getProjects.mockRejectedValue(new Error("Unauthorized"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
-  });
 });

--- a/apps/cli/src/commands/project/list.test.ts
+++ b/apps/cli/src/commands/project/list.test.ts
@@ -69,4 +69,11 @@ describe("project list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "PROJ1");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getProjects.mockRejectedValue(new Error("Unauthorized"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
+  });
 });

--- a/apps/cli/src/commands/project/remove-user.test.ts
+++ b/apps/cli/src/commands/project/remove-user.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteProjectUsers: vi.fn(),
@@ -37,14 +38,11 @@ describe("project remove-user", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.deleteProjectUsers.mockResolvedValue({ id: 12_345, name: "John Doe" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { removeUser } = await import("./remove-user");
-    await removeUser.run?.({
-      args: { project: "TEST", "user-id": "12345", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("John Doe"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { removeUser } = await import("./remove-user");
+      await removeUser.run?.({
+        args: { project: "TEST", "user-id": "12345", json: "" },
+      } as never);
+    }, "John Doe");
   });
 });

--- a/apps/cli/src/commands/project/users.test.ts
+++ b/apps/cli/src/commands/project/users.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getProjectUsers: vi.fn(),
@@ -43,12 +44,9 @@ describe("project users", () => {
       { id: 1, userId: "user1", name: "User One", roleType: 1 },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { users } = await import("./users");
-    await users.run?.({ args: { project: "PROJ1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("user1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { users } = await import("./users");
+      await users.run?.({ args: { project: "PROJ1", json: "" } } as never);
+    }, "user1");
   });
 });

--- a/apps/cli/src/commands/project/view.test.ts
+++ b/apps/cli/src/commands/project/view.test.ts
@@ -1,6 +1,7 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getProject: vi.fn(),
@@ -68,12 +69,9 @@ describe("project view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getProject.mockResolvedValue(sampleProject);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { project: "PROJ1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("PROJ1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { project: "PROJ1", json: "" } } as never);
+    }, "PROJ1");
   });
 });

--- a/apps/cli/src/commands/repo/clone.test.ts
+++ b/apps/cli/src/commands/repo/clone.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from "vitest";
-import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getGitRepository: vi.fn(),

--- a/apps/cli/src/commands/repo/clone.test.ts
+++ b/apps/cli/src/commands/repo/clone.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getGitRepository: vi.fn(),

--- a/apps/cli/src/commands/repo/list.test.ts
+++ b/apps/cli/src/commands/repo/list.test.ts
@@ -71,11 +71,4 @@ describe("repo list", () => {
       await list.run?.({ args: { project: "PROJ", json: "" } } as never);
     }, "api-server");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getGitRepositories.mockRejectedValue(new Error("Not Found"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "PROJ" } } as never)).rejects.toThrow("Not Found");
-  });
 });

--- a/apps/cli/src/commands/repo/list.test.ts
+++ b/apps/cli/src/commands/repo/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getGitRepositories: vi.fn(),
@@ -65,12 +66,9 @@ describe("repo list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getGitRepositories.mockResolvedValue(sampleRepos);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "PROJ", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("api-server"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "PROJ", json: "" } } as never);
+    }, "api-server");
   });
 });

--- a/apps/cli/src/commands/repo/list.test.ts
+++ b/apps/cli/src/commands/repo/list.test.ts
@@ -71,4 +71,11 @@ describe("repo list", () => {
       await list.run?.({ args: { project: "PROJ", json: "" } } as never);
     }, "api-server");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getGitRepositories.mockRejectedValue(new Error("Not Found"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "PROJ" } } as never)).rejects.toThrow("Not Found");
+  });
 });

--- a/apps/cli/src/commands/repo/view.test.ts
+++ b/apps/cli/src/commands/repo/view.test.ts
@@ -1,6 +1,7 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getGitRepository: vi.fn(),
@@ -68,12 +69,9 @@ describe("repo view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getGitRepository.mockResolvedValue(sampleRepo);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { project: "PROJ", repository: "api-server", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("api-server"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { project: "PROJ", repository: "api-server", json: "" } } as never);
+    }, "api-server");
   });
 });

--- a/apps/cli/src/commands/space/activities.test.ts
+++ b/apps/cli/src/commands/space/activities.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getSpaceActivities: vi.fn(),
@@ -93,12 +94,9 @@ describe("space activities", () => {
       },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { activities } = await import("./activities");
-    await activities.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Test"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { activities } = await import("./activities");
+      await activities.run?.({ args: { json: "" } } as never);
+    }, "Test");
   });
 });

--- a/apps/cli/src/commands/space/disk-usage.test.ts
+++ b/apps/cli/src/commands/space/disk-usage.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getSpaceDiskUsage: vi.fn(),
@@ -39,12 +40,9 @@ describe("space disk-usage", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getSpaceDiskUsage.mockResolvedValue(sampleDiskUsage);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { diskUsage } = await import("./disk-usage");
-    await diskUsage.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("1073741824"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { diskUsage } = await import("./disk-usage");
+      await diskUsage.run?.({ args: { json: "" } } as never);
+    }, "1073741824");
   });
 });

--- a/apps/cli/src/commands/space/info.test.ts
+++ b/apps/cli/src/commands/space/info.test.ts
@@ -44,4 +44,11 @@ describe("space info", () => {
       await info.run?.({ args: { json: "" } } as never);
     }, "TESTSPACE");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getSpace.mockRejectedValue(new Error("Unauthorized"));
+
+    const { info } = await import("./info");
+    await expect(info.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
+  });
 });

--- a/apps/cli/src/commands/space/info.test.ts
+++ b/apps/cli/src/commands/space/info.test.ts
@@ -44,11 +44,4 @@ describe("space info", () => {
       await info.run?.({ args: { json: "" } } as never);
     }, "TESTSPACE");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getSpace.mockRejectedValue(new Error("Unauthorized"));
-
-    const { info } = await import("./info");
-    await expect(info.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
-  });
 });

--- a/apps/cli/src/commands/space/info.test.ts
+++ b/apps/cli/src/commands/space/info.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getSpace: vi.fn(),
@@ -38,12 +39,9 @@ describe("space info", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getSpace.mockResolvedValue(sampleSpace);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { info } = await import("./info");
-    await info.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TESTSPACE"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { info } = await import("./info");
+      await info.run?.({ args: { json: "" } } as never);
+    }, "TESTSPACE");
   });
 });

--- a/apps/cli/src/commands/space/notification.test.ts
+++ b/apps/cli/src/commands/space/notification.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getSpaceNotification: vi.fn(),
@@ -46,12 +47,9 @@ describe("space notification", () => {
       updated: "2024-03-01T09:00:00Z",
     });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { notification } = await import("./notification");
-    await notification.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Important notice"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { notification } = await import("./notification");
+      await notification.run?.({ args: { json: "" } } as never);
+    }, "Important notice");
   });
 });

--- a/apps/cli/src/commands/star/count.test.ts
+++ b/apps/cli/src/commands/star/count.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getUserStarsCount: vi.fn(),
@@ -56,12 +57,9 @@ describe("star count", () => {
     mockClient.getMyself.mockResolvedValue({ id: 100 });
     mockClient.getUserStarsCount.mockResolvedValue({ count: 42 });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { count } = await import("./count");
-    await count.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("42"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { count } = await import("./count");
+      await count.run?.({ args: { json: "" } } as never);
+    }, "42");
   });
 });

--- a/apps/cli/src/commands/star/list.test.ts
+++ b/apps/cli/src/commands/star/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getUserStars: vi.fn(),
@@ -66,12 +67,9 @@ describe("star list", () => {
     mockClient.getMyself.mockResolvedValue({ id: 100 });
     mockClient.getUserStars.mockResolvedValue(sampleStars);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Sample issue"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { json: "" } } as never);
+    }, "Sample issue");
   });
 });

--- a/apps/cli/src/commands/star/remove.test.ts
+++ b/apps/cli/src/commands/star/remove.test.ts
@@ -19,4 +19,17 @@ describe("star remove", () => {
     expect(mockClient.removeStar).toHaveBeenCalledWith(12_345);
     expect(consola.success).toHaveBeenCalledWith("Removed star 12345.");
   });
+
+  it("converts string ID to number", async () => {
+    mockClient.removeStar.mockResolvedValue(undefined);
+    const { remove } = await import("./remove");
+    await remove.run?.({ args: { star: "7" } } as never);
+    expect(mockClient.removeStar).toHaveBeenCalledWith(7);
+  });
+
+  it("propagates API errors", async () => {
+    mockClient.removeStar.mockRejectedValue(new Error("Not found"));
+    const { remove } = await import("./remove");
+    await expect(remove.run?.({ args: { star: "999" } } as never)).rejects.toThrow("Not found");
+  });
 });

--- a/apps/cli/src/commands/star/remove.test.ts
+++ b/apps/cli/src/commands/star/remove.test.ts
@@ -26,10 +26,4 @@ describe("star remove", () => {
     await remove.run?.({ args: { star: "7" } } as never);
     expect(mockClient.removeStar).toHaveBeenCalledWith(7);
   });
-
-  it("propagates API errors", async () => {
-    mockClient.removeStar.mockRejectedValue(new Error("Not found"));
-    const { remove } = await import("./remove");
-    await expect(remove.run?.({ args: { star: "999" } } as never)).rejects.toThrow("Not found");
-  });
 });

--- a/apps/cli/src/commands/status/create.test.ts
+++ b/apps/cli/src/commands/status/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postProjectStatus: vi.fn(),
@@ -52,14 +53,11 @@ describe("status create", () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("Open");
     mockClient.postProjectStatus.mockResolvedValue({ id: 1, name: "Open", color: "#e30000" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({
-      args: { project: "TEST", name: "Open", color: "#e30000", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Open"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({
+        args: { project: "TEST", name: "Open", color: "#e30000", json: "" },
+      } as never);
+    }, "Open");
   });
 });

--- a/apps/cli/src/commands/status/delete.test.ts
+++ b/apps/cli/src/commands/status/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteProjectStatus: vi.fn(),
@@ -62,20 +63,17 @@ describe("status delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteProjectStatus.mockResolvedValue({ id: 1, name: "Open", color: "#e30000" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteStatus } = await import("./delete");
-    await deleteStatus.run?.({
-      args: {
-        status: "1",
-        project: "TEST",
-        "substitute-status-id": "2",
-        yes: true,
-        json: "",
-      },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Open"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteStatus } = await import("./delete");
+      await deleteStatus.run?.({
+        args: {
+          status: "1",
+          project: "TEST",
+          "substitute-status-id": "2",
+          yes: true,
+          json: "",
+        },
+      } as never);
+    }, "Open");
   });
 });

--- a/apps/cli/src/commands/status/delete.test.ts
+++ b/apps/cli/src/commands/status/delete.test.ts
@@ -45,7 +45,10 @@ describe("status delete", () => {
       args: { status: "1", project: "TEST", "substitute-status-id": "2", yes: true },
     } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete status 1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/status/edit.test.ts
+++ b/apps/cli/src/commands/status/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchProjectStatus: vi.fn(),
@@ -42,12 +43,9 @@ describe("status edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchProjectStatus.mockResolvedValue({ id: 1, name: "Open", color: "#e30000" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({ args: { status: "1", project: "TEST", name: "Open", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Open"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({ args: { status: "1", project: "TEST", name: "Open", json: "" } } as never);
+    }, "Open");
   });
 });

--- a/apps/cli/src/commands/status/list.test.ts
+++ b/apps/cli/src/commands/status/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getProjectStatuses: vi.fn(),
@@ -52,12 +53,9 @@ describe("status list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getProjectStatuses.mockResolvedValue(sampleStatuses);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Open"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "Open");
   });
 });

--- a/apps/cli/src/commands/status/list.test.ts
+++ b/apps/cli/src/commands/status/list.test.ts
@@ -58,4 +58,11 @@ describe("status list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Open");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getProjectStatuses.mockRejectedValue(new Error("Not Found"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
+  });
 });

--- a/apps/cli/src/commands/status/list.test.ts
+++ b/apps/cli/src/commands/status/list.test.ts
@@ -58,11 +58,4 @@ describe("status list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Open");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getProjectStatuses.mockRejectedValue(new Error("Not Found"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Not Found");
-  });
 });

--- a/apps/cli/src/commands/team/create.test.ts
+++ b/apps/cli/src/commands/team/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postTeam: vi.fn(),
@@ -70,12 +71,9 @@ describe("team create", () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("Team");
     mockClient.postTeam.mockResolvedValue({ id: 1, name: "Team", members: [] });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({ args: { name: "Team", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Team"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({ args: { name: "Team", json: "" } } as never);
+    }, "Team");
   });
 });

--- a/apps/cli/src/commands/team/delete.test.ts
+++ b/apps/cli/src/commands/team/delete.test.ts
@@ -41,7 +41,10 @@ describe("team delete", () => {
     const { deleteTeam } = await import("./delete");
     await deleteTeam.run?.({ args: { team: "1", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete team 1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/team/delete.test.ts
+++ b/apps/cli/src/commands/team/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteTeam: vi.fn(),
@@ -56,12 +57,9 @@ describe("team delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteTeam.mockResolvedValue({ id: 1, name: "Test Team", members: [] });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteTeam } = await import("./delete");
-    await deleteTeam.run?.({ args: { team: "1", yes: true, json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Test Team"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteTeam } = await import("./delete");
+      await deleteTeam.run?.({ args: { team: "1", yes: true, json: "" } } as never);
+    }, "Test Team");
   });
 });

--- a/apps/cli/src/commands/team/edit.test.ts
+++ b/apps/cli/src/commands/team/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchTeam: vi.fn(),
@@ -51,12 +52,9 @@ describe("team edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchTeam.mockResolvedValue({ id: 1, name: "Team", members: [] });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({ args: { team: "1", name: "Team", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Team"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({ args: { team: "1", name: "Team", json: "" } } as never);
+    }, "Team");
   });
 });

--- a/apps/cli/src/commands/team/list.test.ts
+++ b/apps/cli/src/commands/team/list.test.ts
@@ -88,4 +88,11 @@ describe("team list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "Design Team");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getTeams.mockRejectedValue(new Error("Unauthorized"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
+  });
 });

--- a/apps/cli/src/commands/team/list.test.ts
+++ b/apps/cli/src/commands/team/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getTeams: vi.fn(),
@@ -82,12 +83,9 @@ describe("team list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getTeams.mockResolvedValue(sampleTeams);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Design Team"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { json: "" } } as never);
+    }, "Design Team");
   });
 });

--- a/apps/cli/src/commands/team/list.test.ts
+++ b/apps/cli/src/commands/team/list.test.ts
@@ -88,11 +88,4 @@ describe("team list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "Design Team");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getTeams.mockRejectedValue(new Error("Unauthorized"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
-  });
 });

--- a/apps/cli/src/commands/team/view.test.ts
+++ b/apps/cli/src/commands/team/view.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getTeam: vi.fn(),
@@ -54,12 +55,9 @@ describe("team view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getTeam.mockResolvedValue(sampleTeam);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { team: "1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Design Team"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { team: "1", json: "" } } as never);
+    }, "Design Team");
   });
 });

--- a/apps/cli/src/commands/user/activities.test.ts
+++ b/apps/cli/src/commands/user/activities.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getUserActivities: vi.fn(),
@@ -95,12 +96,9 @@ describe("user activities", () => {
       },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { activities } = await import("./activities");
-    await activities.run?.({ args: { user: "12345", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Test"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { activities } = await import("./activities");
+      await activities.run?.({ args: { user: "12345", json: "" } } as never);
+    }, "Test");
   });
 });

--- a/apps/cli/src/commands/user/list.test.ts
+++ b/apps/cli/src/commands/user/list.test.ts
@@ -51,11 +51,4 @@ describe("user list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "user1");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getUsers.mockRejectedValue(new Error("Unauthorized"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
-  });
 });

--- a/apps/cli/src/commands/user/list.test.ts
+++ b/apps/cli/src/commands/user/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getUsers: vi.fn(),
@@ -45,12 +46,9 @@ describe("user list", () => {
       { id: 1, userId: "user1", name: "User One", roleType: 1 },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("user1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { json: "" } } as never);
+    }, "user1");
   });
 });

--- a/apps/cli/src/commands/user/list.test.ts
+++ b/apps/cli/src/commands/user/list.test.ts
@@ -51,4 +51,11 @@ describe("user list", () => {
       await list.run?.({ args: { json: "" } } as never);
     }, "user1");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getUsers.mockRejectedValue(new Error("Unauthorized"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: {} } as never)).rejects.toThrow("Unauthorized");
+  });
 });

--- a/apps/cli/src/commands/user/me.test.ts
+++ b/apps/cli/src/commands/user/me.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getMyself: vi.fn(),
@@ -41,12 +42,9 @@ describe("user me", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getMyself.mockResolvedValue(sampleUser);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { me } = await import("./me");
-    await me.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("myself"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { me } = await import("./me");
+      await me.run?.({ args: { json: "" } } as never);
+    }, "myself");
   });
 });

--- a/apps/cli/src/commands/user/view.test.ts
+++ b/apps/cli/src/commands/user/view.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getUser: vi.fn(),
@@ -51,12 +52,9 @@ describe("user view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getUser.mockResolvedValue(sampleUser);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { user: "12345", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("testuser"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { user: "12345", json: "" } } as never);
+    }, "testuser");
   });
 });

--- a/apps/cli/src/commands/watching/add.test.ts
+++ b/apps/cli/src/commands/watching/add.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postWatchingListItem: vi.fn(),
@@ -52,12 +53,9 @@ describe("watching add", () => {
       issue: { issueKey: "TEST-1", summary: "Fix bug" },
     });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { add } = await import("./add");
-    await add.run?.({ args: { issue: "TEST-1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { add } = await import("./add");
+      await add.run?.({ args: { issue: "TEST-1", json: "" } } as never);
+    }, "TEST-1");
   });
 });

--- a/apps/cli/src/commands/watching/delete.test.ts
+++ b/apps/cli/src/commands/watching/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deletehWatchingListItem: vi.fn(),
@@ -56,14 +57,11 @@ describe("watching delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deletehWatchingListItem.mockResolvedValue({ id: 1 });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteWatching } = await import("./delete");
-    await deleteWatching.run?.({
-      args: { watching: "1", yes: true, json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteWatching } = await import("./delete");
+      await deleteWatching.run?.({
+        args: { watching: "1", yes: true, json: "" },
+      } as never);
+    }, "1");
   });
 });

--- a/apps/cli/src/commands/watching/delete.test.ts
+++ b/apps/cli/src/commands/watching/delete.test.ts
@@ -41,7 +41,10 @@ describe("watching delete", () => {
     const { deleteWatching } = await import("./delete");
     await deleteWatching.run?.({ args: { watching: "1", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete watching 1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/watching/list.test.ts
+++ b/apps/cli/src/commands/watching/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWatchingListItems: vi.fn(),
@@ -54,12 +55,9 @@ describe("watching list", () => {
     mockClient.getMyself.mockResolvedValue({ id: 100 });
     mockClient.getWatchingListItems.mockResolvedValue(sampleWatchings);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { json: "" } } as never);
+    }, "TEST-1");
   });
 });

--- a/apps/cli/src/commands/watching/read.test.ts
+++ b/apps/cli/src/commands/watching/read.test.ts
@@ -23,4 +23,20 @@ describe("watching read", () => {
     expect(mockClient.resetWatchingListItemAsRead).toHaveBeenCalledWith(12_345);
     expect(consola.success).toHaveBeenCalledWith("Marked watching 12345 as read.");
   });
+
+  it("converts string ID to number", async () => {
+    mockClient.resetWatchingListItemAsRead.mockResolvedValue(undefined);
+
+    const { read } = await import("./read");
+    await read.run?.({ args: { watching: "42" } } as never);
+
+    expect(mockClient.resetWatchingListItemAsRead).toHaveBeenCalledWith(42);
+  });
+
+  it("propagates API errors", async () => {
+    mockClient.resetWatchingListItemAsRead.mockRejectedValue(new Error("Not found"));
+
+    const { read } = await import("./read");
+    await expect(read.run?.({ args: { watching: "999" } } as never)).rejects.toThrow("Not found");
+  });
 });

--- a/apps/cli/src/commands/watching/read.test.ts
+++ b/apps/cli/src/commands/watching/read.test.ts
@@ -32,11 +32,4 @@ describe("watching read", () => {
 
     expect(mockClient.resetWatchingListItemAsRead).toHaveBeenCalledWith(42);
   });
-
-  it("propagates API errors", async () => {
-    mockClient.resetWatchingListItemAsRead.mockRejectedValue(new Error("Not found"));
-
-    const { read } = await import("./read");
-    await expect(read.run?.({ args: { watching: "999" } } as never)).rejects.toThrow("Not found");
-  });
 });

--- a/apps/cli/src/commands/watching/view.test.ts
+++ b/apps/cli/src/commands/watching/view.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWatchingListItem: vi.fn(),
@@ -39,12 +40,9 @@ describe("watching view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getWatchingListItem.mockResolvedValue(sampleWatching);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { watching: "1", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("TEST-1"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { watching: "1", json: "" } } as never);
+    }, "TEST-1");
   });
 });

--- a/apps/cli/src/commands/webhook/create.test.ts
+++ b/apps/cli/src/commands/webhook/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postWebhook: vi.fn(),
@@ -85,19 +86,16 @@ describe("webhook create", () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("Hook");
     mockClient.postWebhook.mockResolvedValue({ id: 1, name: "Hook" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({
-      args: {
-        project: "TEST",
-        name: "Hook",
-        "hook-url": "https://example.com/hook",
-        json: "",
-      },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Hook"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({
+        args: {
+          project: "TEST",
+          name: "Hook",
+          "hook-url": "https://example.com/hook",
+          json: "",
+        },
+      } as never);
+    }, "Hook");
   });
 });

--- a/apps/cli/src/commands/webhook/delete.test.ts
+++ b/apps/cli/src/commands/webhook/delete.test.ts
@@ -41,7 +41,10 @@ describe("webhook delete", () => {
     const { deleteWebhook } = await import("./delete");
     await deleteWebhook.run?.({ args: { webhook: "1", project: "TEST", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete webhook 1? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/webhook/delete.test.ts
+++ b/apps/cli/src/commands/webhook/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteWebhook: vi.fn(),
@@ -56,14 +57,11 @@ describe("webhook delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteWebhook.mockResolvedValue({ id: 1, name: "Deploy Hook" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteWebhook } = await import("./delete");
-    await deleteWebhook.run?.({
-      args: { webhook: "1", project: "TEST", yes: true, json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Deploy Hook"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteWebhook } = await import("./delete");
+      await deleteWebhook.run?.({
+        args: { webhook: "1", project: "TEST", yes: true, json: "" },
+      } as never);
+    }, "Deploy Hook");
   });
 });

--- a/apps/cli/src/commands/webhook/edit.test.ts
+++ b/apps/cli/src/commands/webhook/edit.test.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchWebhook: vi.fn(),
@@ -64,14 +65,11 @@ describe("webhook edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchWebhook.mockResolvedValue({ id: 1, name: "Hook" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({
-      args: { webhook: "1", project: "TEST", name: "Hook", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Hook"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({
+        args: { webhook: "1", project: "TEST", name: "Hook", json: "" },
+      } as never);
+    }, "Hook");
   });
 });

--- a/apps/cli/src/commands/webhook/list.test.ts
+++ b/apps/cli/src/commands/webhook/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWebhooks: vi.fn(),
@@ -43,12 +44,9 @@ describe("webhook list", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getWebhooks.mockResolvedValue(sampleWebhooks);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Deploy Hook"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "Deploy Hook");
   });
 });

--- a/apps/cli/src/commands/webhook/list.test.ts
+++ b/apps/cli/src/commands/webhook/list.test.ts
@@ -49,4 +49,11 @@ describe("webhook list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Deploy Hook");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getWebhooks.mockRejectedValue(new Error("Forbidden"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Forbidden");
+  });
 });

--- a/apps/cli/src/commands/webhook/list.test.ts
+++ b/apps/cli/src/commands/webhook/list.test.ts
@@ -49,11 +49,4 @@ describe("webhook list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Deploy Hook");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getWebhooks.mockRejectedValue(new Error("Forbidden"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Forbidden");
-  });
 });

--- a/apps/cli/src/commands/webhook/view.test.ts
+++ b/apps/cli/src/commands/webhook/view.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWebhook: vi.fn(),
@@ -39,12 +40,9 @@ describe("webhook view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getWebhook.mockResolvedValue(sampleWebhook);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { webhook: "1", project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Deploy Hook"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { webhook: "1", project: "TEST", json: "" } } as never);
+    }, "Deploy Hook");
   });
 });

--- a/apps/cli/src/commands/wiki/attachments.test.ts
+++ b/apps/cli/src/commands/wiki/attachments.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWikisAttachments: vi.fn(),
@@ -58,12 +59,9 @@ describe("wiki attachments", () => {
       },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { attachments } = await import("./attachments");
-    await attachments.run?.({ args: { wiki: "123", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("doc.pdf"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { attachments } = await import("./attachments");
+      await attachments.run?.({ args: { wiki: "123", json: "" } } as never);
+    }, "doc.pdf");
   });
 });

--- a/apps/cli/src/commands/wiki/count.test.ts
+++ b/apps/cli/src/commands/wiki/count.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWikisCount: vi.fn(),
@@ -27,12 +28,9 @@ describe("wiki count", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getWikisCount.mockResolvedValue({ count: 42 });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { count } = await import("./count");
-    await count.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("42"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { count } = await import("./count");
+      await count.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "42");
   });
 });

--- a/apps/cli/src/commands/wiki/create.test.ts
+++ b/apps/cli/src/commands/wiki/create.test.ts
@@ -1,6 +1,7 @@
 import { promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   postWiki: vi.fn(),
@@ -85,14 +86,11 @@ describe("wiki create", () => {
     mockClient.getProjects.mockResolvedValue([{ id: 100, projectKey: "TEST" }]);
     mockClient.postWiki.mockResolvedValue({ id: 1, name: "My Page" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { create } = await import("./create");
-    await create.run?.({
-      args: { project: "TEST", name: "My Page", body: "Hello", json: "" },
-    } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("My Page"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { create } = await import("./create");
+      await create.run?.({
+        args: { project: "TEST", name: "My Page", body: "Hello", json: "" },
+      } as never);
+    }, "My Page");
   });
 });

--- a/apps/cli/src/commands/wiki/delete.test.ts
+++ b/apps/cli/src/commands/wiki/delete.test.ts
@@ -41,7 +41,10 @@ describe("wiki delete", () => {
     const { deleteWiki } = await import("./delete");
     await deleteWiki.run?.({ args: { wiki: "123", yes: true } } as never);
 
-    expect(confirmOrExit).toHaveBeenCalledWith(expect.any(String), true);
+    expect(confirmOrExit).toHaveBeenCalledWith(
+      "Are you sure you want to delete wiki page 123? This cannot be undone.",
+      true,
+    );
   });
 
   it("cancels when user declines confirmation", async () => {

--- a/apps/cli/src/commands/wiki/delete.test.ts
+++ b/apps/cli/src/commands/wiki/delete.test.ts
@@ -1,6 +1,7 @@
 import { confirmOrExit } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   deleteWiki: vi.fn(),
@@ -66,12 +67,9 @@ describe("wiki delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteWiki.mockResolvedValue({ id: 123, name: "Old Page" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { deleteWiki } = await import("./delete");
-    await deleteWiki.run?.({ args: { wiki: "123", yes: true, json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Old Page"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { deleteWiki } = await import("./delete");
+      await deleteWiki.run?.({ args: { wiki: "123", yes: true, json: "" } } as never);
+    }, "Old Page");
   });
 });

--- a/apps/cli/src/commands/wiki/edit.test.ts
+++ b/apps/cli/src/commands/wiki/edit.test.ts
@@ -1,6 +1,7 @@
 import { resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   patchWiki: vi.fn(),
@@ -74,12 +75,9 @@ describe("wiki edit", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchWiki.mockResolvedValue({ id: 123, name: "Page" });
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { edit } = await import("./edit");
-    await edit.run?.({ args: { wiki: "123", name: "Page", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Page"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { edit } = await import("./edit");
+      await edit.run?.({ args: { wiki: "123", name: "Page", json: "" } } as never);
+    }, "Page");
   });
 });

--- a/apps/cli/src/commands/wiki/history.test.ts
+++ b/apps/cli/src/commands/wiki/history.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWikisHistory: vi.fn(),
@@ -75,12 +76,9 @@ describe("wiki history", () => {
       { version: 1, createdUser: { name: "Alice" }, created: "2025-01-01T00:00:00Z" },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { history } = await import("./history");
-    await history.run?.({ args: { wiki: "123", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Alice"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { history } = await import("./history");
+      await history.run?.({ args: { wiki: "123", json: "" } } as never);
+    }, "Alice");
   });
 });

--- a/apps/cli/src/commands/wiki/list.test.ts
+++ b/apps/cli/src/commands/wiki/list.test.ts
@@ -64,11 +64,4 @@ describe("wiki list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Home");
   });
-
-  it("propagates API errors", async () => {
-    mockClient.getWikis.mockRejectedValue(new Error("Forbidden"));
-
-    const { list } = await import("./list");
-    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Forbidden");
-  });
 });

--- a/apps/cli/src/commands/wiki/list.test.ts
+++ b/apps/cli/src/commands/wiki/list.test.ts
@@ -64,4 +64,11 @@ describe("wiki list", () => {
       await list.run?.({ args: { project: "TEST", json: "" } } as never);
     }, "Home");
   });
+
+  it("propagates API errors", async () => {
+    mockClient.getWikis.mockRejectedValue(new Error("Forbidden"));
+
+    const { list } = await import("./list");
+    await expect(list.run?.({ args: { project: "TEST" } } as never)).rejects.toThrow("Forbidden");
+  });
 });

--- a/apps/cli/src/commands/wiki/list.test.ts
+++ b/apps/cli/src/commands/wiki/list.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWikis: vi.fn(),
@@ -58,12 +59,9 @@ describe("wiki list", () => {
       { id: 1, name: "Home", updated: "2025-01-01T00:00:00Z" },
     ]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { list } = await import("./list");
-    await list.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Home"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { list } = await import("./list");
+      await list.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "Home");
   });
 });

--- a/apps/cli/src/commands/wiki/tags.test.ts
+++ b/apps/cli/src/commands/wiki/tags.test.ts
@@ -1,6 +1,7 @@
 import { getClient } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWikisTags: vi.fn(),
@@ -40,12 +41,9 @@ describe("wiki tags", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getWikisTags.mockResolvedValue([{ id: 1, name: "guide" }]);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { tags } = await import("./tags");
-    await tags.run?.({ args: { project: "TEST", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("guide"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { tags } = await import("./tags");
+      await tags.run?.({ args: { project: "TEST", json: "" } } as never);
+    }, "guide");
   });
 });

--- a/apps/cli/src/commands/wiki/view.test.ts
+++ b/apps/cli/src/commands/wiki/view.test.ts
@@ -1,6 +1,7 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
 import { describe, expect, it, vi } from "vitest";
+import { expectStdoutContaining } from "@repo/test-utils";
 
 const mockClient = {
   getWiki: vi.fn(),
@@ -55,13 +56,10 @@ describe("wiki view", () => {
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getWiki.mockResolvedValue(sampleWiki);
 
-    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-
-    const { view } = await import("./view");
-    await view.run?.({ args: { wiki: "123", json: "" } } as never);
-
-    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining("Home"));
-    writeSpy.mockRestore();
+    await expectStdoutContaining(async () => {
+      const { view } = await import("./view");
+      await view.run?.({ args: { wiki: "123", json: "" } } as never);
+    }, "Home");
   });
 
   it("handles wiki page with no tags", async () => {

--- a/packages/backlog-utils/src/api-error.test.ts
+++ b/packages/backlog-utils/src/api-error.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi, beforeEach } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import consola from "consola";
 import {
   formatBacklogError,
@@ -7,16 +7,7 @@ import {
   errorCodeName,
 } from "./api-error";
 
-vi.mock("consola", () => ({
-  default: {
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("errorCodeName", () => {
   test("returns error name for known code", () => {

--- a/packages/backlog-utils/vitest.config.ts
+++ b/packages/backlog-utils/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "backlog-utils",
+    setupFiles: ["@repo/test-utils/setup"],
   },
 });

--- a/packages/cli-utils/src/definition-list.test.ts
+++ b/packages/cli-utils/src/definition-list.test.ts
@@ -1,27 +1,19 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import consola from "consola";
 import { printDefinitionList } from "./definition-list";
 
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
 describe("printDefinitionList", () => {
-  const logSpy = vi.spyOn(consola, "log").mockImplementation(() => {});
-
-  beforeEach(() => {
-    logSpy.mockClear();
-  });
-
-  afterEach(() => {
-    logSpy.mockClear();
-  });
-
   it("prints labels padded to the longest label width", () => {
     printDefinitionList([
       ["Status", "Active"],
       ["Text Formatting", "markdown"],
     ]);
 
-    expect(logSpy).toHaveBeenCalledTimes(2);
-    expect(logSpy).toHaveBeenCalledWith("    Status           Active");
-    expect(logSpy).toHaveBeenCalledWith("    Text Formatting  markdown");
+    expect(consola.log).toHaveBeenCalledTimes(2);
+    expect(consola.log).toHaveBeenCalledWith("    Status           Active");
+    expect(consola.log).toHaveBeenCalledWith("    Text Formatting  markdown");
   });
 
   it("skips items with null or undefined values", () => {
@@ -32,9 +24,9 @@ describe("printDefinitionList", () => {
       ["Type", "Bug"],
     ]);
 
-    expect(logSpy).toHaveBeenCalledTimes(2);
-    expect(logSpy).toHaveBeenCalledWith("    Status  Active");
-    expect(logSpy).toHaveBeenCalledWith("    Type    Bug");
+    expect(consola.log).toHaveBeenCalledTimes(2);
+    expect(consola.log).toHaveBeenCalledWith("    Status  Active");
+    expect(consola.log).toHaveBeenCalledWith("    Type    Bug");
   });
 
   it("skips items with empty string values", () => {
@@ -43,8 +35,8 @@ describe("printDefinitionList", () => {
       ["Note", ""],
     ]);
 
-    expect(logSpy).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith("    Status  Active");
+    expect(consola.log).toHaveBeenCalledTimes(1);
+    expect(consola.log).toHaveBeenCalledWith("    Status  Active");
   });
 
   it("does nothing when all items are filtered out", () => {
@@ -53,18 +45,18 @@ describe("printDefinitionList", () => {
       ["B", undefined],
     ]);
 
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(consola.log).not.toHaveBeenCalled();
   });
 
   it("does nothing for empty array", () => {
     printDefinitionList([]);
 
-    expect(logSpy).not.toHaveBeenCalled();
+    expect(consola.log).not.toHaveBeenCalled();
   });
 
   it("respects custom indent", () => {
     printDefinitionList([["Name", "Test"]], 2);
 
-    expect(logSpy).toHaveBeenCalledWith("  Name  Test");
+    expect(consola.log).toHaveBeenCalledWith("  Name  Test");
   });
 });

--- a/packages/cli-utils/src/validation-error.test.ts
+++ b/packages/cli-utils/src/validation-error.test.ts
@@ -1,18 +1,9 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as v from "valibot";
 import consola from "consola";
 import { handleValidationError } from "./validation-error";
 
-vi.mock("consola", () => ({
-  default: {
-    error: vi.fn(),
-    debug: vi.fn(),
-  },
-}));
-
-beforeEach(() => {
-  vi.clearAllMocks();
-});
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("handleValidationError", () => {
   it("returns false for non-ValiError", () => {

--- a/packages/cli-utils/vitest.config.ts
+++ b/packages/cli-utils/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     name: "cli-utils",
+    setupFiles: ["@repo/test-utils/setup"],
   },
 });

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -3,3 +3,4 @@ export type { MockClient } from "./mock-client";
 export { setupMockConsola } from "./mock-consola";
 export type { MockConsola } from "./mock-consola";
 export { spyOnProcessExit } from "./process";
+export { expectStdoutContaining } from "./stdout";

--- a/packages/test-utils/src/stdout.ts
+++ b/packages/test-utils/src/stdout.ts
@@ -1,0 +1,18 @@
+import { vi, expect } from "vitest";
+
+/**
+ * Captures stdout.write calls during the callback and asserts the output
+ * contains the expected string. Used for JSON output tests.
+ */
+export const expectStdoutContaining = async (
+  fn: () => Promise<void>,
+  expected: string,
+): Promise<void> => {
+  const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  try {
+    await fn();
+    expect(writeSpy).toHaveBeenCalledWith(expect.stringContaining(expected));
+  } finally {
+    writeSpy.mockRestore();
+  }
+};


### PR DESCRIPTION
## Summary

- Extract `expectStdoutContaining` helper into `@repo/test-utils` to replace the repeated `vi.spyOn(process.stdout, "write")` / assert / restore pattern across ~60 test cases
- Remove redundant `setupMocks()` functions from 13 test files where `vi.mock()` factories already provide the same mock values
- Unify consola mocking by adopting centralized `mock-consola` from `@repo/test-utils` in `backlog-utils` and `cli-utils` package tests
- Add `setupFiles: ["@repo/test-utils/setup"]` to `backlog-utils` and `cli-utils` vitest configs for automatic `vi.clearAllMocks()` between tests
- Strengthen weak assertions: replace `expect.any(String)` with exact confirmation message strings in delete/destructive-action tests
- Remove 19 low-value "propagates API errors" tests that only verified JavaScript's default error propagation behavior
- Add meaningful error path tests: unknown priority/status validation (issue create/edit/count, pr count), missing body and no own comment errors (issue comment), `--web` without `--project` error (document view)

## Test plan

### Automated

- [x] `pnpm run test` — all 474 CLI tests pass (was 485, removed 19, added 8)
- [x] `pnpm run typecheck` — no type errors introduced

### Manual verification

- [x] Run `pnpm --filter @repo/backlog-utils exec vitest run` — verify tests pass with new `setupFiles` config (7 files, 79 tests passed)
- [x] Run `pnpm --filter @repo/cli-utils exec vitest run` — verify tests pass with new `setupFiles` config (6 files, 63 tests passed)
- [x] Run `pnpm --filter @nulab/bee exec vitest run` — verify all CLI command tests pass after `setupMocks` removal (104 files, 474 tests passed)
- [x] Run `pnpm --filter @nulab/bee exec vitest run src/commands/api.test.ts` — verify `expectStdoutContaining` works for non-JSON stdout output
- [x] Run `pnpm --filter @nulab/bee exec vitest run src/commands/category/delete.test.ts` — verify strengthened confirmation message assertions
- [x] Run `pnpm --filter @nulab/bee exec vitest run src/commands/pr/comment.test.ts` — verify new error path tests for missing body
- [x] Run `pnpm --filter @nulab/bee exec vitest run src/commands/pr/edit.test.ts` — verify `@me` resolution test

### Live testing (simochee.backlog.com)

- [x] `auth status` — authenticated correctly
- [x] `space info` — space info displayed correctly
- [x] `project list` / `project list --json` — table and JSON output both work
- [x] `issue list -p PLAY_GROUND` / `--json` — table and JSON output both work
- [x] `user list` — user list displayed correctly
- [x] `api /api/v2/users/myself` — stdout output (non-JSON flag mode) works correctly
- [x] `notification list` — notifications displayed correctly
- [x] `star list` — stars displayed correctly
- [x] `category list PLAY_GROUND` — categories displayed correctly
- [x] `status list PLAY_GROUND` — statuses displayed correctly
- [x] `dashboard` — dashboard displayed correctly