### PR TITLE
feat: migrate all dependencies to pnpm catalog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,8 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
 
+      - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
+
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: cli-build
@@ -134,14 +136,14 @@ jobs:
       - name: Publish to npm
         working-directory: apps/cli
         run: |
-          flags="--provenance --access public"
+          flags="--provenance --access public --no-git-checks"
           if [ "$PRERELEASE" = "true" ]; then
             flags="$flags --tag rc"
           fi
           if [ "$DRY_RUN" = "true" ]; then
             flags="$flags --dry-run"
           fi
-          npm publish $flags
+          pnpm publish $flags
 
       - name: Push tag
         if: inputs.environment != 'dry-run'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,7 +437,7 @@ validation, internal library code) where a `ValiError` is the appropriate error 
 ## Tooling
 
 - **Runtime**: Node.js 24 (managed by mise)
-- **Package manager**: pnpm (corepack-enabled)
+- **Package manager**: pnpm (corepack-enabled). External dependency versions are managed via [pnpm catalog](https://pnpm.io/catalogs) in `pnpm-workspace.yaml`. When adding dependencies, use `pnpm add --save-catalog <pkg>` (or `pnpm add --save-catalog -D <pkg>` for devDependencies) — this automatically adds the version to the catalog in `pnpm-workspace.yaml` and writes `"catalog:"` in `package.json`. Do not write version ranges directly in `package.json`.
 - **Linter**: oxlint (with plugins: import, typescript, unicorn)
 - **Formatter**: oxfmt
 - **Type checker**: `tsc --noEmit` per package (via Turborepo)

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -37,12 +37,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "backlog-js": "^0.16.0",
-    "commander": "^14.0.3",
-    "consola": "^3.4.2",
-    "is-unicode-supported": "^2.1.0",
-    "open": "^11.0.0",
-    "valibot": "^1.2.0"
+    "backlog-js": "catalog:",
+    "commander": "catalog:",
+    "consola": "catalog:",
+    "is-unicode-supported": "catalog:",
+    "open": "catalog:",
+    "valibot": "catalog:"
   },
   "devDependencies": {
     "@repo/backlog-utils": "workspace:*",
@@ -50,9 +50,9 @@
     "@repo/config": "workspace:*",
     "@repo/test-utils": "workspace:*",
     "@repo/tsconfigs": "workspace:*",
-    "tsx": "^4.19.0",
-    "unbuild": "^3.5.0",
-    "vitest": "^4.0.18"
+    "tsx": "catalog:",
+    "unbuild": "catalog:",
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20.18"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,15 +9,15 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "@astrojs/starlight": "^0.37.6",
-    "astro": "^5.5.0",
-    "marked": "^17.0.3",
-    "remark-definition-list": "^2.0.0",
-    "sharp": "^0.34.5"
+    "@astrojs/starlight": "catalog:",
+    "astro": "catalog:",
+    "marked": "catalog:",
+    "remark-definition-list": "catalog:",
+    "sharp": "catalog:"
   },
   "devDependencies": {
-    "commander": "^14.0.3",
-    "jiti": "^2.6.1",
-    "starlight-links-validator": "^0.19.2"
+    "commander": "catalog:",
+    "jiti": "catalog:",
+    "starlight-links-validator": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,15 +15,15 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@types/node": "^25.3.3",
-    "@vitest/coverage-v8": "^4.0.18",
-    "lefthook": "^2.1.2",
-    "oxfmt": "^0.36.0",
-    "oxlint": "^1.51.0",
-    "oxlint-tsgolint": "^0.16.0",
-    "turbo": "^2.8.13",
-    "typescript": "6.0.0-dev.20260301",
-    "vitest": "^4.0.18"
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "lefthook": "catalog:",
+    "oxfmt": "catalog:",
+    "oxlint": "catalog:",
+    "oxlint-tsgolint": "catalog:",
+    "turbo": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "packageManager": "pnpm@10.30.3",
   "pnpm": {

--- a/packages/backlog-utils/package.json
+++ b/packages/backlog-utils/package.json
@@ -11,15 +11,15 @@
   "dependencies": {
     "@repo/cli-utils": "workspace:*",
     "@repo/config": "workspace:*",
-    "backlog-js": "^0.16.0",
-    "consola": "^3.4.2",
-    "open": "^11.0.0",
-    "undici": "^7.22.0",
-    "valibot": "^1.2.0"
+    "backlog-js": "catalog:",
+    "consola": "catalog:",
+    "open": "catalog:",
+    "undici": "catalog:",
+    "valibot": "catalog:"
   },
   "devDependencies": {
     "@repo/test-utils": "workspace:*",
     "@repo/tsconfigs": "workspace:*",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   }
 }

--- a/packages/cli-utils/package.json
+++ b/packages/cli-utils/package.json
@@ -9,13 +9,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "consola": "^3.4.2",
-    "string-width": "^8.2.0",
-    "valibot": "^1.2.0"
+    "consola": "catalog:",
+    "string-width": "catalog:",
+    "valibot": "catalog:"
   },
   "devDependencies": {
     "@repo/test-utils": "workspace:*",
     "@repo/tsconfigs": "workspace:*",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -10,13 +10,13 @@
   },
   "dependencies": {
     "@repo/cli-utils": "workspace:*",
-    "consola": "^3.4.2",
-    "rc9": "^3.0.0",
-    "valibot": "^1.0.0"
+    "consola": "catalog:",
+    "rc9": "catalog:",
+    "valibot": "catalog:"
   },
   "devDependencies": {
     "@repo/test-utils": "workspace:*",
     "@repo/tsconfigs": "workspace:*",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   }
 }

--- a/packages/tsconfigs/package.json
+++ b/packages/tsconfigs/package.json
@@ -6,11 +6,11 @@
     "./base.json": "./base.json"
   },
   "dependencies": {
-    "@types/node": "^25.3.3"
+    "@types/node": "catalog:"
   },
   "devDependencies": {
-    "@tsconfig/node-lts": "^24.0.0",
-    "@tsconfig/node-ts": "^23.6.4",
-    "typescript": "^6.0.0-dev.20260301"
+    "@tsconfig/node-lts": "catalog:",
+    "@tsconfig/node-ts": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,57 +4,147 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@astrojs/starlight':
+      specifier: ^0.37.6
+      version: 0.37.6
+    '@tsconfig/node-lts':
+      specifier: ^24.0.0
+      version: 24.0.0
+    '@tsconfig/node-ts':
+      specifier: ^23.6.4
+      version: 23.6.4
+    '@types/node':
+      specifier: ^25.3.3
+      version: 25.3.3
+    '@vitest/coverage-v8':
+      specifier: ^4.0.18
+      version: 4.0.18
+    astro:
+      specifier: ^5.5.0
+      version: 5.18.0
+    backlog-js:
+      specifier: ^0.16.0
+      version: 0.16.0
+    commander:
+      specifier: ^14.0.3
+      version: 14.0.3
+    consola:
+      specifier: ^3.4.2
+      version: 3.4.2
+    is-unicode-supported:
+      specifier: ^2.1.0
+      version: 2.1.0
+    jiti:
+      specifier: ^2.6.1
+      version: 2.6.1
+    lefthook:
+      specifier: ^2.1.2
+      version: 2.1.2
+    marked:
+      specifier: ^17.0.3
+      version: 17.0.3
+    open:
+      specifier: ^11.0.0
+      version: 11.0.0
+    oxfmt:
+      specifier: ^0.36.0
+      version: 0.36.0
+    oxlint:
+      specifier: ^1.51.0
+      version: 1.51.0
+    oxlint-tsgolint:
+      specifier: ^0.16.0
+      version: 0.16.0
+    rc9:
+      specifier: ^3.0.0
+      version: 3.0.0
+    remark-definition-list:
+      specifier: ^2.0.0
+      version: 2.0.0
+    sharp:
+      specifier: ^0.34.5
+      version: 0.34.5
+    starlight-links-validator:
+      specifier: ^0.19.2
+      version: 0.19.2
+    string-width:
+      specifier: ^8.2.0
+      version: 8.2.0
+    tsx:
+      specifier: ^4.19.0
+      version: 4.21.0
+    turbo:
+      specifier: ^2.8.13
+      version: 2.8.13
+    typescript:
+      specifier: 6.0.0-dev.20260301
+      version: 6.0.0-dev.20260301
+    unbuild:
+      specifier: ^3.5.0
+      version: 3.6.1
+    undici:
+      specifier: ^7.22.0
+      version: 7.22.0
+    valibot:
+      specifier: ^1.2.0
+      version: 1.2.0
+    vitest:
+      specifier: ^4.0.18
+      version: 4.0.18
+
 importers:
 
   .:
     devDependencies:
       '@types/node':
-        specifier: ^25.3.3
+        specifier: 'catalog:'
         version: 25.3.3
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@25.3.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2))
       lefthook:
-        specifier: ^2.1.2
+        specifier: 'catalog:'
         version: 2.1.2
       oxfmt:
-        specifier: ^0.36.0
+        specifier: 'catalog:'
         version: 0.36.0
       oxlint:
-        specifier: ^1.51.0
+        specifier: 'catalog:'
         version: 1.51.0(oxlint-tsgolint@0.16.0)
       oxlint-tsgolint:
-        specifier: ^0.16.0
+        specifier: 'catalog:'
         version: 0.16.0
       turbo:
-        specifier: ^2.8.13
+        specifier: 'catalog:'
         version: 2.8.13
       typescript:
-        specifier: 6.0.0-dev.20260301
+        specifier: 'catalog:'
         version: 6.0.0-dev.20260301
       vitest:
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/cli:
     dependencies:
       backlog-js:
-        specifier: ^0.16.0
+        specifier: 'catalog:'
         version: 0.16.0
       commander:
-        specifier: ^14.0.3
+        specifier: 'catalog:'
         version: 14.0.3
       consola:
-        specifier: ^3.4.2
+        specifier: 'catalog:'
         version: 3.4.2
       is-unicode-supported:
-        specifier: ^2.1.0
+        specifier: 'catalog:'
         version: 2.1.0
       open:
-        specifier: ^11.0.0
+        specifier: 'catalog:'
         version: 11.0.0
       valibot:
-        specifier: ^1.2.0
+        specifier: 'catalog:'
         version: 1.2.0(typescript@6.0.0-dev.20260301)
     devDependencies:
       '@repo/backlog-utils':
@@ -73,41 +163,41 @@ importers:
         specifier: workspace:*
         version: link:../../packages/tsconfigs
       tsx:
-        specifier: ^4.19.0
+        specifier: 'catalog:'
         version: 4.21.0
       unbuild:
-        specifier: ^3.5.0
+        specifier: 'catalog:'
         version: 3.6.1(typescript@6.0.0-dev.20260301)
       vitest:
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   apps/docs:
     dependencies:
       '@astrojs/starlight':
-        specifier: ^0.37.6
+        specifier: 'catalog:'
         version: 0.37.6(astro@5.18.0(@types/node@25.3.3)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.0-dev.20260301)(yaml@2.8.2))
       astro:
-        specifier: ^5.5.0
+        specifier: 'catalog:'
         version: 5.18.0(@types/node@25.3.3)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.0-dev.20260301)(yaml@2.8.2)
       marked:
-        specifier: ^17.0.3
+        specifier: 'catalog:'
         version: 17.0.3
       remark-definition-list:
-        specifier: ^2.0.0
+        specifier: 'catalog:'
         version: 2.0.0
       sharp:
-        specifier: ^0.34.5
+        specifier: 'catalog:'
         version: 0.34.5
     devDependencies:
       commander:
-        specifier: ^14.0.3
+        specifier: 'catalog:'
         version: 14.0.3
       jiti:
-        specifier: ^2.6.1
+        specifier: 'catalog:'
         version: 2.6.1
       starlight-links-validator:
-        specifier: ^0.19.2
+        specifier: 'catalog:'
         version: 0.19.2(@astrojs/starlight@0.37.6(astro@5.18.0(@types/node@25.3.3)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.0-dev.20260301)(yaml@2.8.2)))(astro@5.18.0(@types/node@25.3.3)(jiti@2.6.1)(rollup@4.59.0)(tsx@4.21.0)(typescript@6.0.0-dev.20260301)(yaml@2.8.2))
 
   packages/backlog-utils:
@@ -119,19 +209,19 @@ importers:
         specifier: workspace:*
         version: link:../config
       backlog-js:
-        specifier: ^0.16.0
+        specifier: 'catalog:'
         version: 0.16.0
       consola:
-        specifier: ^3.4.2
+        specifier: 'catalog:'
         version: 3.4.2
       open:
-        specifier: ^11.0.0
+        specifier: 'catalog:'
         version: 11.0.0
       undici:
-        specifier: ^7.22.0
+        specifier: 'catalog:'
         version: 7.22.0
       valibot:
-        specifier: ^1.2.0
+        specifier: 'catalog:'
         version: 1.2.0(typescript@5.9.3)
     devDependencies:
       '@repo/test-utils':
@@ -141,19 +231,19 @@ importers:
         specifier: workspace:*
         version: link:../tsconfigs
       vitest:
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/cli-utils:
     dependencies:
       consola:
-        specifier: ^3.4.2
+        specifier: 'catalog:'
         version: 3.4.2
       string-width:
-        specifier: ^8.2.0
+        specifier: 'catalog:'
         version: 8.2.0
       valibot:
-        specifier: ^1.2.0
+        specifier: 'catalog:'
         version: 1.2.0(typescript@5.9.3)
     devDependencies:
       '@repo/test-utils':
@@ -163,7 +253,7 @@ importers:
         specifier: workspace:*
         version: link:../tsconfigs
       vitest:
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/config:
@@ -172,13 +262,13 @@ importers:
         specifier: workspace:*
         version: link:../cli-utils
       consola:
-        specifier: ^3.4.2
+        specifier: 'catalog:'
         version: 3.4.2
       rc9:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.0.0
       valibot:
-        specifier: ^1.0.0
+        specifier: 'catalog:'
         version: 1.2.0(typescript@5.9.3)
     devDependencies:
       '@repo/test-utils':
@@ -188,7 +278,7 @@ importers:
         specifier: workspace:*
         version: link:../tsconfigs
       vitest:
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(@types/node@25.3.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/test-utils:
@@ -204,17 +294,17 @@ importers:
   packages/tsconfigs:
     dependencies:
       '@types/node':
-        specifier: ^25.3.3
+        specifier: 'catalog:'
         version: 25.3.3
     devDependencies:
       '@tsconfig/node-lts':
-        specifier: ^24.0.0
+        specifier: 'catalog:'
         version: 24.0.0
       '@tsconfig/node-ts':
-        specifier: ^23.6.4
+        specifier: 'catalog:'
         version: 23.6.4
       typescript:
-        specifier: ^6.0.0-dev.20260301
+        specifier: 'catalog:'
         version: 6.0.0-dev.20260301
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,34 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+catalog:
+  "@astrojs/starlight": ^0.37.6
+  "@tsconfig/node-lts": ^24.0.0
+  "@tsconfig/node-ts": ^23.6.4
+  "@types/node": ^25.3.3
+  "@vitest/coverage-v8": ^4.0.18
+  astro: ^5.5.0
+  backlog-js: ^0.16.0
+  commander: ^14.0.3
+  consola: ^3.4.2
+  is-unicode-supported: ^2.1.0
+  jiti: ^2.6.1
+  lefthook: ^2.1.2
+  marked: ^17.0.3
+  open: ^11.0.0
+  oxfmt: ^0.36.0
+  oxlint: ^1.51.0
+  oxlint-tsgolint: ^0.16.0
+  rc9: ^3.0.0
+  remark-definition-list: ^2.0.0
+  sharp: ^0.34.5
+  starlight-links-validator: ^0.19.2
+  string-width: ^8.2.0
+  tsx: ^4.19.0
+  turbo: ^2.8.13
+  typescript: 6.0.0-dev.20260301
+  unbuild: ^3.5.0
+  undici: ^7.22.0
+  valibot: ^1.2.0
+  vitest: ^4.0.18


### PR DESCRIPTION
## Summary

- Centralize all external dependency versions using [pnpm catalog](https://pnpm.io/catalogs) in `pnpm-workspace.yaml`
- Replace inline version ranges with `"catalog:"` protocol across all `package.json` files
- Switch release workflow from `npm publish` to `pnpm publish` to ensure `catalog:` is resolved during publishing
- Fix valibot version inconsistency (`packages/config` had `^1.0.0`, others had `^1.2.0`)
- Document catalog convention in `AGENTS.md` (use `pnpm add --save-catalog`)

## Test plan

- [x] `pnpm install` succeeds with regenerated lockfile
- [x] `pnpm run build` succeeds for all packages
- [x] `pnpm run test` passes all 720 tests across 115 files
- [x] Verify release workflow dry-run works with `pnpm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)