### PR TITLE
Document pagination behavior for list commands

### DIFF
--- a/skills/using-bee/SKILL.md
+++ b/skills/using-bee/SKILL.md
@@ -78,6 +78,17 @@ bee api issues -f 'projectId[]=12345' -f statusId=1 -f statusId=2
 bee api issues -X POST -f projectId=12345 -f summary="New issue" -f issueTypeId=1 -f priorityId=3
 ```
 
+**Pagination** — Many list commands return **at most 20 items by default**. Receiving 20 results does NOT mean you have fetched everything — there may be more pages. Use `--count` and `--offset` to paginate:
+
+```sh
+bee issue list -p PROJECT --count 100              # up to 100 items
+bee issue list -p PROJECT --count 100 --offset 100 # next 100 items
+```
+
+Some commands use cursor-based pagination (`--min-id` / `--max-id`) instead of `--offset`. Check `bee <command> --help` for the available pagination flags.
+
+To reliably get **all** items, loop with increasing `--offset` (or advancing `--min-id` / `--max-id`) until the returned array is empty or shorter than `--count`.
+
 **`bee browse` for opening pages** — Open Backlog pages in the browser:
 
 ```sh

--- a/skills/using-bee/SKILL.md
+++ b/skills/using-bee/SKILL.md
@@ -78,16 +78,7 @@ bee api issues -f 'projectId[]=12345' -f statusId=1 -f statusId=2
 bee api issues -X POST -f projectId=12345 -f summary="New issue" -f issueTypeId=1 -f priorityId=3
 ```
 
-**Pagination** — Many list commands return **at most 20 items by default**. Receiving 20 results does NOT mean you have fetched everything — there may be more pages. Use `--count` and `--offset` to paginate:
-
-```sh
-bee issue list -p PROJECT --count 100              # up to 100 items
-bee issue list -p PROJECT --count 100 --offset 100 # next 100 items
-```
-
-Some commands use cursor-based pagination (`--min-id` / `--max-id`) instead of `--offset`. Check `bee <command> --help` for the available pagination flags.
-
-To reliably get **all** items, loop with increasing `--offset` (or advancing `--min-id` / `--max-id`) until the returned array is empty or shorter than `--count`.
+**Pagination** — Commands that accept `--count` return **at most 20 items by default** (not all items). Always check whether the result count equals the limit before assuming you have everything. Use `--count` to change the page size and `--offset` (or `--min-id` / `--max-id`) to fetch subsequent pages.
 
 **`bee browse` for opening pages** — Open Backlog pages in the browser:
 


### PR DESCRIPTION
## Summary

Added comprehensive documentation about pagination for list commands in the `bee` CLI tool. The new section explains:

- Default limit of 20 items per request
- How to use `--count` and `--offset` flags for offset-based pagination
- Alternative cursor-based pagination with `--min-id` / `--max-id` flags
- Best practices for reliably fetching all items by looping until results are empty or shorter than the requested count

This clarifies an important aspect of the API that users need to understand to avoid missing data when working with list commands.

## Test plan

N/A - Documentation only change

https://claude.ai/code/session_01UfcbYH3W7Qi5XR7gfQAQhf