### PR TITLE
Add Backlog notation syntax reference skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,10 +70,10 @@ Command reference pages are **auto-generated** from CLI source code — do NOT c
 
 AI エージェント向けの Skill 定義を格納するディレクトリ。
 
-| Skill | 用途 |
-|---|---|
-| `using-bee` | bee CLI の使い方（コマンド、フラグ、パターン） |
-| `backlog-notation` | Backlog 記法（Backlog記法）の構文リファレンス |
+| Skill              | 用途                                           |
+| ------------------ | ---------------------------------------------- |
+| `using-bee`        | bee CLI の使い方（コマンド、フラグ、パターン） |
+| `backlog-notation` | Backlog 記法（Backlog記法）の構文リファレンス  |
 
 #### Definition lists
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,17 @@ Command reference pages are **auto-generated** from CLI source code — do NOT c
 
 **When adding or removing CLI commands**, also update the command table in `skills/using-bee/SKILL.md` to keep the Skill in sync with the CLI.
 
+### Skills (`skills/`)
+
+AI エージェント向けの Skill 定義を格納するディレクトリ。
+
+| Skill | 用途 | 自動トリガー |
+|---|---|---|
+| `using-bee` | bee CLI の使い方（コマンド、フラグ、パターン） | Yes — Backlog 関連の会話で自動発動 |
+| `backlog-notation` | Backlog 記法（Backlog記法）の構文リファレンス | No — AGENTS.md やプロンプトで明示的に有効化 |
+
+`backlog-notation` は Backlog 記法を使うプロジェクト向けの構文リファレンスです。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、このスキルは自動トリガーされません。Backlog 記法を使うプロジェクトで作業する場合は、プロジェクトの AGENTS.md やプロンプトで明示的に有効化してください。
+
 #### Definition lists
 
 The docs site supports Markdown definition list syntax via `remark-definition-list`. Use this instead of raw `<dl>`/`<dt>`/`<dd>` HTML:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,12 +70,10 @@ Command reference pages are **auto-generated** from CLI source code — do NOT c
 
 AI エージェント向けの Skill 定義を格納するディレクトリ。
 
-| Skill | 用途 | 自動トリガー |
-|---|---|---|
-| `using-bee` | bee CLI の使い方（コマンド、フラグ、パターン） | Yes — Backlog 関連の会話で自動発動 |
-| `backlog-notation` | Backlog 記法（Backlog記法）の構文リファレンス | No — AGENTS.md やプロンプトで明示的に有効化 |
-
-`backlog-notation` は Backlog 記法を使うプロジェクト向けの構文リファレンスです。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、このスキルは自動トリガーされません。Backlog 記法を使うプロジェクトで作業する場合は、プロジェクトの AGENTS.md やプロンプトで明示的に有効化してください。
+| Skill | 用途 |
+|---|---|
+| `using-bee` | bee CLI の使い方（コマンド、フラグ、パターン） |
+| `backlog-notation` | Backlog 記法（Backlog記法）の構文リファレンス |
 
 #### Definition lists
 

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -64,6 +64,16 @@ bee を AI エージェントの Skill として登録する方法です。
    npx skills add nulab/bee --skill using-bee
    ```
 
+   Backlog 記法（Markdown ではなく Backlog 独自の記法）を使うプロジェクトでは、構文リファレンスのスキルも追加できます。
+
+   ```sh
+   npx skills add nulab/bee --skill backlog-notation
+   ```
+
+   :::note
+   `backlog-notation` はオプションです。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、Backlog 記法を使うプロジェクトでのみ追加してください。
+   :::
+
 3. **エージェントから使う**
 
    スキルを登録すると、やりたいことを伝えるだけで bee を使って Backlog を操作してくれます。プロンプトに「Backlog」や課題キーなど、Backlog に関連する単語を含めるとスキルがトリガーされます。

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -71,7 +71,7 @@ bee を AI エージェントの Skill として登録する方法です。
    ```
 
    Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、`backlog-notation` はインストールしただけでは自動的に適用されません。
-   使いたいときにプロンプトで `/backlog-notation Backlog 記法で課題の説明文を書いて` のように明示的に指示するか、Backlog 記法を常に使うプロジェクトであれば AGENTS.md に以下のように記載しておくと毎回指示する必要がなくなります。
+   使いたいときにプロンプトで `/backlog-notation PROJECT-123 の説明文をリファクタリングの内容に合わせて更新して` のように明示的に指示するか、Backlog 記法を常に使うプロジェクトであれば AGENTS.md に以下のように記載しておくと毎回指示する必要がなくなります。
 
    ```markdown
    ## Backlog

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -71,7 +71,26 @@ bee を AI エージェントの Skill として登録する方法です。
    ```
 
    :::note
-   `backlog-notation` はインストールしただけでは自動的に適用されません。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、利用するにはプロンプトで明示的に指示するか、プロジェクトの AGENTS.md に記載して有効化してください。
+   `backlog-notation` はインストールしただけでは自動的に適用されません。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、利用するには以下のいずれかの方法で有効化してください。
+
+   **方法 1: プロンプトで指示する**
+
+   会話の中で Backlog 記法を使うよう明示的に伝えます。
+
+   ```
+   Backlog 記法で課題の説明文を書いて。backlog-notation スキルを参照して。
+   ```
+
+   **方法 2: プロジェクトの AGENTS.md に記載する**
+
+   Backlog 記法を常に使うプロジェクトでは、AGENTS.md に記載しておくと毎回指示する必要がなくなります。
+
+   ```markdown
+   ## Backlog
+
+   このプロジェクトの Backlog スペースは Backlog 記法を使用しています。
+   Backlog に課題やコメントを書く際は backlog-notation スキルに従ってください。
+   ```
    :::
 
 3. **エージェントから使う**

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -70,7 +70,8 @@ bee を AI エージェントの Skill として登録する方法です。
    npx skills add nulab/bee --skill backlog-notation
    ```
 
-   Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、`backlog-notation` はインストールしただけでは自動的に適用されません。プロンプトで `Backlog 記法で課題の説明文を書いて。backlog-notation スキルを参照して。` のように明示的に指示するか、Backlog 記法を常に使うプロジェクトであれば AGENTS.md に以下のように記載しておくと毎回指示する必要がなくなります。
+   Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、`backlog-notation` はインストールしただけでは自動的に適用されません。
+   使いたいときにプロンプトで `/backlog-notation Backlog 記法で課題の説明文を書いて` のように明示的に指示するか、Backlog 記法を常に使うプロジェクトであれば AGENTS.md に以下のように記載しておくと毎回指示する必要がなくなります。
 
    ```markdown
    ## Backlog

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -70,20 +70,7 @@ bee を AI エージェントの Skill として登録する方法です。
    npx skills add nulab/bee --skill backlog-notation
    ```
 
-   :::note
-   `backlog-notation` はインストールしただけでは自動的に適用されません。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、利用するには以下のいずれかの方法で有効化してください。
-
-   **方法 1: プロンプトで指示する**
-
-   会話の中で Backlog 記法を使うよう明示的に伝えます。
-
-   ```
-   Backlog 記法で課題の説明文を書いて。backlog-notation スキルを参照して。
-   ```
-
-   **方法 2: プロジェクトの AGENTS.md に記載する**
-
-   Backlog 記法を常に使うプロジェクトでは、AGENTS.md に記載しておくと毎回指示する必要がなくなります。
+   Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、`backlog-notation` はインストールしただけでは自動的に適用されません。プロンプトで `Backlog 記法で課題の説明文を書いて。backlog-notation スキルを参照して。` のように明示的に指示するか、Backlog 記法を常に使うプロジェクトであれば AGENTS.md に以下のように記載しておくと毎回指示する必要がなくなります。
 
    ```markdown
    ## Backlog
@@ -91,7 +78,6 @@ bee を AI エージェントの Skill として登録する方法です。
    このプロジェクトの Backlog スペースは Backlog 記法を使用しています。
    Backlog に課題やコメントを書く際は backlog-notation スキルに従ってください。
    ```
-   :::
 
 3. **エージェントから使う**
 

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -71,7 +71,7 @@ bee を AI エージェントの Skill として登録する方法です。
    ```
 
    :::note
-   `backlog-notation` はオプションです。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、Backlog 記法を使うプロジェクトでのみ追加してください。
+   `backlog-notation` はインストールしただけでは自動的に適用されません。Backlog ではプロジェクトごとに Markdown か Backlog 記法を選択できるため、利用するにはプロンプトで明示的に指示するか、プロジェクトの AGENTS.md に記載して有効化してください。
    :::
 
 3. **エージェントから使う**

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -76,8 +76,8 @@ bee を AI エージェントの Skill として登録する方法です。
    ```markdown
    ## Backlog
 
-   このプロジェクトの Backlog プロジェクトでは Backlog 記法を使用しています。
-   Backlog に課題やコメントを書く際は backlog-notation スキルに従った装飾をしてください。
+   This project's Backlog project uses Backlog notation (Backlog記法).
+   When writing issues or comments on Backlog, follow the backlog-notation skill for formatting.
    ```
 
 3. **エージェントから使う**

--- a/apps/docs/src/content/docs/integrations/ai-agent.mdx
+++ b/apps/docs/src/content/docs/integrations/ai-agent.mdx
@@ -76,8 +76,8 @@ bee を AI エージェントの Skill として登録する方法です。
    ```markdown
    ## Backlog
 
-   このプロジェクトの Backlog スペースは Backlog 記法を使用しています。
-   Backlog に課題やコメントを書く際は backlog-notation スキルに従ってください。
+   このプロジェクトの Backlog プロジェクトでは Backlog 記法を使用しています。
+   Backlog に課題やコメントを書く際は backlog-notation スキルに従った装飾をしてください。
    ```
 
 3. **エージェントから使う**

--- a/skills/backlog-notation/SKILL.md
+++ b/skills/backlog-notation/SKILL.md
@@ -9,28 +9,28 @@ Backlog notation (Backlog記法) syntax reference. This is **not Markdown** — 
 
 ## Quick Reference
 
-| Feature | Syntax |
-|---|---|
-| Heading | `* H1` / `** H2` / `*** H3` / `**** H4` |
-| Bold | `''text''` |
-| Italic | `'''text'''` |
-| Strikethrough | `%%text%%` |
-| Color | `&color(red) { text }` |
-| Color + background | `&color(#fff, #333) { text }` |
-| Bullet list | `- item` (nest with `--`) |
-| Numbered list | `+ item` (nest with `++`) |
-| Checklist | `- [ ] todo` / `- [x] done` (issue descriptions only) |
-| Link | `[[https://example.com]]` |
-| Labeled link | `[[label>https://example.com]]` |
-| Issue link | `PROJECT-123` (auto-linked) |
-| Quote | `> text` or `{quote}...{/quote}` |
-| Code block | `{code}...{/code}` |
-| Code (lang) | `{code:java}...{/code}` |
-| Image | `#image(URL or filename)` |
-| Thumbnail | `#thumbnail(URL or filename)` (< 200KB) |
-| Table of contents | `#contents` |
-| Line break | `&br;` |
-| Escape | `\` before special characters |
+| Feature            | Syntax                                                |
+| ------------------ | ----------------------------------------------------- |
+| Heading            | `* H1` / `** H2` / `*** H3` / `**** H4`               |
+| Bold               | `''text''`                                            |
+| Italic             | `'''text'''`                                          |
+| Strikethrough      | `%%text%%`                                            |
+| Color              | `&color(red) { text }`                                |
+| Color + background | `&color(#fff, #333) { text }`                         |
+| Bullet list        | `- item` (nest with `--`)                             |
+| Numbered list      | `+ item` (nest with `++`)                             |
+| Checklist          | `- [ ] todo` / `- [x] done` (issue descriptions only) |
+| Link               | `[[https://example.com]]`                             |
+| Labeled link       | `[[label>https://example.com]]`                       |
+| Issue link         | `PROJECT-123` (auto-linked)                           |
+| Quote              | `> text` or `{quote}...{/quote}`                      |
+| Code block         | `{code}...{/code}`                                    |
+| Code (lang)        | `{code:java}...{/code}`                               |
+| Image              | `#image(URL or filename)`                             |
+| Thumbnail          | `#thumbnail(URL or filename)` (< 200KB)               |
+| Table of contents  | `#contents`                                           |
+| Line break         | `&br;`                                                |
+| Escape             | `\` before special characters                         |
 
 ## Tables
 
@@ -44,18 +44,18 @@ Separate cells with `|`. End a row with `h` for a header row. Prefix a cell with
 
 ## Markdown → Backlog Notation Conversion
 
-| Markdown | Backlog Notation |
-|---|---|
-| `# H1` | `* H1` |
-| `**bold**` | `''bold''` |
-| `*italic*` | `'''italic'''` |
-| `~~strike~~` | `%%strike%%` |
-| `1. item` | `+ item` |
-| `` ``` `` | `{code}` / `{/code}` |
-| `[text](url)` | `[[text>url]]` |
-| `![alt](url)` | `#image(url)` |
-| `\|---\|` separator | `\|h` at end of row |
-| N/A | `&color(red) { text }` |
+| Markdown            | Backlog Notation       |
+| ------------------- | ---------------------- |
+| `# H1`              | `* H1`                 |
+| `**bold**`          | `''bold''`             |
+| `*italic*`          | `'''italic'''`         |
+| `~~strike~~`        | `%%strike%%`           |
+| `1. item`           | `+ item`               |
+| ` ``` `             | `{code}` / `{/code}`   |
+| `[text](url)`       | `[[text>url]]`         |
+| `![alt](url)`       | `#image(url)`          |
+| `\|---\|` separator | `\|h` at end of row    |
+| N/A                 | `&color(red) { text }` |
 
 ## Gotchas
 

--- a/skills/backlog-notation/SKILL.md
+++ b/skills/backlog-notation/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: backlog-notation
+description: Use when writing or converting text in Backlog notation (Backlog記法) — the native markup syntax used in Nulab Backlog for issues, wikis, pull requests, and comments. Do NOT use for Markdown-formatted Backlog projects.
+---
+
+# backlog-notation
+
+Backlog notation (Backlog記法) is the native markup syntax for Nulab Backlog. It is **not Markdown**. Projects that use Backlog notation require this specific syntax for issues, wikis, PRs, and comments.
+
+> **When to use:** The user's Backlog project is configured to use **Backlog記法** (not Markdown). If the project uses Markdown, use standard Markdown instead.
+
+## Quick Reference
+
+| Feature | Syntax |
+|---|---|
+| Heading | `* H1` / `** H2` / `*** H3` |
+| Bold | `''bold''` |
+| Italic | `'''italic'''` |
+| Strikethrough | `%%strikethrough%%` |
+| Color | `&color(red) { text }` |
+| Background color | `&color(#fff, #333) { text }` |
+| Bullet list | `- item` |
+| Numbered list | `+ item` |
+| Checklist | `- [ ] todo` / `- [x] done` |
+| Link (URL) | `[[https://example.com]]` |
+| Link (labeled) | `[[label>https://example.com]]` |
+| Issue link | `PROJECT-123` or `[[PROJECT-123]]` |
+| Quote (inline) | `> quoted text` |
+| Quote (block) | `{quote} ... {/quote}` |
+| Code (block) | `{code} ... {/code}` |
+| Code (syntax) | `{code:java} ... {/code}` |
+| Image | `#image(URL)` |
+| Thumbnail | `#thumbnail(URL)` |
+| Table of contents | `#contents` |
+| Line break | `&br;` |
+| Escape | `\` before special characters |
+
+## Headings
+
+Lines starting with `*` become headings. More `*` = deeper level.
+
+```
+* Heading 1
+** Heading 2
+*** Heading 3
+**** Heading 4
+```
+
+## Lists
+
+### Bullet list
+
+```
+- Item 1
+- Item 2
+-- Nested item
+-- Nested item
+- Item 3
+```
+
+### Numbered list
+
+```
++ First
++ Second
+++ Nested numbered
++ Third
+```
+
+### Checklist (issue descriptions only)
+
+```
+- [ ] Not done
+- [x] Done
+```
+
+## Text Styling
+
+```
+''bold text''
+'''italic text'''
+%%strikethrough text%%
+&color(red) { red text }
+&color(#ffffff, #8abe00) { text with background color }
+```
+
+- `&color(colorName) { text }` — sets text color
+- `&color(textColor, bgColor) { text }` — sets text and background color
+- Colors accept names (`red`, `blue`) or hex codes (`#ff0000`)
+
+## Links
+
+```
+[[https://example.com]]
+[[Click here>https://example.com]]
+[[PROJECT-123]]
+```
+
+Issue keys written directly (e.g., `PROJECT-123`) are automatically linked.
+
+## Tables
+
+Cells are separated by `|`. End a row with `h` to make it a header row. Prefix a cell with `~` to make that cell a header.
+
+```
+|Column A|Column B|Column C|h
+|data 1|data 2|data 3|
+|~Row header|data 4|data 5|
+```
+
+To merge cells horizontally, use `>` in the cell to be merged:
+
+```
+|Span two columns|>|Column C|h
+|data 1|data 2|data 3|
+```
+
+## Quotes
+
+Single-line:
+
+```
+> This is a quote.
+```
+
+Multi-line:
+
+```
+{quote}
+This is a
+multi-line quote.
+{/quote}
+```
+
+## Code Blocks
+
+Generic code:
+
+```
+{code}
+const x = 1;
+{/code}
+```
+
+With syntax highlighting (supported: `java`, `cs`, `js`, `python`, `ruby`, `perl`, `php`, `sql`, `html`, `xml`, `css`, `shell`, etc.):
+
+```
+{code:java}
+public class Hello {
+    public static void main(String[] args) {
+        System.out.println("Hello");
+    }
+}
+{/code}
+```
+
+## Images
+
+```
+#image(https://example.com/image.png)
+#thumbnail(https://example.com/image.png)
+```
+
+For wiki-attached files:
+
+```
+#image(filename.png)
+#thumbnail(filename.png)
+```
+
+Thumbnail display requires the image to be under 200KB.
+
+## Table of Contents
+
+```
+#contents
+```
+
+Automatically generates a table of contents from headings on the page.
+
+## Line Break
+
+```
+Text before&br;Text after
+```
+
+## Escape Special Characters
+
+Prefix with `\` to display literal special characters:
+
+```
+\* Not a heading
+\- Not a list
+```
+
+## Key Differences from Markdown
+
+| Feature | Markdown | Backlog Notation |
+|---|---|---|
+| Heading | `# H1` | `* H1` |
+| Bold | `**bold**` | `''bold''` |
+| Italic | `*italic*` | `'''italic'''` |
+| Strikethrough | `~~text~~` | `%%text%%` |
+| Bullet list | `- item` | `- item` (same) |
+| Numbered list | `1. item` | `+ item` |
+| Code block | `` ``` `` | `{code}` / `{/code}` |
+| Quote | `> text` | `> text` or `{quote}` (same/extended) |
+| Link | `[text](url)` | `[[text>url]]` |
+| Image | `![alt](url)` | `#image(url)` |
+| Text color | N/A | `&color(red) { text }` |
+| Table header | `\|---|` separator | `\|h` at end of row |
+
+## Tips
+
+- When converting Markdown to Backlog notation, pay special attention to headings (`#` → `*`), bold (`**` → `''`), and code blocks.
+- `{quote}` blocks cannot be nested.
+- Checklist syntax only works in issue descriptions, not in comments or wiki pages.
+- Backlog notation does **not** support inline code (backtick). Use `{code}...{/code}` for code blocks only.

--- a/skills/backlog-notation/SKILL.md
+++ b/skills/backlog-notation/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: writing-backlog-notation
-description: Writes and converts text using Backlog notation (Backlog記法), the native markup syntax for Nulab Backlog issues, wikis, pull requests, and comments. Activated when a Backlog project uses Backlog記法 instead of Markdown. Not applicable to Markdown-formatted Backlog projects.
+name: backlog-notation
+description: Reference for Backlog notation (Backlog記法), the native markup syntax for Nulab Backlog. Provides syntax rules for headings, lists, tables, text styling, links, code blocks, and other formatting elements. Use this when writing or converting text in Backlog記法.
 ---
 
-# writing-backlog-notation
+# backlog-notation
 
-Backlog notation is **not Markdown**. If the project uses Markdown, use standard Markdown instead.
+Backlog notation (Backlog記法) syntax reference. This is **not Markdown** — do not mix the two syntaxes.
 
 ## Quick Reference
 

--- a/skills/backlog-notation/SKILL.md
+++ b/skills/backlog-notation/SKILL.md
@@ -1,218 +1,65 @@
 ---
-name: backlog-notation
-description: Use when writing or converting text in Backlog notation (Backlog記法) — the native markup syntax used in Nulab Backlog for issues, wikis, pull requests, and comments. Do NOT use for Markdown-formatted Backlog projects.
+name: writing-backlog-notation
+description: Writes and converts text using Backlog notation (Backlog記法), the native markup syntax for Nulab Backlog issues, wikis, pull requests, and comments. Activated when a Backlog project uses Backlog記法 instead of Markdown. Not applicable to Markdown-formatted Backlog projects.
 ---
 
-# backlog-notation
+# writing-backlog-notation
 
-Backlog notation (Backlog記法) is the native markup syntax for Nulab Backlog. It is **not Markdown**. Projects that use Backlog notation require this specific syntax for issues, wikis, PRs, and comments.
-
-> **When to use:** The user's Backlog project is configured to use **Backlog記法** (not Markdown). If the project uses Markdown, use standard Markdown instead.
+Backlog notation is **not Markdown**. If the project uses Markdown, use standard Markdown instead.
 
 ## Quick Reference
 
 | Feature | Syntax |
 |---|---|
-| Heading | `* H1` / `** H2` / `*** H3` |
-| Bold | `''bold''` |
-| Italic | `'''italic'''` |
-| Strikethrough | `%%strikethrough%%` |
+| Heading | `* H1` / `** H2` / `*** H3` / `**** H4` |
+| Bold | `''text''` |
+| Italic | `'''text'''` |
+| Strikethrough | `%%text%%` |
 | Color | `&color(red) { text }` |
-| Background color | `&color(#fff, #333) { text }` |
-| Bullet list | `- item` |
-| Numbered list | `+ item` |
-| Checklist | `- [ ] todo` / `- [x] done` |
-| Link (URL) | `[[https://example.com]]` |
-| Link (labeled) | `[[label>https://example.com]]` |
-| Issue link | `PROJECT-123` or `[[PROJECT-123]]` |
-| Quote (inline) | `> quoted text` |
-| Quote (block) | `{quote} ... {/quote}` |
-| Code (block) | `{code} ... {/code}` |
-| Code (syntax) | `{code:java} ... {/code}` |
-| Image | `#image(URL)` |
-| Thumbnail | `#thumbnail(URL)` |
+| Color + background | `&color(#fff, #333) { text }` |
+| Bullet list | `- item` (nest with `--`) |
+| Numbered list | `+ item` (nest with `++`) |
+| Checklist | `- [ ] todo` / `- [x] done` (issue descriptions only) |
+| Link | `[[https://example.com]]` |
+| Labeled link | `[[label>https://example.com]]` |
+| Issue link | `PROJECT-123` (auto-linked) |
+| Quote | `> text` or `{quote}...{/quote}` |
+| Code block | `{code}...{/code}` |
+| Code (lang) | `{code:java}...{/code}` |
+| Image | `#image(URL or filename)` |
+| Thumbnail | `#thumbnail(URL or filename)` (< 200KB) |
 | Table of contents | `#contents` |
 | Line break | `&br;` |
 | Escape | `\` before special characters |
 
-## Headings
-
-Lines starting with `*` become headings. More `*` = deeper level.
-
-```
-* Heading 1
-** Heading 2
-*** Heading 3
-**** Heading 4
-```
-
-## Lists
-
-### Bullet list
-
-```
-- Item 1
-- Item 2
--- Nested item
--- Nested item
-- Item 3
-```
-
-### Numbered list
-
-```
-+ First
-+ Second
-++ Nested numbered
-+ Third
-```
-
-### Checklist (issue descriptions only)
-
-```
-- [ ] Not done
-- [x] Done
-```
-
-## Text Styling
-
-```
-''bold text''
-'''italic text'''
-%%strikethrough text%%
-&color(red) { red text }
-&color(#ffffff, #8abe00) { text with background color }
-```
-
-- `&color(colorName) { text }` — sets text color
-- `&color(textColor, bgColor) { text }` — sets text and background color
-- Colors accept names (`red`, `blue`) or hex codes (`#ff0000`)
-
-## Links
-
-```
-[[https://example.com]]
-[[Click here>https://example.com]]
-[[PROJECT-123]]
-```
-
-Issue keys written directly (e.g., `PROJECT-123`) are automatically linked.
-
 ## Tables
 
-Cells are separated by `|`. End a row with `h` to make it a header row. Prefix a cell with `~` to make that cell a header.
+Separate cells with `|`. End a row with `h` for a header row. Prefix a cell with `~` for a row header. Use `>` to merge a cell with the one to its left.
 
 ```
-|Column A|Column B|Column C|h
-|data 1|data 2|data 3|
-|~Row header|data 4|data 5|
+|Name|Value|Note|h
+|~Header|data 1|data 2|
+|Span two||>|
 ```
 
-To merge cells horizontally, use `>` in the cell to be merged:
+## Markdown → Backlog Notation Conversion
 
-```
-|Span two columns|>|Column C|h
-|data 1|data 2|data 3|
-```
+| Markdown | Backlog Notation |
+|---|---|
+| `# H1` | `* H1` |
+| `**bold**` | `''bold''` |
+| `*italic*` | `'''italic'''` |
+| `~~strike~~` | `%%strike%%` |
+| `1. item` | `+ item` |
+| `` ``` `` | `{code}` / `{/code}` |
+| `[text](url)` | `[[text>url]]` |
+| `![alt](url)` | `#image(url)` |
+| `\|---\|` separator | `\|h` at end of row |
+| N/A | `&color(red) { text }` |
 
-## Quotes
+## Gotchas
 
-Single-line:
-
-```
-> This is a quote.
-```
-
-Multi-line:
-
-```
-{quote}
-This is a
-multi-line quote.
-{/quote}
-```
-
-## Code Blocks
-
-Generic code:
-
-```
-{code}
-const x = 1;
-{/code}
-```
-
-With syntax highlighting (supported: `java`, `cs`, `js`, `python`, `ruby`, `perl`, `php`, `sql`, `html`, `xml`, `css`, `shell`, etc.):
-
-```
-{code:java}
-public class Hello {
-    public static void main(String[] args) {
-        System.out.println("Hello");
-    }
-}
-{/code}
-```
-
-## Images
-
-```
-#image(https://example.com/image.png)
-#thumbnail(https://example.com/image.png)
-```
-
-For wiki-attached files:
-
-```
-#image(filename.png)
-#thumbnail(filename.png)
-```
-
-Thumbnail display requires the image to be under 200KB.
-
-## Table of Contents
-
-```
-#contents
-```
-
-Automatically generates a table of contents from headings on the page.
-
-## Line Break
-
-```
-Text before&br;Text after
-```
-
-## Escape Special Characters
-
-Prefix with `\` to display literal special characters:
-
-```
-\* Not a heading
-\- Not a list
-```
-
-## Key Differences from Markdown
-
-| Feature | Markdown | Backlog Notation |
-|---|---|---|
-| Heading | `# H1` | `* H1` |
-| Bold | `**bold**` | `''bold''` |
-| Italic | `*italic*` | `'''italic'''` |
-| Strikethrough | `~~text~~` | `%%text%%` |
-| Bullet list | `- item` | `- item` (same) |
-| Numbered list | `1. item` | `+ item` |
-| Code block | `` ``` `` | `{code}` / `{/code}` |
-| Quote | `> text` | `> text` or `{quote}` (same/extended) |
-| Link | `[text](url)` | `[[text>url]]` |
-| Image | `![alt](url)` | `#image(url)` |
-| Text color | N/A | `&color(red) { text }` |
-| Table header | `\|---|` separator | `\|h` at end of row |
-
-## Tips
-
-- When converting Markdown to Backlog notation, pay special attention to headings (`#` → `*`), bold (`**` → `''`), and code blocks.
-- `{quote}` blocks cannot be nested.
-- Checklist syntax only works in issue descriptions, not in comments or wiki pages.
-- Backlog notation does **not** support inline code (backtick). Use `{code}...{/code}` for code blocks only.
+- No inline code syntax — only block-level `{code}...{/code}`
+- `{quote}` blocks cannot be nested
+- Checklists work only in issue descriptions, not in comments or wikis
+- Supported code languages: `java`, `cs`, `js`, `python`, `ruby`, `perl`, `php`, `sql`, `html`, `xml`, `css`, `shell`, etc.

--- a/skills/backlog-notation/SKILL.md
+++ b/skills/backlog-notation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backlog-notation
-description: Reference for Backlog notation (Backlog記法), the native markup syntax for Nulab Backlog. Provides syntax rules for headings, lists, tables, text styling, links, code blocks, and other formatting elements. Use this when writing or converting text in Backlog記法.
+description: Syntax reference for Backlog notation (Backlog記法), the native markup syntax for Nulab Backlog. Covers headings, lists, tables, text styling, links, code blocks, and other formatting elements.
 ---
 
 # backlog-notation


### PR DESCRIPTION
## Summary

Adds a new AI agent skill for Backlog notation (Backlog記法) syntax reference. This complements the existing `using-bee` skill by providing documentation for Backlog's native markup syntax, which is distinct from Markdown.

The new skill includes:
- Complete syntax reference for Backlog notation features (headings, lists, tables, text styling, links, code blocks, etc.)
- Quick reference table for common formatting
- Markdown to Backlog notation conversion guide
- Important gotchas and limitations

Also updates documentation to explain when and how to use this optional skill, since Backlog projects can choose between Markdown or Backlog notation on a per-project basis.

## Test plan

N/A — Documentation and skill definition only. The skill content is a static reference that doesn't require functional testing.

https://claude.ai/code/session_01JLsKET1hWZrgai63kwRnPE