### PR TITLE
Simplify command help descriptions

### DIFF
--- a/apps/cli/src/commands/api.ts
+++ b/apps/cli/src/commands/api.ts
@@ -9,24 +9,11 @@ type Params = Record<string, ParamValue | ParamValue[]>;
 const api = new BeeCommand("api")
   .summary("Make an authenticated API request")
   .description(
-    `Make an authenticated Backlog API request.
+    `The endpoint is a Backlog API path (e.g. \`users/myself\`). A leading \`/api/v2/\` prefix is stripped automatically.
 
-The endpoint argument should be a path of the Backlog API
-(e.g. \`users/myself\`). If the path includes the \`/api/v2/\` prefix
-it is stripped automatically — both \`users/myself\` and
-\`/api/v2/users/myself\` work the same way.
+\`-f\` infers types (number, boolean, string); \`-F\` always sends strings. Repeated keys become arrays. Append \`[]\` for a single-element array (e.g. \`-f projectId[]=12345\`).
 
-Use \`--field\` / \`-f\` to pass parameters with automatic type inference:
-numeric strings become numbers, \`true\`/\`false\` become booleans, and
-everything else stays a string. Use \`--raw-field\` / \`-F\` to force a
-value to remain a string. Both flags can be specified multiple times.
-When the same key is repeated, values are collected into an array
-(e.g. \`-f statusId=1 -f statusId=2 -f statusId=3\`).
-To send a single-element array, append \`[]\` to the key name
-(e.g. \`-f projectId[]=12345\`).
-
-For GET requests, fields are sent as query parameters. For POST, PUT,
-PATCH, and DELETE requests, fields are sent as the request body.`,
+For GET, fields are query parameters. For POST/PUT/PATCH/DELETE, fields are the request body.`,
   )
   .argument("<endpoint>", "API endpoint path")
   .option("-X, --method <method>", "HTTP method", "GET")

--- a/apps/cli/src/commands/auth/login.ts
+++ b/apps/cli/src/commands/auth/login.ts
@@ -8,14 +8,10 @@ import { BeeCommand } from "../../lib/bee-command";
 const login = new BeeCommand("login")
   .summary("Authenticate with a Backlog space")
   .description(
-    `Authenticate with a Backlog space.
+    `The default mode is API key with interactive prompts.
 
-The default authentication mode is API key. You will be prompted to enter
-the space hostname and API key interactively.
-
-Alternatively, use \`--with-token\` to pass an API key on standard input.
-For OAuth authentication, use \`--method oauth\`. You will need to provide
-an OAuth Client ID and Client Secret, then authorize in the browser.`,
+Use \`--with-token\` to pass an API key on standard input.
+Use \`--method oauth\` for OAuth authentication via the browser.`,
   )
   .option("-m, --method <method>", "The authentication method to use", "api-key")
   .option("--with-token", "Read token from standard input")

--- a/apps/cli/src/commands/auth/logout.ts
+++ b/apps/cli/src/commands/auth/logout.ts
@@ -6,11 +6,7 @@ import { BeeCommand } from "../../lib/bee-command";
 const logout = new BeeCommand("logout")
   .summary("Remove authentication for a Backlog space")
   .description(
-    `Remove authentication for a Backlog space.
-
-The stored credentials are removed locally. This does not revoke API keys or OAuth tokens on the Backlog server.
-
-If only one space is configured, it will be selected automatically. If multiple spaces are configured, you will be prompted to select one.`,
+    `Removes stored credentials locally. Does not revoke API keys or OAuth tokens on the server.`,
   )
   .option("-s, --space <hostname>", "The hostname of the Backlog space")
   .envVars([["BACKLOG_SPACE", "Space hostname to log out from"]])

--- a/apps/cli/src/commands/auth/refresh.ts
+++ b/apps/cli/src/commands/auth/refresh.ts
@@ -8,11 +8,7 @@ import { BeeCommand } from "../../lib/bee-command";
 const refresh = new BeeCommand("refresh")
   .summary("Refresh OAuth token")
   .description(
-    `Refresh the OAuth access token for a Backlog space.
-
-Uses the stored refresh token to obtain a new access token. Only available for spaces authenticated with OAuth.
-
-If the refresh token is expired or invalid, re-authenticate with \`bee auth login -m oauth\`.`,
+    `Only available for spaces authenticated with OAuth. If the refresh token is expired, re-authenticate with \`bee auth login -m oauth\`.`,
   )
   .option("-s, --space <hostname>", "The hostname of the Backlog space")
   .envVars([["BACKLOG_SPACE", "Default space hostname"]])

--- a/apps/cli/src/commands/auth/status.ts
+++ b/apps/cli/src/commands/auth/status.ts
@@ -10,11 +10,7 @@ const getToken = (auth: RcAuth): string =>
 const status = new BeeCommand("status")
   .summary("Show authentication status")
   .description(
-    `Display authentication status for configured Backlog spaces.
-
-For each space, the authentication method and credential validity are
-verified by calling the Backlog API. The active (default) space is indicated
-so you can see which space is used when \`--space\` is not provided.`,
+    `Verifies credential validity for each configured space via the Backlog API. The active (default) space is indicated.`,
   )
   .option("-s, --space <hostname>", "The hostname of the Backlog space")
   .option("--show-token", "Display the auth token")

--- a/apps/cli/src/commands/auth/switch.ts
+++ b/apps/cli/src/commands/auth/switch.ts
@@ -6,15 +6,7 @@ import { BeeCommand } from "../../lib/bee-command";
 const switchSpace = new BeeCommand("switch")
   .summary("Switch active space")
   .description(
-    `Switch the active (default) Backlog space.
-
-Changes which space is used by default when running commands without
-\`--space\`.
-
-If multiple spaces are configured, you will be prompted to select one
-interactively. Use \`--space\` to switch directly without a prompt.
-
-For a list of configured spaces, see \`bee auth status\`.`,
+    `Changes which space is used by default when \`--space\` is not provided.`,
   )
   .option("-s, --space <hostname>", "The hostname of the Backlog space")
   .envVars([["BACKLOG_SPACE", "Space hostname to switch to"]])

--- a/apps/cli/src/commands/auth/switch.ts
+++ b/apps/cli/src/commands/auth/switch.ts
@@ -5,9 +5,7 @@ import { BeeCommand } from "../../lib/bee-command";
 
 const switchSpace = new BeeCommand("switch")
   .summary("Switch active space")
-  .description(
-    `Changes which space is used by default when \`--space\` is not provided.`,
-  )
+  .description(`Changes which space is used by default when \`--space\` is not provided.`)
   .option("-s, --space <hostname>", "The hostname of the Backlog space")
   .envVars([["BACKLOG_SPACE", "Space hostname to switch to"]])
   .examples([

--- a/apps/cli/src/commands/auth/token.ts
+++ b/apps/cli/src/commands/auth/token.ts
@@ -5,11 +5,7 @@ import { BeeCommand } from "../../lib/bee-command";
 const tokenCommand = new BeeCommand("token")
   .summary("Print the auth token to stdout")
   .description(
-    `Print the auth token for a Backlog space to standard output.
-
-Without \`--space\`, the default space is used.
-
-The token output can be used with \`BACKLOG_API_KEY\` or piped to other commands.`,
+    `Prints the token for the default space, or the space given by \`--space\`. Useful for piping to other commands.`,
   )
   .option("-s, --space <hostname>", "The hostname of the Backlog space")
   .envVars([["BACKLOG_SPACE", "Default space hostname"]])

--- a/apps/cli/src/commands/browse.ts
+++ b/apps/cli/src/commands/browse.ts
@@ -15,19 +15,9 @@ import { resolveUrl } from "./browse-url";
 const browse = new BeeCommand("browse")
   .summary("Open a Backlog page in the browser")
   .description(
-    `Open a Backlog page in the browser.
+    `With no arguments, opens the repository page (inside a Backlog repo) or the dashboard.
 
-With no arguments, the behavior depends on context. Inside a Backlog Git
-repository it opens the repository page; otherwise it opens the dashboard.
-
-When given an issue key (e.g. \`PROJECT-123\`), opens that issue. A bare
-number like \`123\` is also accepted when the project can be inferred from
-the Git remote. Use \`--project\` with section flags to navigate directly
-to a specific project page.
-
-A file path opens the file in the Backlog Git viewer (e.g. \`src/main.ts\`).
-Append \`:<line>\` to jump to a specific line (e.g. \`src/main.ts:42\`).
-Paths ending with \`/\` open the directory tree view.`,
+Accepts an issue key (\`PROJECT-123\`), bare number (\`123\`, project inferred from Git remote), file path (\`src/main.ts\`), or path with line (\`src/main.ts:42\`). Paths ending with \`/\` open the directory tree. Use \`--project\` with section flags (e.g. \`--issues\`, \`--board\`) for project pages.`,
   )
   .argument("[target]", "Issue key, issue number, file path, or project key")
   .addOption(opt.project().makeOptionMandatory(false).default(undefined))

--- a/apps/cli/src/commands/category/create.ts
+++ b/apps/cli/src/commands/category/create.ts
@@ -7,11 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const create = new BeeCommand("create")
   .summary("Create a category")
-  .description(
-    `Create a new category in a Backlog project.
-
-If \`--name\` is not provided, you will be prompted interactively.`,
-  )
+  .description(`Omitted fields will be prompted interactively.`)
   .addOption(opt.project())
   .option("-n, --name <value>", "Category name")
   .addOption(opt.json())

--- a/apps/cli/src/commands/category/delete.ts
+++ b/apps/cli/src/commands/category/delete.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const deleteCategory = new BeeCommand("delete")
   .summary("Delete a category")
-  .description(
-    `Delete a category from a Backlog project.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.`,
-  )
+  .description(`This action is irreversible.`)
   .argument("<category>", "Category ID")
   .addOption(opt.project())
   .option("-y, --yes", "Skip confirmation prompt")

--- a/apps/cli/src/commands/category/edit.ts
+++ b/apps/cli/src/commands/category/edit.ts
@@ -7,11 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a category")
-  .description(
-    `Update an existing category in a Backlog project.
-
-Renames the specified category.`,
-  )
+  .description(`Renames the specified category.`)
   .argument("<category>", "Category ID")
   .addOption(opt.project())
   .option("-n, --name <value>", "New name of the category")

--- a/apps/cli/src/commands/category/list.ts
+++ b/apps/cli/src/commands/category/list.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List categories")
-  .description(
-    `List categories in a Backlog project.
-
-Categories help organize issues by grouping them into logical areas.`,
-  )
+  .description(`Categories help organize issues by grouping them into logical areas.`)
   .argument("[project]", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/completion.ts
+++ b/apps/cli/src/commands/completion.ts
@@ -90,12 +90,7 @@ complete -c bee -n "__fish_use_subcommand" -a "completion" -d "completion comman
 
 const completion = new BeeCommand("completion")
   .summary("Generate shell completion scripts")
-  .description(
-    `Generate shell completion scripts for bee.
-
-The generated script should be sourced in your shell's configuration file.
-Follow the instructions in the output for your specific shell.`,
-  )
+  .description(`Supported shells: bash, zsh, fish. Source the output in your shell configuration.`)
   .argument("<shell>", "Shell to generate completions for")
   .examples([
     {

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -6,7 +6,9 @@ import * as opt from "../lib/common-options";
 
 const dashboard = new BeeCommand("dashboard")
   .summary("Show a summary of your Backlog activity")
-  .description(`Displays assigned issues, unread notifications, and projects. Use \`--web\` to open in the browser.`)
+  .description(
+    `Displays assigned issues, unread notifications, and projects. Use \`--web\` to open in the browser.`,
+  )
   .addOption(opt.json())
   .addOption(opt.web("dashboard"))
   .addOption(opt.noBrowser())

--- a/apps/cli/src/commands/dashboard.ts
+++ b/apps/cli/src/commands/dashboard.ts
@@ -6,14 +6,7 @@ import * as opt from "../lib/common-options";
 
 const dashboard = new BeeCommand("dashboard")
   .summary("Show a summary of your Backlog activity")
-  .description(
-    `Show a summary of your Backlog activity.
-
-Displays your assigned issues sorted by due date, unread notification count,
-and your projects. The layout is modeled after the Backlog web dashboard.
-
-Use \`--web\` to open the Backlog dashboard in your browser instead.`,
-  )
+  .description(`Displays assigned issues, unread notifications, and projects. Use \`--web\` to open in the browser.`)
   .addOption(opt.json())
   .addOption(opt.web("dashboard"))
   .addOption(opt.noBrowser())

--- a/apps/cli/src/commands/document/attachments.ts
+++ b/apps/cli/src/commands/document/attachments.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const attachments = new BeeCommand("attachments")
   .summary("List document attachments")
-  .description(
-    `List attachments of a Backlog document.
-
-Shows file name, size, creator, and creation date.`,
-  )
+  .description(`Shows file name, size, creator, and creation date.`)
   .argument("<document>", "Document ID")
   .addOption(opt.json())
   .envVars([...ENV_AUTH])

--- a/apps/cli/src/commands/document/create.ts
+++ b/apps/cli/src/commands/document/create.ts
@@ -6,14 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const create = new BeeCommand("create")
   .summary("Create a document")
-  .description(
-    `Create a new Backlog document.
-
-Requires a project and title. When run interactively, omitted required
-fields will be prompted.
-
-When input is piped, it is used as the body automatically.`,
-  )
+  .description(`Omitted required fields will be prompted interactively. When input is piped, it is used as the body automatically.`)
   .option("-p, --project <id>", "Project ID or project key")
   .option("-t, --title <text>", "Document title")
   .option("-b, --body <text>", "Document body content")

--- a/apps/cli/src/commands/document/create.ts
+++ b/apps/cli/src/commands/document/create.ts
@@ -6,7 +6,9 @@ import * as opt from "../../lib/common-options";
 
 const create = new BeeCommand("create")
   .summary("Create a document")
-  .description(`Omitted required fields will be prompted interactively. When input is piped, it is used as the body automatically.`)
+  .description(
+    `Omitted required fields will be prompted interactively. When input is piped, it is used as the body automatically.`,
+  )
   .option("-p, --project <id>", "Project ID or project key")
   .option("-t, --title <text>", "Document title")
   .option("-b, --body <text>", "Document body content")

--- a/apps/cli/src/commands/document/delete.ts
+++ b/apps/cli/src/commands/document/delete.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const deleteDocument = new BeeCommand("delete")
   .summary("Delete a document")
-  .description(
-    `Delete a Backlog document.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.`,
-  )
+  .description(`This action is irreversible.`)
   .argument("<document>", "Document ID")
   .option("-y, --yes", "Skip confirmation prompt")
   .addOption(opt.json())

--- a/apps/cli/src/commands/document/list.ts
+++ b/apps/cli/src/commands/document/list.ts
@@ -8,12 +8,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const list = new BeeCommand("list")
   .summary("List documents")
-  .description(
-    `List documents from a Backlog project.
-
-Use \`--sort\` to change the sort field and \`--keyword\` to search within
-document titles and content.`,
-  )
+  .description(`Use \`--keyword\` to search within document titles and content.`)
   .addOption(opt.project())
   .addOption(opt.keyword())
   .option("--sort <field>", "Sort field {created|updated}")

--- a/apps/cli/src/commands/document/tree.ts
+++ b/apps/cli/src/commands/document/tree.ts
@@ -35,11 +35,7 @@ const renderTree = (children: Entity.Document.DocumentTreeNode[]): string[] => {
 
 const tree = new BeeCommand("tree")
   .summary("Display document tree")
-  .description(
-    `Display the document tree structure of a Backlog project.
-
-Shows the hierarchical structure of documents with tree-style indentation.`,
-  )
+  .description(`Shows the hierarchical structure of documents with tree-style indentation.`)
   .argument("[project]", "Project ID or project key", process.env.BACKLOG_PROJECT)
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/document/view.ts
+++ b/apps/cli/src/commands/document/view.ts
@@ -6,14 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const view = new BeeCommand("view")
   .summary("View a document")
-  .description(
-    `Display details of a Backlog document.
-
-Shows the document title, metadata, and body content.
-
-Use \`--web\` to open the document in your default browser instead. The
-\`--project\` flag is required when using \`--web\`.`,
-  )
+  .description(`Use \`--web\` to open in the browser (\`--project\` is required for \`--web\`).`)
   .argument("<document>", "Document ID")
   .option("-p, --project <id>", "Project ID or project key (required for --web)")
   .addOption(opt.web("document"))

--- a/apps/cli/src/commands/issue-type/create.ts
+++ b/apps/cli/src/commands/issue-type/create.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const create = new BeeCommand("create")
   .summary("Create an issue type")
-  .description(
-    `Create a new issue type in a Backlog project.
-
-If \`--name\` is not provided, you will be prompted interactively.
-The \`--color\` flag must be one of the predefined Backlog colors.`,
-  )
+  .description(`Omitted fields will be prompted interactively.`)
   .addOption(opt.project())
   .option("-n, --name <value>", "Issue type name")
   .requiredOption(

--- a/apps/cli/src/commands/issue-type/delete.ts
+++ b/apps/cli/src/commands/issue-type/delete.ts
@@ -7,7 +7,9 @@ import { resolveOptions } from "../../lib/required-option";
 
 const deleteIssueType = new BeeCommand("delete")
   .summary("Delete an issue type")
-  .description(`All issues of this type are reassigned to the substitute issue type. This action is irreversible.`)
+  .description(
+    `All issues of this type are reassigned to the substitute issue type. This action is irreversible.`,
+  )
   .argument("<issueType>", "Issue type ID")
   .addOption(opt.project())
   .requiredOption(

--- a/apps/cli/src/commands/issue-type/delete.ts
+++ b/apps/cli/src/commands/issue-type/delete.ts
@@ -7,16 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const deleteIssueType = new BeeCommand("delete")
   .summary("Delete an issue type")
-  .description(
-    `Delete an issue type from a Backlog project.
-
-When deleting an issue type, all issues of that type must be reassigned
-to another issue type. Use \`--substitute-issue-type-id\` to specify
-the replacement.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.`,
-  )
+  .description(`All issues of this type are reassigned to the substitute issue type. This action is irreversible.`)
   .argument("<issueType>", "Issue type ID")
   .addOption(opt.project())
   .requiredOption(

--- a/apps/cli/src/commands/issue-type/edit.ts
+++ b/apps/cli/src/commands/issue-type/edit.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const edit = new BeeCommand("edit")
   .summary("Edit an issue type")
-  .description(
-    `Update an existing issue type in a Backlog project.
-
-Only the specified fields will be updated. Fields that are not provided
-will remain unchanged.`,
-  )
+  .description(`Only specified fields are updated; others remain unchanged.`)
   .argument("<issueType>", "Issue type ID")
   .addOption(opt.project())
   .option("-n, --name <value>", "New name of the issue type")

--- a/apps/cli/src/commands/issue-type/list.ts
+++ b/apps/cli/src/commands/issue-type/list.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List issue types")
-  .description(
-    `List issue types in a Backlog project.
-
-Issue types categorize issues and are displayed with their associated color.`,
-  )
+  .description(`Issue types categorize issues and are displayed with their associated color.`)
   .argument("[project]", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/issue/attachments.ts
+++ b/apps/cli/src/commands/issue/attachments.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const attachments = new BeeCommand("attachments")
   .summary("List issue attachments")
-  .description(
-    `List attachments of a Backlog issue.
-
-Shows file name, size, creator, and creation date.`,
-  )
+  .description(`Shows file name, size, creator, and creation date.`)
   .argument("<issue>", "Issue ID or issue key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH])

--- a/apps/cli/src/commands/issue/close.ts
+++ b/apps/cli/src/commands/issue/close.ts
@@ -7,12 +7,7 @@ import * as opt from "../../lib/common-options";
 const close = new BeeCommand("close")
   .summary("Close an issue")
   .description(
-    `Close a Backlog issue by setting its status to \`Closed\`.
-
-By default the resolution is set to \`Fixed\`. Use \`--resolution\` to
-specify a different resolution.
-
-Optionally add a comment with \`--comment\`.`,
+    `Sets the status to Closed with resolution \`Fixed\` by default. Use \`--resolution\` for a different resolution.`,
   )
   .argument("<issue>", "Issue ID or issue key")
   .option("-c, --comment <text>", "Comment to add when closing")

--- a/apps/cli/src/commands/issue/comment.ts
+++ b/apps/cli/src/commands/issue/comment.ts
@@ -14,14 +14,9 @@ import * as opt from "../../lib/common-options";
 const comment = new BeeCommand("comment")
   .summary("Add a comment to an issue")
   .description(
-    `Add a comment to a Backlog issue.
+    `When input is piped, it is used as the body automatically.
 
-The comment body is required when adding a comment. When input is piped,
-it is used as the body automatically.
-
-Use \`--list\` to list all comments on an issue.
-Use \`--edit-last\` to edit your most recent comment.
-Use \`--delete-last\` to delete your most recent comment.`,
+Use \`--list\`, \`--edit-last\`, or \`--delete-last\` for other comment operations.`,
   )
   .argument("<issue>", "Issue ID or issue key")
   .option("-b, --body <text>", "Comment body")

--- a/apps/cli/src/commands/issue/count.ts
+++ b/apps/cli/src/commands/issue/count.ts
@@ -23,12 +23,7 @@ const resolvePriorityIds = (priorities: string[]): number[] =>
 
 const count = new BeeCommand("count")
   .summary("Count issues")
-  .description(
-    `Count issues matching the given filter criteria.
-
-Accepts the same filter flags as \`bee issue list\`. Outputs a plain number
-by default, or a JSON object with \`--json\`.`,
-  )
+  .description(`Accepts the same filter flags as \`bee issue list\`.`)
   .addOption(
     new Option(
       "-p, --project <id>",

--- a/apps/cli/src/commands/issue/create.ts
+++ b/apps/cli/src/commands/issue/create.ts
@@ -15,13 +15,7 @@ import * as opt from "../../lib/common-options";
 const create = new BeeCommand("create")
   .summary("Create an issue")
   .description(
-    `Create a new Backlog issue.
-
-Requires a project, title, issue type, and priority. When run
-interactively, omitted required fields will be prompted.
-
-Issue type accepts a numeric ID. Priority accepts a name: \`high\`, \`normal\`,
-or \`low\`.`,
+    `Omitted required fields will be prompted interactively. Priority accepts a name: \`high\`, \`normal\`, or \`low\`.`,
   )
   .addOption(new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT"))
   .option("-t, --title <text>", "Issue title")

--- a/apps/cli/src/commands/issue/delete.ts
+++ b/apps/cli/src/commands/issue/delete.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const deleteIssue = new BeeCommand("delete")
   .summary("Delete an issue")
-  .description(
-    `Delete a Backlog issue.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.`,
-  )
+  .description(`This action is irreversible.`)
   .argument("<issue>", "Issue ID or issue key")
   .option("-y, --yes", "Skip confirmation prompt")
   .addOption(opt.json())

--- a/apps/cli/src/commands/issue/edit.ts
+++ b/apps/cli/src/commands/issue/edit.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const edit = new BeeCommand("edit")
   .summary("Edit an issue")
-  .description(
-    `Update an existing Backlog issue.
-
-Only the specified fields will be updated. Fields that are not provided
-will remain unchanged.`,
-  )
+  .description(`Only specified fields are updated; others remain unchanged.`)
   .argument("<issue>", "Issue ID or issue key")
   .option("-t, --title <text>", "New title of the issue")
   .option("-d, --description <text>", "New description of the issue")

--- a/apps/cli/src/commands/issue/list.ts
+++ b/apps/cli/src/commands/issue/list.ts
@@ -24,12 +24,7 @@ const resolvePriorityIds = (priorities: string[]): number[] =>
 const list = new BeeCommand("list")
   .summary("List issues")
   .description(
-    `List issues from one or more Backlog projects.
-
-By default, issues are sorted by last updated date in descending order.
-Use filtering flags to narrow results by assignee, status, priority, and more.
-
-Multiple project keys can be specified as a comma-separated list.`,
+    `By default, sorted by last updated date in descending order. Multiple project keys can be comma-separated.`,
   )
   .addOption(
     new Option(

--- a/apps/cli/src/commands/issue/reopen.ts
+++ b/apps/cli/src/commands/issue/reopen.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const reopen = new BeeCommand("reopen")
   .summary("Reopen an issue")
-  .description(
-    `Reopen a closed Backlog issue by setting its status back to \`Open\`.
-
-Optionally add a comment with \`--comment\`.`,
-  )
+  .description(`Sets the status back to Open.`)
   .argument("<issue>", "Issue ID or issue key")
   .option("-c, --comment <text>", "Comment to add when reopening")
   .addOption(opt.notify())

--- a/apps/cli/src/commands/issue/status.ts
+++ b/apps/cli/src/commands/issue/status.ts
@@ -6,7 +6,9 @@ import * as opt from "../../lib/common-options";
 
 const status = new BeeCommand("status")
   .summary("Show issue status summary for yourself")
-  .description(`Displays your assigned issues grouped by status (e.g., Open, In Progress, Resolved).`)
+  .description(
+    `Displays your assigned issues grouped by status (e.g., Open, In Progress, Resolved).`,
+  )
   .addOption(opt.json())
   .envVars([...ENV_AUTH])
   .examples([

--- a/apps/cli/src/commands/issue/status.ts
+++ b/apps/cli/src/commands/issue/status.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const status = new BeeCommand("status")
   .summary("Show issue status summary for yourself")
-  .description(
-    `Show a summary of issues assigned to you, grouped by status.
-
-Fetches issues where you are the assignee and displays them organized by
-their current status (e.g., Open, In Progress, Resolved).`,
-  )
+  .description(`Displays your assigned issues grouped by status (e.g., Open, In Progress, Resolved).`)
   .addOption(opt.json())
   .envVars([...ENV_AUTH])
   .examples([

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -6,9 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const view = new BeeCommand("view")
   .summary("View an issue")
-  .description(
-    `Use \`--comments\` to include comments. Use \`--web\` to open in the browser.`,
-  )
+  .description(`Use \`--comments\` to include comments. Use \`--web\` to open in the browser.`)
   .argument("<issue>", "Issue ID or issue key")
   .option("--comments", "Include comments")
   .addOption(opt.web("issue"))

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -7,12 +7,7 @@ import * as opt from "../../lib/common-options";
 const view = new BeeCommand("view")
   .summary("View an issue")
   .description(
-    `Display details of a Backlog issue.
-
-Shows the issue summary, status, type, priority, assignee, dates, and
-description. Use \`--comments\` to also fetch and display comments.
-
-Use \`--web\` to open the issue in your default browser instead.`,
+    `Use \`--comments\` to include comments. Use \`--web\` to open in the browser.`,
   )
   .argument("<issue>", "Issue ID or issue key")
   .option("--comments", "Include comments")

--- a/apps/cli/src/commands/milestone/create.ts
+++ b/apps/cli/src/commands/milestone/create.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const create = new BeeCommand("create")
   .summary("Create a milestone")
-  .description(
-    `Create a new milestone in a Backlog project.
-
-If \`--name\` is not provided, you will be prompted interactively.
-Use \`--start-date\` and \`--release-due-date\` to set the milestone schedule.`,
-  )
+  .description(`Omitted fields will be prompted interactively.`)
   .addOption(opt.project())
   .option("-n, --name <value>", "Milestone name")
   .option("-d, --description <value>", "Milestone description")

--- a/apps/cli/src/commands/milestone/delete.ts
+++ b/apps/cli/src/commands/milestone/delete.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const deleteMilestone = new BeeCommand("delete")
   .summary("Delete a milestone")
-  .description(
-    `Delete a milestone from a Backlog project.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.`,
-  )
+  .description(`This action is irreversible.`)
   .argument("<milestone>", "Milestone ID")
   .addOption(opt.project())
   .option("-y, --yes", "Skip confirmation prompt")

--- a/apps/cli/src/commands/milestone/edit.ts
+++ b/apps/cli/src/commands/milestone/edit.ts
@@ -7,13 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a milestone")
-  .description(
-    `Update an existing milestone in a Backlog project.
-
-Only the specified fields will be updated. Fields that are not provided
-will remain unchanged. Use \`--archived\` to archive or \`--no-archived\` to
-unarchive a milestone.`,
-  )
+  .description(`Only specified fields are updated; others remain unchanged.`)
   .argument("<milestone>", "Milestone ID")
   .addOption(opt.project())
   .requiredOption("-n, --name <value>", "New name of the milestone")

--- a/apps/cli/src/commands/milestone/list.ts
+++ b/apps/cli/src/commands/milestone/list.ts
@@ -6,7 +6,9 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List milestones")
-  .description(`Milestones (versions) track release schedules and group issues by development cycle.`)
+  .description(
+    `Milestones (versions) track release schedules and group issues by development cycle.`,
+  )
   .argument("[project]", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/milestone/list.ts
+++ b/apps/cli/src/commands/milestone/list.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List milestones")
-  .description(
-    `List milestones in a Backlog project.
-
-Milestones (also known as versions) help track release schedules and
-group issues by development cycle.`,
-  )
+  .description(`Milestones (versions) track release schedules and group issues by development cycle.`)
   .argument("[project]", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/notification/count.ts
+++ b/apps/cli/src/commands/notification/count.ts
@@ -16,7 +16,7 @@ const count = new BeeCommand("count")
   .description(
     `By default, counts all notifications regardless of read status.
 
-For details, see:
+For details, see:  
 https://developer.nulab.com/docs/backlog/api/2/count-notification/`,
   )
   .option(

--- a/apps/cli/src/commands/notification/count.ts
+++ b/apps/cli/src/commands/notification/count.ts
@@ -17,7 +17,7 @@ const count = new BeeCommand("count")
     `By default, counts all notifications regardless of read status.
 
 For details, see:
-https://developer.nulab.com/docs/backlog/api/2/count-notifications/`,
+https://developer.nulab.com/docs/backlog/api/2/count-notification/`,
   )
   .option(
     "--already-read <value>",

--- a/apps/cli/src/commands/notification/count.ts
+++ b/apps/cli/src/commands/notification/count.ts
@@ -14,10 +14,7 @@ const parseReadFilter = (value: string | undefined): boolean | undefined => {
 const count = new BeeCommand("count")
   .summary("Count notifications")
   .description(
-    `Display the count of notifications for the authenticated user.
-
-By default, returns the count of all notifications regardless of read status.
-Use \`--already-read\` and \`--resource-already-read\` to filter by read status.
+    `By default, counts all notifications regardless of read status.
 
 For details, see:
 https://developer.nulab.com/docs/backlog/api/2/count-notifications/`,

--- a/apps/cli/src/commands/notification/list.ts
+++ b/apps/cli/src/commands/notification/list.ts
@@ -6,13 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List notifications")
-  .description(
-    `List notifications for the authenticated user.
-
-Unread notifications are marked with an asterisk (\`*\`). Use \`--count\` to
-control the number of notifications returned, and \`--min-id\` / \`--max-id\`
-for cursor-based pagination.`,
-  )
+  .description(`Unread notifications are marked with \`*\`. Use \`--min-id\` / \`--max-id\` for cursor-based pagination.`)
   .addOption(opt.count())
   .addOption(opt.minId())
   .addOption(opt.maxId())

--- a/apps/cli/src/commands/notification/list.ts
+++ b/apps/cli/src/commands/notification/list.ts
@@ -6,7 +6,9 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List notifications")
-  .description(`Unread notifications are marked with \`*\`. Use \`--min-id\` / \`--max-id\` for cursor-based pagination.`)
+  .description(
+    `Unread notifications are marked with \`*\`. Use \`--min-id\` / \`--max-id\` for cursor-based pagination.`,
+  )
   .addOption(opt.count())
   .addOption(opt.minId())
   .addOption(opt.maxId())

--- a/apps/cli/src/commands/notification/read-all.ts
+++ b/apps/cli/src/commands/notification/read-all.ts
@@ -4,9 +4,7 @@ import { BeeCommand, ENV_AUTH } from "../../lib/bee-command";
 
 const readAll = new BeeCommand("read-all")
   .summary("Mark all notifications as read")
-  .description(`Mark all notifications as read.
-
-This resets the unread notification count to zero.`)
+  .description(`Resets the unread notification count to zero.`)
   .envVars([...ENV_AUTH])
   .examples([
     { description: "Mark all notifications as read", command: "bee notification read-all" },

--- a/apps/cli/src/commands/notification/read.ts
+++ b/apps/cli/src/commands/notification/read.ts
@@ -4,12 +4,7 @@ import { BeeCommand, ENV_AUTH } from "../../lib/bee-command";
 
 const read = new BeeCommand("read")
   .summary("Mark a notification as read")
-  .description(
-    `Mark a notification as read.
-
-Specify the notification ID to mark as read. Use \`bee notification list\`
-to find notification IDs.`,
-  )
+  .description(`Use \`bee notification list\` to find notification IDs.`)
   .argument("<id>", "Notification ID")
   .envVars([...ENV_AUTH])
   .examples([

--- a/apps/cli/src/commands/pr/comment.ts
+++ b/apps/cli/src/commands/pr/comment.ts
@@ -8,13 +8,9 @@ import { resolveOptions } from "../../lib/required-option";
 const comment = new BeeCommand("comment")
   .summary("Add a comment to a pull request")
   .description(
-    `Add a comment to a Backlog pull request.
+    `When input is piped, it is used as the body automatically.
 
-The comment body is required when adding a comment. When input is piped,
-it is used as the body automatically.
-
-Use \`--list\` to list all comments on a pull request.
-Use \`--edit-last\` to edit your most recent comment.`,
+Use \`--list\` or \`--edit-last\` for other comment operations.`,
   )
   .argument("<number>", "Pull request number")
   .addOption(opt.project())

--- a/apps/cli/src/commands/pr/comments.ts
+++ b/apps/cli/src/commands/pr/comments.ts
@@ -7,11 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const comments = new BeeCommand("comments")
   .summary("List comments on a pull request")
-  .description(
-    `List comments on a Backlog pull request.
-
-Displays all comments in chronological order with the author and date.`,
-  )
+  .description(`Displays all comments in chronological order.`)
   .argument("<number>", "Pull request number")
   .addOption(opt.project())
   .addOption(opt.repo())

--- a/apps/cli/src/commands/pr/count.ts
+++ b/apps/cli/src/commands/pr/count.ts
@@ -17,12 +17,7 @@ const resolveStatusIds = (statuses: string[]): number[] =>
 
 const count = new BeeCommand("count")
   .summary("Count pull requests")
-  .description(
-    `Count pull requests in a Backlog repository.
-
-Accepts the same status filter as \`bee pr list\`. Outputs a plain number
-by default, or a JSON object with \`--json\`.`,
-  )
+  .description(`Accepts the same filter flags as \`bee pr list\`.`)
   .addOption(opt.project())
   .addOption(opt.repo())
   .option("-S, --status <name>", "Status name (repeatable)", collect, [] satisfies string[])

--- a/apps/cli/src/commands/pr/create.ts
+++ b/apps/cli/src/commands/pr/create.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const create = new BeeCommand("create")
   .summary("Create a pull request")
-  .description(
-    `Create a new pull request in a Backlog repository.
-
-Requires a base branch, head branch, title, and description. When run
-interactively, omitted required fields will be prompted.`,
-  )
+  .description(`Omitted required fields will be prompted interactively.`)
   .addOption(opt.project())
   .addOption(opt.repo())
   .option("--base <branch>", "Base branch name")

--- a/apps/cli/src/commands/pr/edit.ts
+++ b/apps/cli/src/commands/pr/edit.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a pull request")
-  .description(
-    `Update an existing Backlog pull request.
-
-Only the specified fields will be updated. Fields that are not provided
-will remain unchanged.`,
-  )
+  .description(`Only specified fields are updated; others remain unchanged.`)
   .argument("<number>", "Pull request number")
   .addOption(opt.project())
   .addOption(opt.repo())

--- a/apps/cli/src/commands/pr/list.ts
+++ b/apps/cli/src/commands/pr/list.ts
@@ -17,12 +17,7 @@ const resolveStatusIds = (statuses: string[]): number[] =>
 
 const list = new BeeCommand("list")
   .summary("List pull requests")
-  .description(
-    `List pull requests in a Backlog repository.
-
-By default, all pull requests are returned. Use \`--status\` to filter by
-status (open, closed, merged).`,
-  )
+  .description(`Use \`--status\` to filter by status (open, closed, merged).`)
   .addOption(opt.project())
   .addOption(opt.repo())
   .option("-S, --status <name>", "Status name (repeatable)", collect, [] satisfies string[])

--- a/apps/cli/src/commands/pr/status.ts
+++ b/apps/cli/src/commands/pr/status.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const status = new BeeCommand("status")
   .summary("Show pull request status summary for yourself")
-  .description(
-    `Show a summary of pull requests assigned to you, grouped by status.
-
-Fetches pull requests where you are the assignee and displays them
-organized by their current status (Open, Closed, Merged).`,
-  )
+  .description(`Displays your assigned pull requests grouped by status (Open, Closed, Merged).`)
   .addOption(opt.project())
   .addOption(opt.repo())
   .addOption(opt.json())

--- a/apps/cli/src/commands/pr/view.ts
+++ b/apps/cli/src/commands/pr/view.ts
@@ -7,14 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const view = new BeeCommand("view")
   .summary("View a pull request")
-  .description(
-    `Display details of a Backlog pull request.
-
-Shows the pull request summary, status, assignee, base/head branches,
-and description.
-
-Use \`--web\` to open the pull request in your default browser instead.`,
-  )
+  .description(`Use \`--web\` to open in the browser.`)
   .argument("<number>", "Pull request number")
   .addOption(opt.project())
   .addOption(opt.repo())

--- a/apps/cli/src/commands/project/activities.ts
+++ b/apps/cli/src/commands/project/activities.ts
@@ -38,7 +38,7 @@ const activities = new BeeCommand("activities")
     `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
 For activity type IDs, see:
-https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates/#activity-type`,
+https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates/#response-description`,
   )
   .argument("<project>", "Project ID or project key")
   .option(

--- a/apps/cli/src/commands/project/activities.ts
+++ b/apps/cli/src/commands/project/activities.ts
@@ -35,15 +35,9 @@ const getActivitySummary = (activity: {
 const activities = new BeeCommand("activities")
   .summary("List project activities")
   .description(
-    `List recent activities of a Backlog project.
+    `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
-Shows the most recent updates including issue changes, wiki edits, git pushes,
-and other project activities. Results are ordered by most recent first.
-
-Use \`--activity-type\` to filter by specific activity types (repeatable).
-Use \`--count\` to control how many activities are returned (default: 20, max: 100).
-
-For a list of activity type IDs, see:
+For activity type IDs, see:
 https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates/#activity-type`,
   )
   .argument("<project>", "Project ID or project key")

--- a/apps/cli/src/commands/project/activities.ts
+++ b/apps/cli/src/commands/project/activities.ts
@@ -37,7 +37,7 @@ const activities = new BeeCommand("activities")
   .description(
     `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
-For activity type IDs, see:
+For activity type IDs, see:  
 https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates/#response-description`,
   )
   .argument("<project>", "Project ID or project key")

--- a/apps/cli/src/commands/project/add-user.ts
+++ b/apps/cli/src/commands/project/add-user.ts
@@ -7,14 +7,7 @@ import { RequiredOption, resolveOptions } from "../../lib/required-option";
 
 const addUser = new BeeCommand("add-user")
   .summary("Add a user to a project")
-  .description(
-    `Add a user to a Backlog project.
-
-The user is specified by their numeric user ID. Use \`bee project users\`
-to look up user IDs.
-
-Requires Administrator or Project Administrator role.`,
-  )
+  .description(`Use \`bee project users\` to look up user IDs.`)
   .addOption(opt.project())
   .addOption(new RequiredOption("--user-id <id>", "User ID"))
   .addOption(opt.json())

--- a/apps/cli/src/commands/project/create.ts
+++ b/apps/cli/src/commands/project/create.ts
@@ -7,11 +7,7 @@ import * as opt from "../../lib/common-options";
 const create = new BeeCommand("create")
   .summary("Create a project")
   .description(
-    `Create a new Backlog project.
-
-Project key must consist of uppercase letters (A\u2013Z), numbers (0\u20139), and
-underscores (\`_\`). If \`--name\` or \`--key\` is not provided, you will be
-prompted interactively.`,
+    `Project key must consist of uppercase letters, numbers, and underscores. Omitted fields will be prompted interactively.`,
   )
   .option("-k, --key <key>", "Project key")
   .option("-n, --name <name>", "Project name")

--- a/apps/cli/src/commands/project/delete.ts
+++ b/apps/cli/src/commands/project/delete.ts
@@ -6,14 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const deleteProject = new BeeCommand("delete")
   .summary("Delete a project")
-  .description(
-    `Delete a Backlog project.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.
-
-Requires Administrator role.`,
-  )
+  .description(`This action is irreversible. Requires Administrator role.`)
   .argument("<project>", "Project ID or project key")
   .option("-y, --yes", "Skip confirmation prompt")
   .addOption(opt.json())

--- a/apps/cli/src/commands/project/edit.ts
+++ b/apps/cli/src/commands/project/edit.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a project")
-  .description(
-    `Update an existing Backlog project.
-
-Only the specified fields will be updated. Fields that are not provided
-will remain unchanged.`,
-  )
+  .description(`Only specified fields are updated; others remain unchanged.`)
   .argument("<project>", "Project ID or project key")
   .option("-n, --name <name>", "New name of the project")
   .option("-k, --key <key>", "New key of the project")

--- a/apps/cli/src/commands/project/list.ts
+++ b/apps/cli/src/commands/project/list.ts
@@ -7,13 +7,7 @@ import * as opt from "../../lib/common-options";
 const list = new BeeCommand("list")
   .summary("List projects")
   .description(
-    `List projects accessible to the authenticated user.
-
-By default, only active (non-archived) projects are shown. Use \`--archived\`
-to include archived projects.
-
-Administrators can use \`--all\` to list every project in the space, not just
-the ones they have joined.`,
+    `By default, only active (non-archived) projects are shown. Use \`--all\` to list all projects in the space (admin only).`,
   )
   .option("--archived", "Include archived projects")
   .option("--all", "Include all projects (admin only)")

--- a/apps/cli/src/commands/project/remove-user.ts
+++ b/apps/cli/src/commands/project/remove-user.ts
@@ -7,14 +7,7 @@ import { RequiredOption, resolveOptions } from "../../lib/required-option";
 
 const removeUser = new BeeCommand("remove-user")
   .summary("Remove a user from a project")
-  .description(
-    `Remove a user from a Backlog project.
-
-The user is specified by their numeric user ID. Use \`bee project users\`
-to look up user IDs.
-
-Requires Administrator or Project Administrator role.`,
-  )
+  .description(`Use \`bee project users\` to look up user IDs.`)
   .addOption(opt.project())
   .addOption(new RequiredOption("--user-id <id>", "User ID"))
   .addOption(opt.json())

--- a/apps/cli/src/commands/project/users.ts
+++ b/apps/cli/src/commands/project/users.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const users = new BeeCommand("users")
   .summary("List project users")
-  .description(
-    `List members of a Backlog project.
-
-Displays each user's ID, user ID, name, and role within the project.`,
-  )
+  .description(`Displays each member's ID, name, and role.`)
   .argument("<project>", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/project/view.ts
+++ b/apps/cli/src/commands/project/view.ts
@@ -6,14 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const view = new BeeCommand("view")
   .summary("View a project")
-  .description(
-    `Display details of a Backlog project.
-
-Shows project settings including chart, subtasking, wiki, file sharing,
-and git/subversion integration status.
-
-Use \`--web\` to open the project in your default browser instead.`,
-  )
+  .description(`Use \`--web\` to open in the browser.`)
   .argument("<project>", "Project ID or project key")
   .addOption(opt.web("project"))
   .addOption(opt.noBrowser())

--- a/apps/cli/src/commands/repo/clone.ts
+++ b/apps/cli/src/commands/repo/clone.ts
@@ -20,15 +20,7 @@ const gitClone = (gitArgs: string[]): Promise<void> =>
 
 const clone = new BeeCommand("clone")
   .summary("Clone a repository")
-  .description(
-    `Clone a Backlog Git repository.
-
-Fetches the repository metadata to obtain the clone URL, then runs
-\`git clone\` as a subprocess. By default the SSH URL is used; pass
-\`--http\` to clone over HTTPS instead.
-
-Use \`--directory\` to specify a custom destination directory.`,
-  )
+  .description(`By default the SSH URL is used; pass \`--http\` to clone over HTTPS instead.`)
   .argument("<repository>", "Repository name or ID")
   .addOption(opt.project())
   .option("-d, --directory <path>", "Directory to clone into")

--- a/apps/cli/src/commands/repo/list.ts
+++ b/apps/cli/src/commands/repo/list.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List repositories in a project")
-  .description(
-    `List Git repositories in a Backlog project.
-
-By default, repositories are listed in the configured display order.`,
-  )
+  .description(`Repositories are listed in the configured display order.`)
   .argument("<project>", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/repo/view.ts
+++ b/apps/cli/src/commands/repo/view.ts
@@ -7,14 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const view = new BeeCommand("view")
   .summary("View a repository")
-  .description(
-    `Display details of a Git repository in a Backlog project.
-
-Shows repository name, description, HTTP and SSH clone URLs, size,
-creation and update timestamps.
-
-Use \`--web\` to open the repository in your default browser instead.`,
-  )
+  .description(`Use \`--web\` to open in the browser.`)
   .argument("<repository>", "Repository name or ID")
   .addOption(opt.project())
   .addOption(opt.web("repository"))

--- a/apps/cli/src/commands/space/activities.ts
+++ b/apps/cli/src/commands/space/activities.ts
@@ -38,7 +38,7 @@ const activities = new BeeCommand("activities")
     `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
 For activity type IDs, see:
-https://developer.nulab.com/docs/backlog/api/2/get-space-activities/#activity-type`,
+https://developer.nulab.com/docs/backlog/api/2/get-recent-updates/#activity-type`,
   )
   .option(
     "--activity-type <id>",

--- a/apps/cli/src/commands/space/activities.ts
+++ b/apps/cli/src/commands/space/activities.ts
@@ -38,7 +38,7 @@ const activities = new BeeCommand("activities")
     `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
 For activity type IDs, see:
-https://developer.nulab.com/docs/backlog/api/2/get-recent-updates/#activity-type`,
+https://developer.nulab.com/docs/backlog/api/2/get-recent-updates/#response-description`,
   )
   .option(
     "--activity-type <id>",

--- a/apps/cli/src/commands/space/activities.ts
+++ b/apps/cli/src/commands/space/activities.ts
@@ -37,7 +37,7 @@ const activities = new BeeCommand("activities")
   .description(
     `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
-For activity type IDs, see:
+For activity type IDs, see:  
 https://developer.nulab.com/docs/backlog/api/2/get-recent-updates/#response-description`,
   )
   .option(

--- a/apps/cli/src/commands/space/activities.ts
+++ b/apps/cli/src/commands/space/activities.ts
@@ -35,14 +35,10 @@ const getActivitySummary = (activity: {
 const activities = new BeeCommand("activities")
   .summary("List space activities")
   .description(
-    `List recent activities across the Backlog space.
+    `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
-Shows the most recent updates across the entire space, including
-issue changes, wiki edits, git pushes, and other activities. Results are
-ordered by most recent first.
-
-Use \`--activity-type\` to filter by specific activity types (repeatable).
-Use \`--count\` to control how many activities are returned (default: 20, max: 100).`,
+For activity type IDs, see:
+https://developer.nulab.com/docs/backlog/api/2/get-space-activities/#activity-type`,
   )
   .option(
     "--activity-type <id>",

--- a/apps/cli/src/commands/star/add.ts
+++ b/apps/cli/src/commands/star/add.ts
@@ -6,13 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const add = new BeeCommand("add")
   .summary("Add a star")
-  .description(
-    `Add a star to an issue, comment, wiki page, or pull request comment.
-
-Exactly one of \`--issue\`, \`--comment\`, \`--wiki\`, or \`--pr-comment\` must be
-provided. The \`--issue\` flag accepts an issue key (e.g., PROJECT-123) or a
-numeric ID. Other flags require numeric IDs.`,
-  )
+  .description(`Specify exactly one target: \`--issue\` (accepts key or ID), \`--comment\`, \`--wiki\`, or \`--pr-comment\`.`)
   .addOption(opt.issue())
   .option("--comment <number>", "Comment ID to star")
   .option("--wiki <number>", "Wiki page ID to star")

--- a/apps/cli/src/commands/star/add.ts
+++ b/apps/cli/src/commands/star/add.ts
@@ -6,7 +6,9 @@ import * as opt from "../../lib/common-options";
 
 const add = new BeeCommand("add")
   .summary("Add a star")
-  .description(`Specify exactly one target: \`--issue\` (accepts key or ID), \`--comment\`, \`--wiki\`, or \`--pr-comment\`.`)
+  .description(
+    `Specify exactly one target: \`--issue\` (accepts key or ID), \`--comment\`, \`--wiki\`, or \`--pr-comment\`.`,
+  )
   .addOption(opt.issue())
   .option("--comment <number>", "Comment ID to star")
   .option("--wiki <number>", "Wiki page ID to star")

--- a/apps/cli/src/commands/star/count.ts
+++ b/apps/cli/src/commands/star/count.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const count = new BeeCommand("count")
   .summary("Count received stars")
-  .description(
-    `Count stars received by a user.
-
-If no user ID is specified, counts stars for the authenticated user. Use
-\`--since\` and \`--until\` to filter by date range.`,
-  )
+  .description(`Defaults to the authenticated user if no user ID is given.`)
   .argument("[user]", "User ID")
   .option("--since <yyyy-MM-dd>", "Count stars received on or after this date")
   .option("--until <yyyy-MM-dd>", "Count stars received on or before this date")

--- a/apps/cli/src/commands/star/list.ts
+++ b/apps/cli/src/commands/star/list.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List received stars")
-  .description(
-    `List stars received by a user.
-
-If no user ID is specified, lists stars for the authenticated user.`,
-  )
+  .description(`Defaults to the authenticated user if no user ID is given.`)
   .argument("[user]", "User ID")
   .addOption(opt.json())
   .envVars([...ENV_AUTH])

--- a/apps/cli/src/commands/star/remove.ts
+++ b/apps/cli/src/commands/star/remove.ts
@@ -4,11 +4,7 @@ import { BeeCommand, ENV_AUTH } from "../../lib/bee-command";
 
 const remove = new BeeCommand("remove")
   .summary("Remove a star")
-  .description(
-    `Remove a star.
-
-Use \`bee star list\` to find star IDs.`,
-  )
+  .description(`Use \`bee star list\` to find star IDs.`)
   .argument("<star>", "Star ID")
   .envVars([...ENV_AUTH])
   .examples([{ description: "Remove a star", command: "bee star remove 12345" }])

--- a/apps/cli/src/commands/status/create.ts
+++ b/apps/cli/src/commands/status/create.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const create = new BeeCommand("create")
   .summary("Create a status")
-  .description(
-    `Create a new status in a Backlog project.
-
-If \`--name\` is not provided, you will be prompted interactively.
-The \`--color\` flag must be one of the predefined Backlog colors.`,
-  )
+  .description(`Omitted fields will be prompted interactively.`)
   .addOption(opt.project())
   .option("-n, --name <value>", "Status name")
   .requiredOption(

--- a/apps/cli/src/commands/status/delete.ts
+++ b/apps/cli/src/commands/status/delete.ts
@@ -7,7 +7,9 @@ import { resolveOptions } from "../../lib/required-option";
 
 const deleteStatus = new BeeCommand("delete")
   .summary("Delete a status")
-  .description(`All issues with this status are reassigned to the substitute status. This action is irreversible.`)
+  .description(
+    `All issues with this status are reassigned to the substitute status. This action is irreversible.`,
+  )
   .argument("<status>", "Status ID")
   .addOption(opt.project())
   .requiredOption("--substitute-status-id <value>", "Replacement status ID for affected issues")

--- a/apps/cli/src/commands/status/delete.ts
+++ b/apps/cli/src/commands/status/delete.ts
@@ -7,16 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const deleteStatus = new BeeCommand("delete")
   .summary("Delete a status")
-  .description(
-    `Delete a status from a Backlog project.
-
-When deleting a status, all issues with that status must be reassigned
-to another status. Use \`--substitute-status-id\` to specify
-the replacement.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.`,
-  )
+  .description(`All issues with this status are reassigned to the substitute status. This action is irreversible.`)
   .argument("<status>", "Status ID")
   .addOption(opt.project())
   .requiredOption("--substitute-status-id <value>", "Replacement status ID for affected issues")

--- a/apps/cli/src/commands/status/edit.ts
+++ b/apps/cli/src/commands/status/edit.ts
@@ -7,12 +7,7 @@ import { resolveOptions } from "../../lib/required-option";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a status")
-  .description(
-    `Update an existing status in a Backlog project.
-
-Only the specified fields will be updated. Fields that are not provided
-will remain unchanged.`,
-  )
+  .description(`Only specified fields are updated; others remain unchanged.`)
   .argument("<status>", "Status ID")
   .addOption(opt.project())
   .option("-n, --name <value>", "New name of the status")

--- a/apps/cli/src/commands/status/list.ts
+++ b/apps/cli/src/commands/status/list.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List statuses")
-  .description(
-    `List statuses in a Backlog project.
-
-Statuses define the workflow states that issues can move through.
-Each status is displayed with its associated color.`,
-  )
+  .description(`Statuses define the workflow states that issues move through.`)
   .argument("[project]", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/team/list.ts
+++ b/apps/cli/src/commands/team/list.ts
@@ -7,13 +7,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List teams")
-  .description(
-    `List teams in the space.
-
-Teams are groups of users that can be assigned to projects collectively.
-Use \`--order\` to control sort direction and \`--offset\` / \`--count\` for
-pagination.`,
-  )
+  .description(`Teams are groups of users that can be assigned to projects collectively.`)
   .addOption(opt.json())
   .addOption(opt.order())
   .addOption(opt.offset())

--- a/apps/cli/src/commands/team/view.ts
+++ b/apps/cli/src/commands/team/view.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const view = new BeeCommand("view")
   .summary("View a team")
-  .description(
-    `Display details of a Backlog team.
-
-Shows team name, ID, creator, creation date, and the list of members
-belonging to the team.`,
-  )
+  .description(`Shows team details and the list of members.`)
   .argument("<team>", "Team ID")
   .addOption(opt.json())
   .envVars([...ENV_AUTH])

--- a/apps/cli/src/commands/user/activities.ts
+++ b/apps/cli/src/commands/user/activities.ts
@@ -38,7 +38,7 @@ const activities = new BeeCommand("activities")
     `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
 For activity type IDs, see:
-https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates/#activity-type`,
+https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates/#response-description`,
   )
   .argument("<user>", "User ID")
   .option(

--- a/apps/cli/src/commands/user/activities.ts
+++ b/apps/cli/src/commands/user/activities.ts
@@ -35,16 +35,9 @@ const getActivitySummary = (activity: {
 const activities = new BeeCommand("activities")
   .summary("List user activities")
   .description(
-    `List recent activities of a Backlog user.
+    `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
-Shows the most recent updates performed by the specified user, including
-issue changes, wiki edits, git pushes, and other activities. Results are
-ordered by most recent first.
-
-Use \`--activity-type\` to filter by specific activity types (repeatable).
-Use \`--count\` to control how many activities are returned (default: 20, max: 100).
-
-For a list of activity type IDs, see:
+For activity type IDs, see:
 https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates/#activity-type`,
   )
   .argument("<user>", "User ID")

--- a/apps/cli/src/commands/user/activities.ts
+++ b/apps/cli/src/commands/user/activities.ts
@@ -37,7 +37,7 @@ const activities = new BeeCommand("activities")
   .description(
     `Results are ordered by most recent first. Use \`--activity-type\` to filter by type.
 
-For activity type IDs, see:
+For activity type IDs, see:  
 https://developer.nulab.com/docs/backlog/api/2/get-user-recent-updates/#response-description`,
   )
   .argument("<user>", "User ID")

--- a/apps/cli/src/commands/user/list.ts
+++ b/apps/cli/src/commands/user/list.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List users")
-  .description(
-    `List all users in the Backlog space.
-
-Displays each user's ID, user ID, name, and role. Only space administrators
-can see the full list of users.`,
-  )
+  .description(`Only space administrators can see the full list of users.`)
   .addOption(opt.json())
   .envVars([...ENV_AUTH])
   .examples([

--- a/apps/cli/src/commands/user/me.ts
+++ b/apps/cli/src/commands/user/me.ts
@@ -6,13 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const me = new BeeCommand("me")
   .summary("View the authenticated user")
-  .description(
-    `Display details of the authenticated user.
-
-This is a shortcut for \`bee user view\` that automatically looks up the
-currently authenticated user. Shows the same profile information: name,
-user ID, email address, role, language, and last login time.`,
-  )
+  .description(`Shortcut for \`bee user view\` using the currently authenticated user.`)
   .addOption(opt.json())
   .envVars([...ENV_AUTH])
   .examples([

--- a/apps/cli/src/commands/user/view.ts
+++ b/apps/cli/src/commands/user/view.ts
@@ -6,14 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const view = new BeeCommand("view")
   .summary("View a user")
-  .description(
-    `Display details of a Backlog user.
-
-Shows user profile information including name, user ID, email address,
-role, language, and last login time.
-
-Use \`bee user me\` as a shortcut to view your own profile.`,
-  )
+  .description(`Use \`bee user me\` as a shortcut to view your own profile.`)
   .argument("<user>", "User ID")
   .addOption(opt.json())
   .envVars([...ENV_AUTH])

--- a/apps/cli/src/commands/watching/add.ts
+++ b/apps/cli/src/commands/watching/add.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const add = new BeeCommand("add")
   .summary("Add a watching item")
-  .description(
-    `Add an issue to your watching list.
-
-Subscribe to an issue to receive notifications when it is updated. Optionally
-attach a note for your own reference.`,
-  )
+  .description(`Subscribe to an issue to receive update notifications.`)
   .requiredOption("--issue <key>", "Issue ID or issue key")
   .option("--note <text>", "Note to attach to the watching item")
   .addOption(opt.json())

--- a/apps/cli/src/commands/watching/delete.ts
+++ b/apps/cli/src/commands/watching/delete.ts
@@ -6,7 +6,9 @@ import * as opt from "../../lib/common-options";
 
 const deleteWatching = new BeeCommand("delete")
   .summary("Delete a watching item")
-  .description(`Removes the issue from your watching list. You will no longer receive update notifications.`)
+  .description(
+    `Removes the issue from your watching list. You will no longer receive update notifications.`,
+  )
   .argument("<watching>", "Watching ID")
   .option("-y, --yes", "Skip confirmation prompt")
   .addOption(opt.json())

--- a/apps/cli/src/commands/watching/delete.ts
+++ b/apps/cli/src/commands/watching/delete.ts
@@ -6,13 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const deleteWatching = new BeeCommand("delete")
   .summary("Delete a watching item")
-  .description(
-    `Delete a watching item.
-
-This removes the issue from your watching list. You will no longer receive
-notifications for updates to the issue. You will be prompted for confirmation
-unless \`--yes\` is provided.`,
-  )
+  .description(`Removes the issue from your watching list. You will no longer receive update notifications.`)
   .argument("<watching>", "Watching ID")
   .option("-y, --yes", "Skip confirmation prompt")
   .addOption(opt.json())

--- a/apps/cli/src/commands/watching/list.ts
+++ b/apps/cli/src/commands/watching/list.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List watching items")
-  .description(
-    `List watching items for the authenticated user.
-
-Watching items are issue subscriptions. Unread items are marked with an
-asterisk (\`*\`).`,
-  )
+  .description(`Unread items are marked with an asterisk (\`*\`).`)
   .addOption(opt.json())
   .envVars([...ENV_AUTH])
   .examples([

--- a/apps/cli/src/commands/watching/read.ts
+++ b/apps/cli/src/commands/watching/read.ts
@@ -4,12 +4,7 @@ import { BeeCommand, ENV_AUTH } from "../../lib/bee-command";
 
 const read = new BeeCommand("read")
   .summary("Mark a watching item as read")
-  .description(
-    `Mark a watching item as read.
-
-Specify the watching ID to mark as read. Use \`bee watching list\`
-to find watching IDs.`,
-  )
+  .description(`Use \`bee watching list\` to find watching IDs.`)
   .argument("<watching>", "Watching ID")
   .envVars([...ENV_AUTH])
   .examples([{ description: "Mark a watching item as read", command: "bee watching read 12345" }])

--- a/apps/cli/src/commands/watching/view.ts
+++ b/apps/cli/src/commands/watching/view.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const view = new BeeCommand("view")
   .summary("View a watching item")
-  .description(
-    `Display details of a watching item.
-
-Shows the watching ID, associated issue, note, read status, and timestamps.`,
-  )
+  .description(`Shows the associated issue, note, read status, and timestamps.`)
   .argument("<watching>", "Watching ID")
   .addOption(opt.json())
   .envVars([...ENV_AUTH])

--- a/apps/cli/src/commands/wiki/attachments.ts
+++ b/apps/cli/src/commands/wiki/attachments.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const attachments = new BeeCommand("attachments")
   .summary("List wiki page attachments")
-  .description(
-    `List files attached to a Backlog wiki page.
-
-Shows file name, size, creator, and creation date.`,
-  )
+  .description(`Shows file name, size, creator, and creation date.`)
   .argument("<wiki>", "Wiki page ID")
   .addOption(opt.json())
   .envVars([...ENV_AUTH])

--- a/apps/cli/src/commands/wiki/count.ts
+++ b/apps/cli/src/commands/wiki/count.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const count = new BeeCommand("count")
   .summary("Count wiki pages")
-  .description(
-    `Display the number of wiki pages in a Backlog project.
-
-The count includes all wiki pages regardless of tag or keyword.`,
-  )
+  .description(`Counts all wiki pages regardless of tag or keyword.`)
   .argument("<project>", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/wiki/create.ts
+++ b/apps/cli/src/commands/wiki/create.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const create = new BeeCommand("create")
   .summary("Create a wiki page")
-  .description(
-    `Create a new Backlog wiki page.
-
-Requires a project, page name, and body content. When input is piped,
-it is used as the body automatically.`,
-  )
+  .description(`When input is piped, it is used as the body automatically.`)
   .option("-p, --project <id>", "Project ID or project key")
   .option("-n, --name <name>", "Wiki page name")
   .option("-b, --body <text>", "Wiki page content")

--- a/apps/cli/src/commands/wiki/delete.ts
+++ b/apps/cli/src/commands/wiki/delete.ts
@@ -6,12 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const deleteWiki = new BeeCommand("delete")
   .summary("Delete a wiki page")
-  .description(
-    `Delete a Backlog wiki page.
-
-This action is irreversible. You will be prompted for confirmation unless
-\`--yes\` is provided.`,
-  )
+  .description(`This action is irreversible.`)
   .argument("<wiki>", "Wiki page ID")
   .option("-y, --yes", "Skip confirmation prompt")
   .option("--mail-notify", "Send notification email")

--- a/apps/cli/src/commands/wiki/edit.ts
+++ b/apps/cli/src/commands/wiki/edit.ts
@@ -6,13 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a wiki page")
-  .description(
-    `Update an existing Backlog wiki page.
-
-Only the specified fields will be updated. Fields that are not provided
-will remain unchanged. When input is piped, it is used as the body
-automatically.`,
-  )
+  .description(`Only specified fields are updated. When input is piped, it is used as the body automatically.`)
   .argument("<wiki>", "Wiki page ID")
   .option("-n, --name <name>", "New name of the wiki page")
   .option("-b, --body <text>", "New content of the wiki page")

--- a/apps/cli/src/commands/wiki/edit.ts
+++ b/apps/cli/src/commands/wiki/edit.ts
@@ -6,7 +6,9 @@ import * as opt from "../../lib/common-options";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a wiki page")
-  .description(`Only specified fields are updated. When input is piped, it is used as the body automatically.`)
+  .description(
+    `Only specified fields are updated. When input is piped, it is used as the body automatically.`,
+  )
   .argument("<wiki>", "Wiki page ID")
   .option("-n, --name <name>", "New name of the wiki page")
   .option("-b, --body <text>", "New content of the wiki page")

--- a/apps/cli/src/commands/wiki/history.ts
+++ b/apps/cli/src/commands/wiki/history.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const history = new BeeCommand("history")
   .summary("View wiki page history")
-  .description(
-    `Display the revision history of a Backlog wiki page.
-
-Shows version number, updater, and update date for each revision.`,
-  )
+  .description(`Shows version number, updater, and update date for each revision.`)
   .argument("<wiki>", "Wiki page ID")
   .addOption(opt.minId())
   .addOption(opt.maxId())

--- a/apps/cli/src/commands/wiki/list.ts
+++ b/apps/cli/src/commands/wiki/list.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const list = new BeeCommand("list")
   .summary("List wiki pages")
-  .description(
-    `List wiki pages in a Backlog project.
-
-Use \`--keyword\` to filter pages by name or content.`,
-  )
+  .description(`Use \`--keyword\` to filter pages by name or content.`)
   .argument("<project>", "Project ID or project key")
   .addOption(opt.keyword())
   .addOption(opt.json())

--- a/apps/cli/src/commands/wiki/tags.ts
+++ b/apps/cli/src/commands/wiki/tags.ts
@@ -6,11 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const tags = new BeeCommand("tags")
   .summary("List wiki tags")
-  .description(
-    `List wiki tags in a Backlog project.
-
-Tags are labels attached to wiki pages for organization.`,
-  )
+  .description(`Tags are labels attached to wiki pages for organization.`)
   .argument("<project>", "Project ID or project key")
   .addOption(opt.json())
   .envVars([...ENV_AUTH, ENV_PROJECT])

--- a/apps/cli/src/commands/wiki/view.ts
+++ b/apps/cli/src/commands/wiki/view.ts
@@ -6,14 +6,7 @@ import * as opt from "../../lib/common-options";
 
 const view = new BeeCommand("view")
   .summary("View a wiki page")
-  .description(
-    `Display details of a Backlog wiki page.
-
-Shows the page name, ID, tags, created/updated info, and the full body
-content.
-
-Use \`--web\` to open the wiki page in your default browser instead.`,
-  )
+  .description(`Use \`--web\` to open in the browser.`)
   .argument("<wiki>", "Wiki page ID")
   .addOption(opt.web("wiki page"))
   .addOption(opt.noBrowser())

--- a/packages/backlog-utils/src/issue-constants.ts
+++ b/packages/backlog-utils/src/issue-constants.ts
@@ -10,7 +10,7 @@ const IssueStatusId = {
  * Backlog resolution name-to-ID map.
  *
  * Resolution values are fixed in Backlog and cannot be changed by users.
- * @see https://developer.nulab.com/ja/docs/backlog/api/2/get-resolution-list/
+ * @see https://developer.nulab.com/docs/backlog/api/2/get-resolution-list/
  */
 const ResolutionId: Record<string, number> = {
   fixed: 0,
@@ -26,7 +26,7 @@ const RESOLUTION_NAMES = Object.keys(ResolutionId);
  * Backlog priority name-to-ID map.
  *
  * Priority values are fixed in Backlog and cannot be changed by users.
- * @see https://developer.nulab.com/ja/docs/backlog/api/2/get-priority-list/
+ * @see https://developer.nulab.com/docs/backlog/api/2/get-priority-list/
  */
 const PriorityId: Record<string, number> = {
   high: 2,


### PR DESCRIPTION
## Summary

Streamline help text for 100+ CLI commands by removing redundant phrasing and condensing verbose descriptions into concise, actionable guidance. This improves readability in the CLI help output while retaining essential information about command behavior.

Changes include:
- Removing repetitive introductory phrases (e.g., "Create a new Backlog..." → "Omitted fields will be prompted...")
- Consolidating multi-paragraph descriptions into 1-3 focused sentences
- Eliminating obvious context (e.g., "This action is irreversible. You will be prompted for confirmation unless `--yes` is provided." → "This action is irreversible.")
- Keeping critical details like flag descriptions, examples, and special behaviors

Affected commands span all major areas: auth, issue, project, wiki, document, pull request, repository, user, notification, watching, and more.

## Test plan

No testing needed. These are documentation-only changes to help text strings. The command functionality remains unchanged, and help text is verified by running `bee <command> --help` for any command.

https://claude.ai/code/session_01SzyrJZ5eKMhsdJhfP1nc83