### PR TITLE
Add release notes configuration and PR label guidelines

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - question
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Performance
+      labels:
+        - performance
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other Changes
+      labels:
+        - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -473,4 +473,6 @@ PRs must have at least one label for release note categorization (`.github/relea
 | `documentation` | Documentation-only changes                           |
 | `dependencies`  | Dependency updates (auto-applied by dependabot)      |
 
+Use `enhancement` only for end-user-facing features — changes that a `bee` CLI user would notice. CI configuration, repo maintenance, developer experience improvements, and internal refactors do not qualify and should be left unlabeled (they appear under "Other Changes").
+
 PRs without these labels appear under "Other Changes" in release notes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,3 +459,18 @@ Plan files (implementation plans, design docs, etc.) go in `.claude/plans/`.
 - **PR / Issue titles**: Always in English.
 - **PR / Issue body**: English by default unless otherwise specified.
 - **PR assignee**: Always use `--assignee @me` to assign the PR to the current user.
+
+### PR Labels
+
+PRs must have at least one label for release note categorization (`.github/release.yml`). Apply the most specific label:
+
+| Label           | When to use                                          |
+| --------------- | ---------------------------------------------------- |
+| `breaking`      | Breaking changes (removal, rename, behavioral shift) |
+| `enhancement`   | New features                                         |
+| `bug`           | Bug fixes                                            |
+| `performance`   | Performance improvements                             |
+| `documentation` | Documentation-only changes                           |
+| `dependencies`  | Dependency updates (auto-applied by dependabot)      |
+
+PRs without these labels appear under "Other Changes" in release notes.


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` to categorize auto-generated release notes by PR labels
- Add `breaking` and `performance` GitHub labels
- Document PR labeling conventions in AGENTS.md for agent-assisted PR creation

## Test plan
- [x] Verify `.github/release.yml` syntax is valid by checking a dry-run release
- [x] Confirm `breaking` and `performance` labels exist on the repo
- [x] Verify AGENTS.md table matches release.yml categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)