### PR TITLE
Update README badges and Node.js version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/nulab/bee/ci.yml?logo=github&label=CI)](https://github.com/nulab/bee/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/nulab/bee/codeql.yml?logo=github&label=CodeQL)](https://github.com/nulab/bee/actions/workflows/codeql.yml)
 [![npm version](https://img.shields.io/npm/v/@nulab/bee?logo=npm)](https://www.npmjs.com/package/@nulab/bee)
+[![npm last publish](https://img.shields.io/npm/last-update/@nulab/bee?logo=npm&label=last%20publish)](https://www.npmjs.com/package/@nulab/bee)
 [![node](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=nodedotjs)](https://nodejs.org/)
 [![license](https://img.shields.io/github/license/nulab/bee?logo=opensourceinitiative)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![npm last publish](https://img.shields.io/npm/last-update/@nulab/bee?logo=npm&label=last%20publish)](https://www.npmjs.com/package/@nulab/bee)
 [![node](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=nodedotjs)](https://nodejs.org/)
 [![license](https://img.shields.io/github/license/nulab/bee?logo=opensourceinitiative)](LICENSE)
+[![docs](https://img.shields.io/badge/docs-Starlight-purple?logo=astro&logoColor=white)](https://nulab.github.io/bee)
 
 Bring [Backlog](https://backlog.com/) to your command line.
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/nulab/bee/ci.yml?logo=github&label=CI)](https://github.com/nulab/bee/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/nulab/bee/codeql.yml?logo=github&label=CodeQL)](https://github.com/nulab/bee/actions/workflows/codeql.yml)
 [![npm version](https://img.shields.io/npm/v/@nulab/bee?logo=npm)](https://www.npmjs.com/package/@nulab/bee)
-[![node](https://img.shields.io/node/v/@nulab/bee?logo=nodedotjs)](https://nodejs.org/)
-[![last commit](https://img.shields.io/github/last-commit/nulab/bee?logo=github)](https://github.com/nulab/bee/commits/main)
+[![node](https://img.shields.io/badge/node-%3E%3D20-brightgreen?logo=nodedotjs)](https://nodejs.org/)
 [![license](https://img.shields.io/github/license/nulab/bee?logo=opensourceinitiative)](LICENSE)
 
 Bring [Backlog](https://backlog.com/) to your command line.


### PR DESCRIPTION
## Summary

Updates the README.md badges to reflect current project status:
- Replaces the "last commit" badge with an "npm last publish" badge to better indicate package release status
- Updates the Node.js version badge from a dynamic version display to an explicit minimum version requirement (Node.js >= 20)

## Test plan

N/A - Documentation-only changes to README badges

https://claude.ai/code/session_013Ud9bgyo4BTN1etRwSMon2