### PR TITLE
feat(cli): add --category, --version, --milestone to issue create

### DIFF
--- a/apps/cli/src/commands/issue/create.test.ts
+++ b/apps/cli/src/commands/issue/create.test.ts
@@ -191,6 +191,51 @@ describe("issue create", () => {
     );
   });
 
+  it("passes categoryId, versionId, and milestoneId to API", async () => {
+    vi.mocked(promptRequired)
+      .mockResolvedValueOnce("100")
+      .mockResolvedValueOnce("Title")
+      .mockResolvedValueOnce("1")
+      .mockResolvedValueOnce("normal");
+    mockClient.postIssue.mockResolvedValue({
+      issueKey: "TEST-7",
+      summary: "Title",
+    });
+
+    const { default: create } = await import("./create");
+    await create.parseAsync(
+      [
+        "--project",
+        "100",
+        "--title",
+        "Title",
+        "--type",
+        "1",
+        "--priority",
+        "normal",
+        "--category",
+        "10",
+        "--category",
+        "20",
+        "--version",
+        "30",
+        "--milestone",
+        "40",
+        "--milestone",
+        "50",
+      ],
+      { from: "user" },
+    );
+
+    expect(mockClient.postIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        categoryId: [10, 20],
+        versionId: [30],
+        milestoneId: [40, 50],
+      }),
+    );
+  });
+
   it("outputs JSON when --json flag is set", async () => {
     vi.mocked(promptRequired)
       .mockResolvedValueOnce("100")

--- a/apps/cli/src/commands/issue/create.ts
+++ b/apps/cli/src/commands/issue/create.ts
@@ -23,6 +23,9 @@ const create = new BeeCommand("create")
   .option("-P, --priority <name>", "Priority")
   .option("-d, --description <text>", "Issue description")
   .addOption(opt.assignee())
+  .addOption(opt.category())
+  .addOption(opt.version())
+  .addOption(opt.milestone())
   .option("--parent-issue <id>", "Parent issue ID")
   .option("--start-date <date>", "Start date")
   .option("--due-date <date>", "Due date")
@@ -68,6 +71,9 @@ const create = new BeeCommand("create")
 
     const [projectId] = await resolveProjectIds(client, [project]);
     const assigneeId = opts.assignee ? await resolveUserId(client, opts.assignee) : undefined;
+    const categoryId = opts.category ?? [];
+    const versionId = opts.version ?? [];
+    const milestoneId = opts.milestone ?? [];
     const notifiedUserId = opts.notify ?? [];
     const attachmentId = opts.attachment ?? [];
 
@@ -78,6 +84,9 @@ const create = new BeeCommand("create")
       priorityId,
       description: opts.description,
       assigneeId,
+      categoryId,
+      versionId,
+      milestoneId,
       parentIssueId: opts.parentIssue ? Number(opts.parentIssue) : undefined,
       startDate: opts.startDate,
       dueDate: opts.dueDate,

--- a/apps/cli/src/commands/issue/edit.test.ts
+++ b/apps/cli/src/commands/issue/edit.test.ts
@@ -99,6 +99,39 @@ describe("issue edit", () => {
     );
   });
 
+  it("passes categoryId, versionId, and milestoneId to API", async () => {
+    mockClient.patchIssue.mockResolvedValue({ issueKey: "TEST-1", summary: "Title" });
+
+    const { default: edit } = await import("./edit");
+    await edit.parseAsync(
+      [
+        "TEST-1",
+        "--title",
+        "Title",
+        "--category",
+        "10",
+        "--category",
+        "20",
+        "--version",
+        "30",
+        "--milestone",
+        "40",
+        "--milestone",
+        "50",
+      ],
+      { from: "user" },
+    );
+
+    expect(mockClient.patchIssue).toHaveBeenCalledWith(
+      "TEST-1",
+      expect.objectContaining({
+        categoryId: [10, 20],
+        versionId: [30],
+        milestoneId: [40, 50],
+      }),
+    );
+  });
+
   it("outputs JSON when --json flag is set", async () => {
     mockClient.patchIssue.mockResolvedValue({ issueKey: "TEST-1", summary: "Title" });
 

--- a/apps/cli/src/commands/issue/edit.ts
+++ b/apps/cli/src/commands/issue/edit.ts
@@ -14,6 +14,9 @@ const edit = new BeeCommand("edit")
   .option("-P, --priority <name>", `Change priority`)
   .option("-T, --type <id>", "New issue type ID")
   .option("--assignee <id>", "New assignee user ID. Use @me for yourself.")
+  .addOption(opt.category())
+  .addOption(opt.version())
+  .addOption(opt.milestone())
   .option("--resolution <id>", "Resolution ID")
   .option("--parent-issue <id>", "New parent issue ID")
   .option("--start-date <date>", "New start date")
@@ -43,6 +46,9 @@ const edit = new BeeCommand("edit")
   .action(async (issue, opts) => {
     const { client } = await getClient(opts.space);
 
+    const categoryId = opts.category ?? [];
+    const versionId = opts.version ?? [];
+    const milestoneId = opts.milestone ?? [];
     const notifiedUserId = opts.notify ?? [];
     const attachmentId = opts.attachment ?? [];
 
@@ -63,6 +69,9 @@ const edit = new BeeCommand("edit")
       priorityId,
       issueTypeId: opts.type ? Number(opts.type) : undefined,
       assigneeId: opts.assignee ? await resolveUserId(client, opts.assignee) : undefined,
+      categoryId,
+      versionId,
+      milestoneId,
       resolutionId: opts.resolution ? Number(opts.resolution) : undefined,
       parentIssueId: opts.parentIssue ? Number(opts.parentIssue) : undefined,
       startDate: opts.startDate,

--- a/apps/cli/src/lib/common-options.ts
+++ b/apps/cli/src/lib/common-options.ts
@@ -24,6 +24,12 @@ const notify = () =>
   new Option("--notify <id>", "User IDs to notify (repeatable)").argParser(collectNum).default([]);
 const attachment = () =>
   new Option("--attachment <id>", "Attachment IDs (repeatable)").argParser(collectNum).default([]);
+const category = () =>
+  new Option("--category <id>", "Category IDs (repeatable)").argParser(collectNum).default([]);
+const version = () =>
+  new Option("--version <id>", "Version IDs (repeatable)").argParser(collectNum).default([]);
+const milestone = () =>
+  new Option("--milestone <id>", "Milestone IDs (repeatable)").argParser(collectNum).default([]);
 const comment = () => new Option("-c, --comment <text>", "Comment to add with the update");
 const web = (resource: string) => new Option("-w, --web", `Open the ${resource} in the browser`);
 const noBrowser = () =>
@@ -52,6 +58,9 @@ export {
   issue,
   notify,
   attachment,
+  category,
+  version,
+  milestone,
   comment,
   web,
   noBrowser,


### PR DESCRIPTION
## Summary
- Add `--category`, `--version`, `--milestone` options to `bee issue create` and `bee issue edit`
- These Backlog API parameters (`categoryId`, `versionId`, `milestoneId`) were previously unsupported in both commands
- All three accept repeatable numeric IDs (e.g. `--category 10 --category 20`)
- Shared option definitions added to `common-options.ts` for reuse

## Test plan
- [x] New test cases verify all three options for both `issue create` and `issue edit`
- [x] All 16 tests pass (8 create + 8 edit)
- [x] Linting passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)