### PR TITLE
ci: run build job in parallel with CI in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,6 @@ jobs:
       pull-requests: write
 
   build:
-    needs: ci
     runs-on: ubuntu-latest
     outputs:
       new_tag: ${{ steps.bump_version.outputs.new_tag }}
@@ -107,7 +106,7 @@ jobs:
             apps/cli/package.json
 
   publish:
-    needs: build
+    needs: [ci, build]
     runs-on: ubuntu-latest
     environment:
       name: ${{ inputs.environment }}


### PR DESCRIPTION
## Summary
- Remove `needs: ci` from the `build` job so it starts immediately alongside CI
- Update `publish` to `needs: [ci, build]` so it waits for both before proceeding
- Reduces overall release workflow duration by running build concurrently with tests/lint

## Test plan
- [x] Trigger a dry-run release and verify build and CI jobs start in parallel
- [x] Verify publish job waits for both CI and build to complete
- [x] Verify publish is skipped if CI fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)