### PR TITLE
feat(cli): add --attachment option to issue comment

### DIFF
--- a/apps/cli/src/commands/issue/comment.test.ts
+++ b/apps/cli/src/commands/issue/comment.test.ts
@@ -34,6 +34,7 @@ describe("issue comment", () => {
     expect(mockClient.postIssueComments).toHaveBeenCalledWith("TEST-1", {
       content: "Hello",
       notifiedUserId: [],
+      attachmentId: [],
     });
     expect(consola.success).toHaveBeenCalledWith("Added comment to TEST-1");
   });
@@ -49,6 +50,7 @@ describe("issue comment", () => {
     expect(mockClient.postIssueComments).toHaveBeenCalledWith("TEST-1", {
       content: "Stdin content",
       notifiedUserId: [],
+      attachmentId: [],
     });
   });
 
@@ -63,6 +65,23 @@ describe("issue comment", () => {
     expect(mockClient.postIssueComments).toHaveBeenCalledWith("TEST-1", {
       content: "FYI",
       notifiedUserId: [111, 222],
+      attachmentId: [],
+    });
+  });
+
+  it("adds a comment with attachments", async () => {
+    mockClient.postIssueComments.mockResolvedValue({ id: 4, content: "See attached" });
+
+    const { default: comment } = await import("./comment");
+    await comment.parseAsync(
+      ["TEST-1", "--body", "See attached", "--attachment", "1", "--attachment", "2"],
+      { from: "user" },
+    );
+
+    expect(mockClient.postIssueComments).toHaveBeenCalledWith("TEST-1", {
+      content: "See attached",
+      notifiedUserId: [],
+      attachmentId: [1, 2],
     });
   });
 

--- a/apps/cli/src/commands/issue/comment.ts
+++ b/apps/cli/src/commands/issue/comment.ts
@@ -21,6 +21,7 @@ Use \`--list\`, \`--edit-last\`, or \`--delete-last\` for other comment operatio
   .argument("<issue>", "Issue ID or issue key")
   .option("-b, --body <text>", "Comment body")
   .addOption(opt.notify())
+  .addOption(opt.attachment())
   .option("--list", "List comments on the issue")
   .option("--edit-last", "Edit your most recent comment")
   .option("--delete-last", "Delete your most recent comment")
@@ -129,10 +130,12 @@ Use \`--list\`, \`--edit-last\`, or \`--delete-last\` for other comment operatio
       return;
     }
     const notifiedUserId = opts.notify ?? [];
+    const attachmentId = opts.attachment ?? [];
 
     const result = await client.postIssueComments(issue, {
       content,
       notifiedUserId,
+      attachmentId,
     });
 
     outputResult(result, opts as { json?: string }, () => {


### PR DESCRIPTION
## Summary
- Add `--attachment` option to `bee issue comment` for attaching files to comments
- The Backlog API (`postIssueComments`) supports `attachmentId: number[]` but this was not exposed in the CLI
- Accepts repeatable numeric IDs (e.g. `--attachment 1 --attachment 2`)

## Test plan
- [x] New test verifies attachmentId is passed to the API
- [x] Existing tests updated to include the new default `attachmentId: []`
- [x] All 15 tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)