### PR TITLE
Add prerelease support to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,28 +124,19 @@ jobs:
           path: apps/cli
 
       - name: Publish to npm
-        if: inputs.environment != 'dry-run'
         working-directory: apps/cli
         env:
           PRERELEASE: ${{ inputs.prerelease }}
+          DRY_RUN: ${{ inputs.environment == 'dry-run' }}
         run: |
+          flags="--provenance --access public"
           if [ "$PRERELEASE" = "true" ]; then
-            npm publish --provenance --access public --tag rc
-          else
-            npm publish --provenance --access public
+            flags="$flags --tag rc"
           fi
-
-      - name: Publish dry run
-        if: inputs.environment == 'dry-run'
-        working-directory: apps/cli
-        env:
-          PRERELEASE: ${{ inputs.prerelease }}
-        run: |
-          if [ "$PRERELEASE" = "true" ]; then
-            npm publish --provenance --access public --dry-run --tag rc
-          else
-            npm publish --provenance --access public --dry-run
+          if [ "$DRY_RUN" = "true" ]; then
+            flags="$flags --dry-run"
           fi
+          npm publish $flags
 
       - name: Configure git
         if: inputs.environment != 'dry-run'
@@ -166,28 +157,13 @@ jobs:
           git push origin "${NEW_TAG}"
 
       - name: Create GitHub release
-        if: inputs.environment != 'dry-run'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
           PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
           PRERELEASE: ${{ inputs.prerelease }}
-        run: |
-          if [ "$PRERELEASE" = "true" ]; then
-            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG" --prerelease
-          else
-            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_STABLE_TAG"
-          fi
-
-      - name: Preview release notes (dry-run)
-        if: inputs.environment == 'dry-run'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_TAG: ${{ needs.build.outputs.new_tag }}
-          PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
-          PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
-          PRERELEASE: ${{ inputs.prerelease }}
+          DRY_RUN: ${{ inputs.environment == 'dry-run' }}
           REPOSITORY: ${{ github.repository }}
           TARGET_COMMITISH: ${{ github.sha }}
         run: |
@@ -197,10 +173,18 @@ jobs:
             notes_start_tag="$PREVIOUS_STABLE_TAG"
           fi
 
-          echo "## Release notes for ${NEW_TAG}" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          gh api "repos/${REPOSITORY}/releases/generate-notes" \
-            -f tag_name="$NEW_TAG" \
-            -f target_commitish="$TARGET_COMMITISH" \
-            -f previous_tag_name="$notes_start_tag" \
-            --jq '.body' >> "$GITHUB_STEP_SUMMARY"
+          if [ "$DRY_RUN" = "true" ]; then
+            echo "## Release notes for ${NEW_TAG}" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            gh api "repos/${REPOSITORY}/releases/generate-notes" \
+              -f tag_name="$NEW_TAG" \
+              -f target_commitish="$TARGET_COMMITISH" \
+              -f previous_tag_name="$notes_start_tag" \
+              --jq '.body' >> "$GITHUB_STEP_SUMMARY"
+          else
+            flags="--generate-notes --notes-start-tag $notes_start_tag"
+            if [ "$PRERELEASE" = "true" ]; then
+              flags="$flags --prerelease"
+            fi
+            gh release create "$NEW_TAG" $flags
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ on:
         description: Release as rc (prerelease)
         default: false
 
+env:
+  PRERELEASE: ${{ inputs.prerelease }}
+  DRY_RUN: ${{ inputs.environment == 'dry-run' }}
+
 permissions:
   contents: read
 
@@ -70,8 +74,7 @@ jobs:
         working-directory: apps/cli
         env:
           LATEST_TAG: ${{ steps.get_latest_tag.outputs.latest_tag }}
-          NEW_VERSION_TYPE: ${{ github.event.inputs.newversion }}
-          PRERELEASE: ${{ github.event.inputs.prerelease }}
+          NEW_VERSION_TYPE: ${{ inputs.newversion }}
         run: |
           npm version "$LATEST_TAG" --no-git-tag-version --allow-same-version
 
@@ -110,6 +113,10 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    env:
+      NEW_TAG: ${{ needs.build.outputs.new_tag }}
+      PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
+      PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -125,9 +132,6 @@ jobs:
 
       - name: Publish to npm
         working-directory: apps/cli
-        env:
-          PRERELEASE: ${{ inputs.prerelease }}
-          DRY_RUN: ${{ inputs.environment == 'dry-run' }}
         run: |
           flags="--provenance --access public"
           if [ "$PRERELEASE" = "true" ]; then
@@ -147,7 +151,6 @@ jobs:
       - name: Push version commit and tag
         if: inputs.environment != 'dry-run'
         env:
-          NEW_TAG: ${{ needs.build.outputs.new_tag }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           git add apps/cli/package.json
@@ -159,11 +162,6 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NEW_TAG: ${{ needs.build.outputs.new_tag }}
-          PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
-          PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
-          PRERELEASE: ${{ inputs.prerelease }}
-          DRY_RUN: ${{ inputs.environment == 'dry-run' }}
           REPOSITORY: ${{ github.repository }}
           TARGET_COMMITISH: ${{ github.sha }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ on:
         default: false
 
 env:
+  NEW_VERSION_TYPE: ${{ inputs.newversion }}
   PRERELEASE: ${{ inputs.prerelease }}
   DRY_RUN: ${{ inputs.environment == 'dry-run' }}
 
@@ -74,7 +75,6 @@ jobs:
         working-directory: apps/cli
         env:
           LATEST_TAG: ${{ steps.get_latest_tag.outputs.latest_tag }}
-          NEW_VERSION_TYPE: ${{ inputs.newversion }}
         run: |
           npm version "$LATEST_TAG" --no-git-tag-version --allow-same-version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
     outputs:
       new_tag: ${{ steps.bump_version.outputs.new_tag }}
       previous_tag: ${{ steps.get_latest_tag.outputs.latest_tag }}
+      previous_stable_tag: ${{ steps.get_latest_tag.outputs.latest_stable_tag }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -63,6 +64,10 @@ jobs:
         run: |
           latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+
+          latest_stable_tag=$(git tag --list 'v*' --sort=-v:refname | grep -v '-' | head -n 1)
+          latest_stable_tag="${latest_stable_tag:-v0.0.0}"
+          echo "latest_stable_tag=${latest_stable_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Bump version
         id: bump_version
@@ -170,12 +175,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
+          PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
           PRERELEASE: ${{ inputs.prerelease }}
         run: |
           if [ -n "$PRERELEASE" ]; then
             gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG" --prerelease
           else
-            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG"
+            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_STABLE_TAG"
           fi
 
       - name: Preview release notes (dry-run)
@@ -184,13 +190,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
+          PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
+          PRERELEASE: ${{ inputs.prerelease }}
           REPOSITORY: ${{ github.repository }}
           TARGET_COMMITISH: ${{ github.sha }}
         run: |
+          if [ -n "$PRERELEASE" ]; then
+            notes_start_tag="$PREVIOUS_TAG"
+          else
+            notes_start_tag="$PREVIOUS_STABLE_TAG"
+          fi
+
           echo "## Release notes for ${NEW_TAG}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           gh api "repos/${REPOSITORY}/releases/generate-notes" \
             -f tag_name="$NEW_TAG" \
             -f target_commitish="$TARGET_COMMITISH" \
-            -f previous_tag_name="$PREVIOUS_TAG" \
+            -f previous_tag_name="$notes_start_tag" \
             --jq '.body' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,17 +17,12 @@ on:
           - patch
           - minor
           - major
-        description: New version
+          - preminor
+          - premajor
+          - prerelease
+        description: New version (preminor/premajor create rc, prerelease bumps rc number)
         default: patch
         required: true
-      prerelease:
-        type: choice
-        options:
-          - ''
-          - rc
-        description: Prerelease tag (leave empty for stable release)
-        default: ''
-        required: false
 
 permissions:
   contents: read
@@ -75,20 +70,17 @@ jobs:
         env:
           LATEST_TAG: ${{ steps.get_latest_tag.outputs.latest_tag }}
           NEW_VERSION_TYPE: ${{ github.event.inputs.newversion }}
-          PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
           npm version "$LATEST_TAG" --no-git-tag-version --allow-same-version
 
-          if [ -n "$PRERELEASE" ]; then
-            current_version=$(node -p "require('./package.json').version")
-            if echo "$current_version" | grep -q -- "-${PRERELEASE}\."; then
-              npm version prerelease --preid "$PRERELEASE" --no-git-tag-version
-            else
-              npm version "pre${NEW_VERSION_TYPE}" --preid "$PRERELEASE" --no-git-tag-version
-            fi
-          else
-            npm version "$NEW_VERSION_TYPE" --no-git-tag-version
-          fi
+          case "$NEW_VERSION_TYPE" in
+            preminor|premajor|prerelease)
+              npm version "$NEW_VERSION_TYPE" --preid rc --no-git-tag-version
+              ;;
+            *)
+              npm version "$NEW_VERSION_TYPE" --no-git-tag-version
+              ;;
+          esac
 
           new_version=$(node -p "require('./package.json').version")
           new_tag="v${new_version}"
@@ -131,25 +123,31 @@ jobs:
         if: inputs.environment != 'dry-run'
         working-directory: apps/cli
         env:
-          PRERELEASE: ${{ inputs.prerelease }}
+          NEW_VERSION_TYPE: ${{ inputs.newversion }}
         run: |
-          if [ -n "$PRERELEASE" ]; then
-            npm publish --provenance --access public --tag "$PRERELEASE"
-          else
-            npm publish --provenance --access public
-          fi
+          case "$NEW_VERSION_TYPE" in
+            preminor|premajor|prerelease)
+              npm publish --provenance --access public --tag rc
+              ;;
+            *)
+              npm publish --provenance --access public
+              ;;
+          esac
 
       - name: Publish dry run
         if: inputs.environment == 'dry-run'
         working-directory: apps/cli
         env:
-          PRERELEASE: ${{ inputs.prerelease }}
+          NEW_VERSION_TYPE: ${{ inputs.newversion }}
         run: |
-          if [ -n "$PRERELEASE" ]; then
-            npm publish --provenance --access public --dry-run --tag "$PRERELEASE"
-          else
-            npm publish --provenance --access public --dry-run
-          fi
+          case "$NEW_VERSION_TYPE" in
+            preminor|premajor|prerelease)
+              npm publish --provenance --access public --dry-run --tag rc
+              ;;
+            *)
+              npm publish --provenance --access public --dry-run
+              ;;
+          esac
 
       - name: Configure git
         if: inputs.environment != 'dry-run'
@@ -176,13 +174,16 @@ jobs:
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
           PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
-          PRERELEASE: ${{ inputs.prerelease }}
+          NEW_VERSION_TYPE: ${{ inputs.newversion }}
         run: |
-          if [ -n "$PRERELEASE" ]; then
-            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG" --prerelease
-          else
-            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_STABLE_TAG"
-          fi
+          case "$NEW_VERSION_TYPE" in
+            preminor|premajor|prerelease)
+              gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG" --prerelease
+              ;;
+            *)
+              gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_STABLE_TAG"
+              ;;
+          esac
 
       - name: Preview release notes (dry-run)
         if: inputs.environment == 'dry-run'
@@ -191,15 +192,18 @@ jobs:
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
           PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
-          PRERELEASE: ${{ inputs.prerelease }}
+          NEW_VERSION_TYPE: ${{ inputs.newversion }}
           REPOSITORY: ${{ github.repository }}
           TARGET_COMMITISH: ${{ github.sha }}
         run: |
-          if [ -n "$PRERELEASE" ]; then
-            notes_start_tag="$PREVIOUS_TAG"
-          else
-            notes_start_tag="$PREVIOUS_STABLE_TAG"
-          fi
+          case "$NEW_VERSION_TYPE" in
+            preminor|premajor|prerelease)
+              notes_start_tag="$PREVIOUS_TAG"
+              ;;
+            *)
+              notes_start_tag="$PREVIOUS_STABLE_TAG"
+              ;;
+          esac
 
           echo "## Release notes for ${NEW_TAG}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,14 @@ on:
         description: New version
         default: patch
         required: true
+      prerelease:
+        type: choice
+        options:
+          - ''
+          - rc
+        description: Prerelease tag (leave empty for stable release)
+        default: ''
+        required: false
 
 permissions:
   contents: read
@@ -62,9 +70,20 @@ jobs:
         env:
           LATEST_TAG: ${{ steps.get_latest_tag.outputs.latest_tag }}
           NEW_VERSION_TYPE: ${{ github.event.inputs.newversion }}
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
           npm version "$LATEST_TAG" --no-git-tag-version --allow-same-version
-          npm version "$NEW_VERSION_TYPE" --no-git-tag-version
+
+          if [ -n "$PRERELEASE" ]; then
+            current_version=$(node -p "require('./package.json').version")
+            if echo "$current_version" | grep -q -- "-${PRERELEASE}\."; then
+              npm version prerelease --preid "$PRERELEASE" --no-git-tag-version
+            else
+              npm version "pre${NEW_VERSION_TYPE}" --preid "$PRERELEASE" --no-git-tag-version
+            fi
+          else
+            npm version "$NEW_VERSION_TYPE" --no-git-tag-version
+          fi
 
           new_version=$(node -p "require('./package.json').version")
           new_tag="v${new_version}"
@@ -106,12 +125,26 @@ jobs:
       - name: Publish to npm
         if: inputs.environment != 'dry-run'
         working-directory: apps/cli
-        run: npm publish --provenance --access public
+        env:
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          if [ -n "$PRERELEASE" ]; then
+            npm publish --provenance --access public --tag "$PRERELEASE"
+          else
+            npm publish --provenance --access public
+          fi
 
       - name: Publish dry run
         if: inputs.environment == 'dry-run'
         working-directory: apps/cli
-        run: npm publish --provenance --access public --dry-run
+        env:
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          if [ -n "$PRERELEASE" ]; then
+            npm publish --provenance --access public --dry-run --tag "$PRERELEASE"
+          else
+            npm publish --provenance --access public --dry-run
+          fi
 
       - name: Configure git
         if: inputs.environment != 'dry-run'
@@ -137,7 +170,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
-        run: gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG"
+          PRERELEASE: ${{ inputs.prerelease }}
+        run: |
+          if [ -n "$PRERELEASE" ]; then
+            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG" --prerelease
+          else
+            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG"
+          fi
 
       - name: Preview release notes (dry-run)
         if: inputs.environment == 'dry-run'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,13 @@ on:
           - patch
           - minor
           - major
-          - preminor
-          - premajor
-          - prerelease
-        description: New version (preminor/premajor create rc, prerelease bumps rc number)
+        description: New version
         default: patch
         required: true
+      prerelease:
+        type: boolean
+        description: Release as rc (prerelease)
+        default: false
 
 permissions:
   contents: read
@@ -70,17 +71,20 @@ jobs:
         env:
           LATEST_TAG: ${{ steps.get_latest_tag.outputs.latest_tag }}
           NEW_VERSION_TYPE: ${{ github.event.inputs.newversion }}
+          PRERELEASE: ${{ github.event.inputs.prerelease }}
         run: |
           npm version "$LATEST_TAG" --no-git-tag-version --allow-same-version
 
-          case "$NEW_VERSION_TYPE" in
-            preminor|premajor|prerelease)
-              npm version "$NEW_VERSION_TYPE" --preid rc --no-git-tag-version
-              ;;
-            *)
-              npm version "$NEW_VERSION_TYPE" --no-git-tag-version
-              ;;
-          esac
+          if [ "$PRERELEASE" = "true" ]; then
+            current_version=$(node -p "require('./package.json').version")
+            if echo "$current_version" | grep -q -- "-rc\."; then
+              npm version prerelease --preid rc --no-git-tag-version
+            else
+              npm version "pre${NEW_VERSION_TYPE}" --preid rc --no-git-tag-version
+            fi
+          else
+            npm version "$NEW_VERSION_TYPE" --no-git-tag-version
+          fi
 
           new_version=$(node -p "require('./package.json').version")
           new_tag="v${new_version}"
@@ -123,31 +127,25 @@ jobs:
         if: inputs.environment != 'dry-run'
         working-directory: apps/cli
         env:
-          NEW_VERSION_TYPE: ${{ inputs.newversion }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
-          case "$NEW_VERSION_TYPE" in
-            preminor|premajor|prerelease)
-              npm publish --provenance --access public --tag rc
-              ;;
-            *)
-              npm publish --provenance --access public
-              ;;
-          esac
+          if [ "$PRERELEASE" = "true" ]; then
+            npm publish --provenance --access public --tag rc
+          else
+            npm publish --provenance --access public
+          fi
 
       - name: Publish dry run
         if: inputs.environment == 'dry-run'
         working-directory: apps/cli
         env:
-          NEW_VERSION_TYPE: ${{ inputs.newversion }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
-          case "$NEW_VERSION_TYPE" in
-            preminor|premajor|prerelease)
-              npm publish --provenance --access public --dry-run --tag rc
-              ;;
-            *)
-              npm publish --provenance --access public --dry-run
-              ;;
-          esac
+          if [ "$PRERELEASE" = "true" ]; then
+            npm publish --provenance --access public --dry-run --tag rc
+          else
+            npm publish --provenance --access public --dry-run
+          fi
 
       - name: Configure git
         if: inputs.environment != 'dry-run'
@@ -174,16 +172,13 @@ jobs:
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
           PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
-          NEW_VERSION_TYPE: ${{ inputs.newversion }}
+          PRERELEASE: ${{ inputs.prerelease }}
         run: |
-          case "$NEW_VERSION_TYPE" in
-            preminor|premajor|prerelease)
-              gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG" --prerelease
-              ;;
-            *)
-              gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_STABLE_TAG"
-              ;;
-          esac
+          if [ "$PRERELEASE" = "true" ]; then
+            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_TAG" --prerelease
+          else
+            gh release create "$NEW_TAG" --generate-notes --notes-start-tag "$PREVIOUS_STABLE_TAG"
+          fi
 
       - name: Preview release notes (dry-run)
         if: inputs.environment == 'dry-run'
@@ -192,18 +187,15 @@ jobs:
           NEW_TAG: ${{ needs.build.outputs.new_tag }}
           PREVIOUS_TAG: ${{ needs.build.outputs.previous_tag }}
           PREVIOUS_STABLE_TAG: ${{ needs.build.outputs.previous_stable_tag }}
-          NEW_VERSION_TYPE: ${{ inputs.newversion }}
+          PRERELEASE: ${{ inputs.prerelease }}
           REPOSITORY: ${{ github.repository }}
           TARGET_COMMITISH: ${{ github.sha }}
         run: |
-          case "$NEW_VERSION_TYPE" in
-            preminor|premajor|prerelease)
-              notes_start_tag="$PREVIOUS_TAG"
-              ;;
-            *)
-              notes_start_tag="$PREVIOUS_STABLE_TAG"
-              ;;
-          esac
+          if [ "$PRERELEASE" = "true" ]; then
+            notes_start_tag="$PREVIOUS_TAG"
+          else
+            notes_start_tag="$PREVIOUS_STABLE_TAG"
+          fi
 
           echo "## Release notes for ${NEW_TAG}" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,15 +78,15 @@ Dry-run mode publishes with `--dry-run` and skips git tag/push, so it's safe to 
 
 ### Input combinations
 
-| newversion | prerelease | Example result | npm tag |
-|---|---|---|---|
-| `minor` | unchecked | `1.0.0` → `1.1.0` | `latest` |
-| `major` | unchecked | `1.0.0` → `2.0.0` | `latest` |
-| `patch` | unchecked | `1.0.1` → `1.0.2` | `latest` |
-| `minor` | checked | `1.0.0` → `1.1.0-rc.0` | `rc` |
-| `major` | checked | `1.0.0` → `2.0.0-rc.0` | `rc` |
-| `minor` | checked | `1.1.0-rc.0` → `1.1.0-rc.1` (already rc: bumps rc number) | `rc` |
-| `minor` | unchecked | `1.1.0-rc.1` → `1.1.0` (promote to stable) | `latest` |
+| newversion | prerelease | Example result                                            | npm tag  |
+| ---------- | ---------- | --------------------------------------------------------- | -------- |
+| `minor`    | unchecked  | `1.0.0` → `1.1.0`                                         | `latest` |
+| `major`    | unchecked  | `1.0.0` → `2.0.0`                                         | `latest` |
+| `patch`    | unchecked  | `1.0.1` → `1.0.2`                                         | `latest` |
+| `minor`    | checked    | `1.0.0` → `1.1.0-rc.0`                                    | `rc`     |
+| `major`    | checked    | `1.0.0` → `2.0.0-rc.0`                                    | `rc`     |
+| `minor`    | checked    | `1.1.0-rc.0` → `1.1.0-rc.1` (already rc: bumps rc number) | `rc`     |
+| `minor`    | unchecked  | `1.1.0-rc.1` → `1.1.0` (promote to stable)                | `latest` |
 
 ## Documentation Site
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,15 +64,29 @@ pnpm --filter @nulab/bee build
 Releases are triggered manually via the [Release workflow](https://github.com/nulab/bee/actions/workflows/release.yml) (`workflow_dispatch`).
 
 1. Go to **Actions > Release > Run workflow**.
-2. Select the **environment** (`dry-run` or production).
-3. Select the **version bump** (`patch`, `minor`, or `major`).
-4. The workflow will:
+2. Select the inputs:
+   - **environment** — `dry-run` (default) or `production`
+   - **newversion** — `patch`, `minor`, or `major`
+   - **prerelease** — check to release as rc (prerelease)
+3. The workflow will:
    - Bump the version in `apps/cli/package.json`
    - Build the CLI
    - Publish to npm with provenance
    - Create a git tag and GitHub release with auto-generated notes
 
 Dry-run mode publishes with `--dry-run` and skips git tag/push, so it's safe to test.
+
+### Input combinations
+
+| newversion | prerelease | Example result | npm tag |
+|---|---|---|---|
+| `minor` | unchecked | `1.0.0` → `1.1.0` | `latest` |
+| `major` | unchecked | `1.0.0` → `2.0.0` | `latest` |
+| `patch` | unchecked | `1.0.1` → `1.0.2` | `latest` |
+| `minor` | checked | `1.0.0` → `1.1.0-rc.0` | `rc` |
+| `major` | checked | `1.0.0` → `2.0.0-rc.0` | `rc` |
+| `minor` | checked | `1.1.0-rc.0` → `1.1.0-rc.1` (already rc: bumps rc number) | `rc` |
+| `minor` | unchecked | `1.1.0-rc.1` → `1.1.0` (promote to stable) | `latest` |
 
 ## Documentation Site
 


### PR DESCRIPTION
## Summary

Adds support for creating prerelease versions in the release workflow. This allows publishing release candidates and other prerelease versions to npm with appropriate tags and GitHub release markers.

Changes include:
- New `prerelease` input parameter (choice between empty string for stable or 'rc' for release candidate)
- Updated version bumping logic to handle prerelease versioning using `npm version prerelease` or `npm version pre{major|minor|patch}`
- Conditional npm publish with `--tag` flag for prerelease versions
- Conditional GitHub release creation with `--prerelease` flag for prerelease versions
- Applied to both regular publish and dry-run publish steps

## Test plan

The release workflow can be tested by:
1. Triggering the workflow with `prerelease` set to empty string (stable release) - should behave as before
2. Triggering the workflow with `prerelease` set to 'rc' - should create rc-tagged versions and publish with appropriate npm and GitHub release tags
3. Verifying dry-run mode works correctly with prerelease versions

https://claude.ai/code/session_01ULoEJZPc1AfKpew9Pz8w9H