### PR TITLE
Remove unused ufo dependency from CLI

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -42,7 +42,6 @@
     "consola": "^3.4.2",
     "is-unicode-supported": "^2.1.0",
     "open": "^11.0.0",
-    "ufo": "^1.5.4",
     "valibot": "^1.2.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       open:
         specifier: ^11.0.0
         version: 11.0.0
-      ufo:
-        specifier: ^1.5.4
-        version: 1.6.3
       valibot:
         specifier: ^1.2.0
         version: 1.2.0(typescript@6.0.0-dev.20260301)


### PR DESCRIPTION
## Summary

Removes the unused `ufo` package (^1.5.4) from the CLI app's dependencies. This dependency is no longer needed and can be safely removed to reduce the dependency footprint.

## Test plan

N/A - This is a dependency cleanup with no source code changes. Existing tests will verify that the CLI continues to function correctly.

https://claude.ai/code/session_013WYAurfosNqN1VYjHcCvjC