### PR TITLE
feat(cli): add missing filter options to issue list

### DIFF
--- a/apps/cli/src/commands/issue/list.test.ts
+++ b/apps/cli/src/commands/issue/list.test.ts
@@ -112,6 +112,65 @@ describe("issue list", () => {
     );
   });
 
+  it("passes issue type filter", async () => {
+    mockClient.getIssues.mockResolvedValue([]);
+
+    const { default: list } = await import("./list");
+    await list.parseAsync(["--type", "1", "--type", "2"], { from: "user" });
+
+    expect(mockClient.getIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ issueTypeId: [1, 2] }),
+    );
+  });
+
+  it("passes category, version, and milestone filters", async () => {
+    mockClient.getIssues.mockResolvedValue([]);
+
+    const { default: list } = await import("./list");
+    await list.parseAsync(
+      ["--category", "10", "--version", "20", "--milestone", "30", "--milestone", "31"],
+      { from: "user" },
+    );
+
+    expect(mockClient.getIssues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        categoryId: [10],
+        versionId: [20],
+        milestoneId: [30, 31],
+      }),
+    );
+  });
+
+  it("passes resolution and parent issue filters", async () => {
+    mockClient.getIssues.mockResolvedValue([]);
+
+    const { default: list } = await import("./list");
+    await list.parseAsync(["--resolution", "0", "--parent-issue", "100"], { from: "user" });
+
+    expect(mockClient.getIssues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolutionId: [0],
+        parentIssueId: [100],
+      }),
+    );
+  });
+
+  it("passes start date range filters", async () => {
+    mockClient.getIssues.mockResolvedValue([]);
+
+    const { default: list } = await import("./list");
+    await list.parseAsync(["--start-since", "2026-01-01", "--start-until", "2026-12-31"], {
+      from: "user",
+    });
+
+    expect(mockClient.getIssues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startDateSince: "2026-01-01",
+        startDateUntil: "2026-12-31",
+      }),
+    );
+  });
+
   it("outputs JSON when --json flag is set", async () => {
     mockClient.getIssues.mockResolvedValue(sampleIssues);
 

--- a/apps/cli/src/commands/issue/list.ts
+++ b/apps/cli/src/commands/issue/list.ts
@@ -35,11 +35,19 @@ const list = new BeeCommand("list")
   .addOption(opt.assigneeList())
   .option("-S, --status <id>", "Status ID (repeatable)", collectNum, [] satisfies number[])
   .option("-P, --priority <name>", "Priority name (repeatable)", collect, [] satisfies string[])
+  .option("-T, --type <id>", "Issue type ID (repeatable)", collectNum, [] satisfies number[])
+  .option("--category <id>", "Category ID (repeatable)", collectNum, [] satisfies number[])
+  .option("--version <id>", "Version ID (repeatable)", collectNum, [] satisfies number[])
+  .option("--milestone <id>", "Milestone ID (repeatable)", collectNum, [] satisfies number[])
+  .option("--resolution <id>", "Resolution ID (repeatable)", collectNum, [] satisfies number[])
+  .option("--parent-issue <id>", "Parent issue ID (repeatable)", collectNum, [] satisfies number[])
   .addOption(opt.keyword())
   .option("--created-since <date>", "Show issues created on or after this date")
   .option("--created-until <date>", "Show issues created on or before this date")
   .option("--updated-since <date>", "Show issues updated on or after this date")
   .option("--updated-until <date>", "Show issues updated on or before this date")
+  .option("--start-since <date>", "Show issues starting on or after this date")
+  .option("--start-until <date>", "Show issues starting on or before this date")
   .option("--due-since <date>", "Show issues due on or after this date")
   .option("--due-until <date>", "Show issues due on or before this date")
   .option("--sort <field>", "Sort field")
@@ -75,12 +83,24 @@ const list = new BeeCommand("list")
     );
     const statusId: number[] = opts.status;
     const priorityId = opts.priority.length > 0 ? resolvePriorityIds(opts.priority) : [];
+    const issueTypeId: number[] = opts.type;
+    const categoryId: number[] = opts.category;
+    const versionId: number[] = opts.version;
+    const milestoneId: number[] = opts.milestone;
+    const resolutionId: number[] = opts.resolution;
+    const parentIssueId: number[] = opts.parentIssue;
 
     const issues = await client.getIssues({
       projectId,
       assigneeId,
       statusId,
       priorityId,
+      issueTypeId,
+      categoryId,
+      versionId,
+      milestoneId,
+      resolutionId,
+      parentIssueId,
       keyword: opts.keyword,
       sort: opts.sort,
       order: opts.order,
@@ -90,6 +110,8 @@ const list = new BeeCommand("list")
       createdUntil: opts.createdUntil,
       updatedSince: opts.updatedSince,
       updatedUntil: opts.updatedUntil,
+      startDateSince: opts.startSince,
+      startDateUntil: opts.startUntil,
       dueDateSince: opts.dueSince,
       dueDateUntil: opts.dueUntil,
     });


### PR DESCRIPTION
## Summary
- Add filter options to `bee issue list` that were available in the Backlog API but not exposed in the CLI
- New filters: `--type`, `--category`, `--version`, `--milestone`, `--resolution`, `--parent-issue`, `--start-since`, `--start-until`
- All repeatable ID filters accept multiple values (e.g. `--type 1 --type 2`)

### Before vs After

| Filter | API param | Before | After |
|---|---|---|---|
| Issue type | `issueTypeId` | ❌ | ✅ `--type` |
| Category | `categoryId` | ❌ | ✅ `--category` |
| Version | `versionId` | ❌ | ✅ `--version` |
| Milestone | `milestoneId` | ❌ | ✅ `--milestone` |
| Resolution | `resolutionId` | ❌ | ✅ `--resolution` |
| Parent issue | `parentIssueId` | ❌ | ✅ `--parent-issue` |
| Start date range | `startDateSince/Until` | ❌ | ✅ `--start-since/until` |

## Test plan
- [x] 4 new test cases covering all added filters
- [x] All 12 tests pass (8 existing + 4 new)
- [x] Linting passes with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)