### PR TITLE
fix: add pnpm install to publish job for workspace protocol resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
 
       - uses: jdx/mise-action@5228313ee0372e111a38da051671ca30fc5a96db # v3.6.3
 
+      - run: pnpm install --frozen-lockfile
+
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
           name: cli-build


### PR DESCRIPTION
## Summary
- The `publish` job in the release workflow was missing `pnpm install --frozen-lockfile`, causing `pnpm publish` to fail because it could not resolve `workspace:*` protocols
- Added `pnpm install` before artifact download to fix the issue

## Test plan
- [x] Run a dry-run release and verify the publish step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)