### PR TITLE
Set file permission 0600 on .beerc and add external credential management docs

### DIFF
--- a/apps/docs/src/content/docs/guides/authentication.mdx
+++ b/apps/docs/src/content/docs/guides/authentication.mdx
@@ -4,7 +4,7 @@ description: |-
   bee CLI の認証方法。Backlog への API キー・OAuth 認証の設定手順、使い分け、複数スペースの切り替えに対応。
 ---
 
-import { Card, LinkCard, CardGrid } from "@astrojs/starlight/components";
+import { Card, LinkCard, CardGrid, Tabs, TabItem } from "@astrojs/starlight/components";
 
 bee は 2 つの認証方式をサポートしています。
 
@@ -115,6 +115,62 @@ bee auth switch
 ```sh
 bee auth status
 ```
+
+## 認証情報の外部管理
+
+パスワードマネージャーや OS のクレデンシャルストアを使うと、環境変数経由で認証情報を渡せます。この方法では `~/.beerc` に認証情報が保存されません。
+
+<Tabs>
+  <TabItem label="1Password">
+    [1Password CLI](https://developer.1password.com/docs/cli/) (`op`) を使う場合:
+
+    ```sh
+    BACKLOG_API_KEY=$(op read "op://vault/backlog/api-key") \
+      BACKLOG_SPACE=xxx.backlog.com \
+      bee issue list --project MY_PROJECT
+    ```
+
+    シェルの設定ファイルにエイリアスを登録しておくと便利です。
+
+    ```sh
+    alias bee='BACKLOG_API_KEY=$(op read "op://vault/backlog/api-key") BACKLOG_SPACE=xxx.backlog.com bee'
+    ```
+  </TabItem>
+  <TabItem label="Bitwarden">
+    [Bitwarden CLI](https://bitwarden.com/help/cli/) (`bw`) を使う場合:
+
+    ```sh
+    BACKLOG_API_KEY=$(bw get password backlog-api-key) \
+      BACKLOG_SPACE=xxx.backlog.com \
+      bee issue list --project MY_PROJECT
+    ```
+
+    シェルの設定ファイルにエイリアスを登録しておくと便利です。
+
+    ```sh
+    alias bee='BACKLOG_API_KEY=$(bw get password backlog-api-key) BACKLOG_SPACE=xxx.backlog.com bee'
+    ```
+  </TabItem>
+  <TabItem label="macOS Keychain">
+    macOS の Keychain に保存した認証情報を使う場合:
+
+    ```sh
+    # 事前に Keychain に保存
+    security add-generic-password -s "bee" -a "api-key" -w "your-api-key"
+
+    # 呼び出し
+    BACKLOG_API_KEY=$(security find-generic-password -s "bee" -a "api-key" -w) \
+      BACKLOG_SPACE=xxx.backlog.com \
+      bee issue list --project MY_PROJECT
+    ```
+
+    シェルの設定ファイルにエイリアスを登録しておくと便利です。
+
+    ```sh
+    alias bee='BACKLOG_API_KEY=$(security find-generic-password -s "bee" -a "api-key" -w) BACKLOG_SPACE=xxx.backlog.com bee'
+    ```
+  </TabItem>
+</Tabs>
 
 ## 関連コマンド
 

--- a/packages/config/src/config.test.ts
+++ b/packages/config/src/config.test.ts
@@ -1,5 +1,10 @@
+import { chmodSync } from "node:fs";
 import { readUser, writeUser } from "rc9";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", () => ({
+  chmodSync: vi.fn(),
+}));
 
 vi.mock("rc9", () => ({
   readUser: vi.fn(),
@@ -11,6 +16,7 @@ const { loadConfig, updateConfig, writeConfig } = await import("./config");
 
 const mockReadUser = vi.mocked(readUser);
 const mockWriteUser = vi.mocked(writeUser);
+const mockChmodSync = vi.mocked(chmodSync);
 
 describe("loadConfig", () => {
   it("returns validated config when rc file is valid", () => {
@@ -66,6 +72,12 @@ describe("writeConfig", () => {
     writeConfig(sampleConfig);
 
     expect(mockWriteUser).toHaveBeenCalledWith(sampleConfig, ".beerc");
+  });
+
+  it("sets file permission to 0600 after writing", () => {
+    writeConfig(sampleConfig);
+
+    expect(mockChmodSync).toHaveBeenCalledWith(expect.stringContaining(".beerc"), 0o600);
   });
 });
 

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -1,3 +1,6 @@
+import { chmodSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
 import { UserError } from "@repo/cli-utils";
 import * as v from "valibot";
 import { readUser, writeUser } from "rc9";
@@ -17,8 +20,12 @@ const loadConfig = (): Rc => {
   return result.output;
 };
 
+const configFilePath = (): string =>
+  resolve(process.env.XDG_CONFIG_HOME || homedir(), CONFIG_FILE_NAME);
+
 const writeConfig = (config: Rc): void => {
   writeUser(config, CONFIG_FILE_NAME);
+  chmodSync(configFilePath(), 0o600);
 };
 
 const updateConfig = (updater: (config: Rc) => Rc): Rc => {


### PR DESCRIPTION
## Summary
- Apply `chmod 0600` to `.beerc` after every write to prevent other users from reading stored credentials
- Add documentation for managing credentials via external tools (1Password, Bitwarden, macOS Keychain)

## Test plan
- [x] Unit tests in `packages/config` pass
- [x] Docs build (`astro build`) succeeds
- [x] After `bee auth login`, verify `ls -la ~/.beerc` shows `-rw-------`

🤖 Generated with [Claude Code](https://claude.com/claude-code)