### PR TITLE
refactor: replace project positional arguments with --project flag

### DIFF
--- a/apps/cli/src/commands/category/list.test.ts
+++ b/apps/cli/src/commands/category/list.test.ts
@@ -15,7 +15,7 @@ const sampleCategories = [
 describe("category list", () => {
   it("displays category list in tabular format", async () => {
     mockClient.getCategories.mockResolvedValue(sampleCategories);
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(mockClient.getCategories).toHaveBeenCalledWith("TEST");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("ID"));
@@ -25,7 +25,7 @@ describe("category list", () => {
 
   it("shows message when no categories found", async () => {
     mockClient.getCategories.mockResolvedValue([]);
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.info).toHaveBeenCalledWith("No categories found.");
   });
@@ -34,7 +34,7 @@ describe("category list", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./list"),
-      ["TEST", "--json"],
+      ["-p", "TEST", "--json"],
       "Bug",
       () => {
         mockClient.getCategories.mockResolvedValue(sampleCategories);

--- a/apps/cli/src/commands/category/list.ts
+++ b/apps/cli/src/commands/category/list.ts
@@ -3,22 +3,24 @@ import { type Row, outputResult, printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const list = new BeeCommand("list")
   .summary("List categories")
   .description(`Categories help organize issues by grouping them into logical areas.`)
-  .argument("[project]", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List all categories in a project", command: "bee category list PROJECT" },
-    { description: "Output as JSON", command: "bee category list PROJECT --json" },
+    { description: "List all categories in a project", command: "bee category list -p PROJECT" },
+    { description: "Output as JSON", command: "bee category list -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const categories = await client.getCategories(project);
+    const categories = await client.getCategories(opts.project);
 
     outputResult(categories, opts, (data) => {
       if (data.length === 0) {

--- a/apps/cli/src/commands/document/tree.test.ts
+++ b/apps/cli/src/commands/document/tree.test.ts
@@ -43,7 +43,7 @@ describe("document tree", () => {
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
     const { default: tree } = await import("./tree");
-    await tree.parseAsync(["PROJECT"], { from: "user" });
+    await tree.parseAsync(["-p", "PROJECT"], { from: "user" });
 
     expect(mockClient.getDocumentTree).toHaveBeenCalledWith("PROJECT");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Getting Started"));
@@ -55,7 +55,7 @@ describe("document tree", () => {
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
     const { default: tree } = await import("./tree");
-    await tree.parseAsync(["PROJECT"], { from: "user" });
+    await tree.parseAsync(["-p", "PROJECT"], { from: "user" });
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("\ud83d\ude80"));
   });
@@ -67,7 +67,7 @@ describe("document tree", () => {
     });
 
     const { default: tree } = await import("./tree");
-    await tree.parseAsync(["PROJECT"], { from: "user" });
+    await tree.parseAsync(["-p", "PROJECT"], { from: "user" });
 
     expect(consola.info).toHaveBeenCalledWith("No documents found.");
   });
@@ -78,7 +78,7 @@ describe("document tree", () => {
     });
 
     const { default: tree } = await import("./tree");
-    await tree.parseAsync(["PROJECT"], { from: "user" });
+    await tree.parseAsync(["-p", "PROJECT"], { from: "user" });
 
     expect(consola.info).toHaveBeenCalledWith("No documents found.");
   });
@@ -99,7 +99,7 @@ describe("document tree", () => {
     });
 
     const { default: tree } = await import("./tree");
-    await tree.parseAsync(["PROJECT"], { from: "user" });
+    await tree.parseAsync(["-p", "PROJECT"], { from: "user" });
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("doc-no-name"));
   });
@@ -109,7 +109,7 @@ describe("document tree", () => {
 
     await expectStdoutContaining(async () => {
       const { default: tree } = await import("./tree");
-      await tree.parseAsync(["PROJECT", "--json"], { from: "user" });
+      await tree.parseAsync(["-p", "PROJECT", "--json"], { from: "user" });
     }, "doc-1");
   });
 
@@ -117,7 +117,7 @@ describe("document tree", () => {
     mockClient.getDocumentTree.mockResolvedValue(sampleTree);
 
     const { default: tree } = await import("./tree");
-    await tree.parseAsync(["PROJECT"], { from: "user" });
+    await tree.parseAsync(["-p", "PROJECT"], { from: "user" });
 
     // First child uses ├── connector
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("\u251c\u2500\u2500"));

--- a/apps/cli/src/commands/document/tree.ts
+++ b/apps/cli/src/commands/document/tree.ts
@@ -4,6 +4,7 @@ import { type Entity } from "backlog-js";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const renderNode = (
   node: Entity.Document.DocumentTreeNode,
@@ -36,18 +37,19 @@ const renderTree = (children: Entity.Document.DocumentTreeNode[]): string[] => {
 const tree = new BeeCommand("tree")
   .summary("Display document tree")
   .description(`Shows the hierarchical structure of documents with tree-style indentation.`)
-  .argument("[project]", "Project ID or project key", process.env.BACKLOG_PROJECT)
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "Show document tree", command: "bee document tree PROJECT" },
-    { description: "Output as JSON", command: "bee document tree PROJECT --json" },
+    { description: "Show document tree", command: "bee document tree -p PROJECT" },
+    { description: "Output as JSON", command: "bee document tree -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const docTree = await client.getDocumentTree(project);
+    const docTree = await client.getDocumentTree(opts.project);
 
     outputResult(docTree, opts, (data) => {
       if (!data.activeTree || data.activeTree.children.length === 0) {

--- a/apps/cli/src/commands/issue-type/list.test.ts
+++ b/apps/cli/src/commands/issue-type/list.test.ts
@@ -16,7 +16,7 @@ describe("issue-type list", () => {
   it("displays issue type list in tabular format", async () => {
     mockClient.getIssueTypes.mockResolvedValue(sampleIssueTypes);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(mockClient.getIssueTypes).toHaveBeenCalledWith("TEST");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("ID"));
@@ -27,7 +27,7 @@ describe("issue-type list", () => {
   it("shows message when no issue types found", async () => {
     mockClient.getIssueTypes.mockResolvedValue([]);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.info).toHaveBeenCalledWith("No issue types found.");
   });
@@ -35,7 +35,7 @@ describe("issue-type list", () => {
   it("displays color column", async () => {
     mockClient.getIssueTypes.mockResolvedValue(sampleIssueTypes);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("#e30000"));
   });
@@ -44,7 +44,7 @@ describe("issue-type list", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./list"),
-      ["TEST", "--json"],
+      ["-p", "TEST", "--json"],
       "Bug",
       () => mockClient.getIssueTypes.mockResolvedValue(sampleIssueTypes),
     ),

--- a/apps/cli/src/commands/issue-type/list.ts
+++ b/apps/cli/src/commands/issue-type/list.ts
@@ -3,22 +3,24 @@ import { type Row, outputResult, printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const list = new BeeCommand("list")
   .summary("List issue types")
   .description(`Issue types categorize issues and are displayed with their associated color.`)
-  .argument("[project]", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List all issue types", command: "bee issue-type list PROJECT" },
-    { description: "Output as JSON", command: "bee issue-type list PROJECT --json" },
+    { description: "List all issue types", command: "bee issue-type list -p PROJECT" },
+    { description: "Output as JSON", command: "bee issue-type list -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const issueTypes = await client.getIssueTypes(project);
+    const issueTypes = await client.getIssueTypes(opts.project);
 
     outputResult(issueTypes, opts, (data) => {
       if (data.length === 0) {

--- a/apps/cli/src/commands/milestone/list.test.ts
+++ b/apps/cli/src/commands/milestone/list.test.ts
@@ -30,7 +30,7 @@ describe("milestone list", () => {
   it("displays milestone list in tabular format", async () => {
     mockClient.getVersions.mockResolvedValue(sampleMilestones);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(mockClient.getVersions).toHaveBeenCalledWith("TEST");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("ID"));
@@ -41,7 +41,7 @@ describe("milestone list", () => {
   it("shows message when no milestones found", async () => {
     mockClient.getVersions.mockResolvedValue([]);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.info).toHaveBeenCalledWith("No milestones found.");
   });
@@ -49,7 +49,7 @@ describe("milestone list", () => {
   it("displays archived milestone as Yes and non-archived as No", async () => {
     mockClient.getVersions.mockResolvedValue(sampleMilestones);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Yes"));
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("No"));
@@ -67,7 +67,7 @@ describe("milestone list", () => {
       },
     ]);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("v3.0.0"));
   });
@@ -76,7 +76,7 @@ describe("milestone list", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./list"),
-      ["TEST", "--json"],
+      ["-p", "TEST", "--json"],
       "v1.0.0",
       () => mockClient.getVersions.mockResolvedValue(sampleMilestones),
     ),

--- a/apps/cli/src/commands/milestone/list.ts
+++ b/apps/cli/src/commands/milestone/list.ts
@@ -3,24 +3,26 @@ import { type Row, outputResult, printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const list = new BeeCommand("list")
   .summary("List milestones")
   .description(
     `Milestones (versions) track release schedules and group issues by development cycle.`,
   )
-  .argument("[project]", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List all milestones", command: "bee milestone list PROJECT" },
-    { description: "Output as JSON", command: "bee milestone list PROJECT --json" },
+    { description: "List all milestones", command: "bee milestone list -p PROJECT" },
+    { description: "Output as JSON", command: "bee milestone list -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const milestones = await client.getVersions(project);
+    const milestones = await client.getVersions(opts.project);
 
     outputResult(milestones, opts, (data) => {
       if (data.length === 0) {

--- a/apps/cli/src/commands/project/activities.test.ts
+++ b/apps/cli/src/commands/project/activities.test.ts
@@ -38,7 +38,7 @@ describe("project activities", () => {
     ]);
 
     const { default: activities } = await import("./activities");
-    await activities.parseAsync(["PROJ1"], { from: "user" });
+    await activities.parseAsync(["-p", "PROJ1"], { from: "user" });
 
     expect(mockClient.getProjectActivities).toHaveBeenCalledWith("PROJ1", expect.any(Object));
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("2024-01-15"));
@@ -51,7 +51,7 @@ describe("project activities", () => {
     mockClient.getProjectActivities.mockResolvedValue([]);
 
     const { default: activities } = await import("./activities");
-    await activities.parseAsync(["PROJ1"], { from: "user" });
+    await activities.parseAsync(["-p", "PROJ1"], { from: "user" });
 
     expect(consola.info).toHaveBeenCalledWith("No activities found.");
   });
@@ -61,7 +61,7 @@ describe("project activities", () => {
 
     const { default: activities } = await import("./activities");
     await activities.parseAsync(
-      ["PROJ1", "--activity-type", "1", "--activity-type", "2", "--activity-type", "3"],
+      ["-p", "PROJ1", "--activity-type", "1", "--activity-type", "2", "--activity-type", "3"],
       { from: "user" },
     );
 
@@ -77,7 +77,7 @@ describe("project activities", () => {
     mockClient.getProjectActivities.mockResolvedValue([]);
 
     const { default: activities } = await import("./activities");
-    await activities.parseAsync(["PROJ1", "--count", "50"], { from: "user" });
+    await activities.parseAsync(["-p", "PROJ1", "--count", "50"], { from: "user" });
 
     expect(mockClient.getProjectActivities).toHaveBeenCalledWith(
       "PROJ1",
@@ -97,7 +97,7 @@ describe("project activities", () => {
     ]);
 
     const { default: activities } = await import("./activities");
-    await activities.parseAsync(["PROJ1"], { from: "user" });
+    await activities.parseAsync(["-p", "PROJ1"], { from: "user" });
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Unknown"));
   });
@@ -114,7 +114,7 @@ describe("project activities", () => {
     ]);
 
     const { default: activities } = await import("./activities");
-    await activities.parseAsync(["PROJ1"], { from: "user" });
+    await activities.parseAsync(["-p", "PROJ1"], { from: "user" });
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("User"));
   });
@@ -132,7 +132,7 @@ describe("project activities", () => {
 
     await expectStdoutContaining(async () => {
       const { default: activities } = await import("./activities");
-      await activities.parseAsync(["PROJ1", "--json"], { from: "user" });
+      await activities.parseAsync(["-p", "PROJ1", "--json"], { from: "user" });
     }, "Test");
   });
 });

--- a/apps/cli/src/commands/project/activities.ts
+++ b/apps/cli/src/commands/project/activities.ts
@@ -12,6 +12,7 @@ import * as v from "valibot";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 import { collectNum } from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const getActivitySummary = (activity: {
   type: number;
@@ -48,7 +49,7 @@ const activities = new BeeCommand("activities")
 For activity type IDs, see:  
 https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates/#response-description`,
   )
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .option(
     "--activity-type <id>",
     "Filter by activity type IDs (repeatable)",
@@ -61,27 +62,28 @@ https://developer.nulab.com/docs/backlog/api/2/get-project-recent-updates/#respo
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List recent activities", command: "bee project activities PROJECT_KEY" },
+    { description: "List recent activities", command: "bee project activities -p PROJECT_KEY" },
     {
       description: "Show only issue-related activities",
       command:
-        "bee project activities PROJECT_KEY --activity-type 1 --activity-type 2 --activity-type 3",
+        "bee project activities -p PROJECT_KEY --activity-type 1 --activity-type 2 --activity-type 3",
     },
     {
       description: "Show last 50 activities",
-      command: "bee project activities PROJECT_KEY --count 50",
+      command: "bee project activities -p PROJECT_KEY --count 50",
     },
     {
       description: "Output as JSON",
-      command: "bee project activities PROJECT_KEY --json",
+      command: "bee project activities -p PROJECT_KEY --json",
     },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
     const activityTypeId: number[] = opts.activityType;
 
-    const activityList = await client.getProjectActivities(project, {
+    const activityList = await client.getProjectActivities(opts.project, {
       activityTypeId,
       count: parseArg(v.optional(vInteger), opts.count, "--count"),
       order: opts.order,

--- a/apps/cli/src/commands/project/delete.test.ts
+++ b/apps/cli/src/commands/project/delete.test.ts
@@ -17,7 +17,7 @@ describe("project delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteProject.mockResolvedValue({ projectKey: "TEST", name: "Test Project" });
 
-    await parseCommand(() => import("./delete"), ["TEST"]);
+    await parseCommand(() => import("./delete"), ["-p", "TEST"]);
 
     expect(confirmOrExit).toHaveBeenCalledWith(
       "Are you sure you want to delete project TEST? This cannot be undone.",
@@ -31,7 +31,7 @@ describe("project delete", () => {
     vi.mocked(confirmOrExit).mockResolvedValue(true);
     mockClient.deleteProject.mockResolvedValue({ projectKey: "TEST", name: "Test Project" });
 
-    await parseCommand(() => import("./delete"), ["TEST", "--yes"]);
+    await parseCommand(() => import("./delete"), ["-p", "TEST", "--yes"]);
 
     expect(confirmOrExit).toHaveBeenCalledWith(
       "Are you sure you want to delete project TEST? This cannot be undone.",
@@ -41,7 +41,7 @@ describe("project delete", () => {
 
   it("cancels when user declines confirmation", async () => {
     vi.mocked(confirmOrExit).mockResolvedValue(false);
-    await parseCommand(() => import("./delete"), ["TEST"]);
+    await parseCommand(() => import("./delete"), ["-p", "TEST"]);
 
     expect(mockClient.deleteProject).not.toHaveBeenCalled();
   });
@@ -49,7 +49,7 @@ describe("project delete", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./delete"),
-      ["TEST", "--yes", "--json"],
+      ["-p", "TEST", "--yes", "--json"],
       "TEST",
       () => {
         vi.mocked(confirmOrExit).mockResolvedValue(true);

--- a/apps/cli/src/commands/project/delete.ts
+++ b/apps/cli/src/commands/project/delete.ts
@@ -3,11 +3,12 @@ import { confirmOrExit, outputResult } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const deleteProject = new BeeCommand("delete")
   .summary("Delete a project")
   .description(`This action is irreversible. Requires Administrator role.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .option("-y, --yes", "Skip confirmation prompt")
   .addOption(opt.json())
   .addOption(opt.space())
@@ -15,16 +16,17 @@ const deleteProject = new BeeCommand("delete")
   .examples([
     {
       description: "Delete a project (with confirmation)",
-      command: "bee project delete PROJECT_KEY",
+      command: "bee project delete -p PROJECT_KEY",
     },
     {
       description: "Delete a project without confirmation",
-      command: "bee project delete PROJECT_KEY --yes",
+      command: "bee project delete -p PROJECT_KEY --yes",
     },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const confirmed = await confirmOrExit(
-      `Are you sure you want to delete project ${project}? This cannot be undone.`,
+      `Are you sure you want to delete project ${opts.project}? This cannot be undone.`,
       opts.yes,
     );
 
@@ -34,7 +36,7 @@ const deleteProject = new BeeCommand("delete")
 
     const { client } = await getClient(opts.space);
 
-    const projectData = await client.deleteProject(project);
+    const projectData = await client.deleteProject(opts.project);
 
     const jsonArg = opts.json === true ? "" : opts.json;
     outputResult(projectData, { ...opts, json: jsonArg }, (data) => {

--- a/apps/cli/src/commands/project/edit.test.ts
+++ b/apps/cli/src/commands/project/edit.test.ts
@@ -17,7 +17,7 @@ describe("project edit", () => {
   it("updates project name", async () => {
     mockClient.patchProject.mockResolvedValue({ projectKey: "TEST", name: "New Name" });
 
-    await parseCommand(() => import("./edit"), ["TEST", "--name", "New Name"]);
+    await parseCommand(() => import("./edit"), ["-p", "TEST", "--name", "New Name"]);
 
     expect(mockClient.patchProject).toHaveBeenCalledWith(
       "TEST",
@@ -29,7 +29,7 @@ describe("project edit", () => {
   it("updates project archived status", async () => {
     mockClient.patchProject.mockResolvedValue({ projectKey: "TEST", name: "Test" });
 
-    await parseCommand(() => import("./edit"), ["TEST", "--archived"]);
+    await parseCommand(() => import("./edit"), ["-p", "TEST", "--archived"]);
 
     expect(mockClient.patchProject).toHaveBeenCalledWith(
       "TEST",
@@ -40,7 +40,10 @@ describe("project edit", () => {
   it("passes text formatting rule", async () => {
     mockClient.patchProject.mockResolvedValue({ projectKey: "TEST", name: "Test" });
 
-    await parseCommand(() => import("./edit"), ["TEST", "--text-formatting-rule", "markdown"]);
+    await parseCommand(
+      () => import("./edit"),
+      ["-p", "TEST", "--text-formatting-rule", "markdown"],
+    );
 
     expect(mockClient.patchProject).toHaveBeenCalledWith(
       "TEST",
@@ -51,7 +54,7 @@ describe("project edit", () => {
   it("sends exact payload when only name is provided", async () => {
     mockClient.patchProject.mockResolvedValue({ projectKey: "TEST", name: "New Name" });
 
-    await parseCommand(() => import("./edit"), ["TEST", "--name", "New Name"]);
+    await parseCommand(() => import("./edit"), ["-p", "TEST", "--name", "New Name"]);
 
     expect(mockClient.patchProject).toHaveBeenCalledWith("TEST", {
       name: "New Name",
@@ -68,7 +71,7 @@ describe("project edit", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./edit"),
-      ["TEST", "--name", "Test", "--json"],
+      ["-p", "TEST", "--name", "Test", "--json"],
       "TEST",
       () => mockClient.patchProject.mockResolvedValue({ projectKey: "TEST", name: "Test" }),
     ),

--- a/apps/cli/src/commands/project/edit.ts
+++ b/apps/cli/src/commands/project/edit.ts
@@ -3,11 +3,12 @@ import { outputResult } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const edit = new BeeCommand("edit")
   .summary("Edit a project")
   .description(`Only specified fields are updated; others remain unchanged.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .option("-n, --name <name>", "New name of the project")
   .option("-k, --key <key>", "New key of the project")
   .option("--chart-enabled", "Change whether the chart is enabled")
@@ -24,21 +25,22 @@ const edit = new BeeCommand("edit")
   .examples([
     {
       description: "Rename a project",
-      command: 'bee project edit PROJECT_KEY --name "New Name"',
+      command: 'bee project edit -p PROJECT_KEY --name "New Name"',
     },
     {
       description: "Archive a project",
-      command: "bee project edit PROJECT_KEY --archived",
+      command: "bee project edit -p PROJECT_KEY --archived",
     },
     {
       description: "Change formatting rule to markdown",
-      command: "bee project edit PROJECT_KEY --text-formatting-rule markdown",
+      command: "bee project edit -p PROJECT_KEY --text-formatting-rule markdown",
     },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const projectData = await client.patchProject(project, {
+    const projectData = await client.patchProject(opts.project, {
       name: opts.name,
       key: opts.key,
       chartEnabled: opts.chartEnabled,

--- a/apps/cli/src/commands/project/users.test.ts
+++ b/apps/cli/src/commands/project/users.test.ts
@@ -26,7 +26,7 @@ describe("project users", () => {
     ]);
 
     const { default: users } = await import("./users");
-    await users.parseAsync(["PROJ1"], { from: "user" });
+    await users.parseAsync(["-p", "PROJ1"], { from: "user" });
 
     expect(mockClient.getProjectUsers).toHaveBeenCalledWith("PROJ1");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("ID"));
@@ -39,7 +39,7 @@ describe("project users", () => {
     mockClient.getProjectUsers.mockResolvedValue([]);
 
     const { default: users } = await import("./users");
-    await users.parseAsync(["PROJ1"], { from: "user" });
+    await users.parseAsync(["-p", "PROJ1"], { from: "user" });
 
     expect(consola.info).toHaveBeenCalledWith("No users found.");
   });
@@ -51,7 +51,7 @@ describe("project users", () => {
 
     await expectStdoutContaining(async () => {
       const { default: users } = await import("./users");
-      await users.parseAsync(["PROJ1", "--json"], { from: "user" });
+      await users.parseAsync(["-p", "PROJ1", "--json"], { from: "user" });
     }, "user1");
   });
 });

--- a/apps/cli/src/commands/project/users.ts
+++ b/apps/cli/src/commands/project/users.ts
@@ -3,22 +3,24 @@ import { type Row, outputResult, printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const users = new BeeCommand("users")
   .summary("List project users")
   .description(`Displays each member's ID, name, and role.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List project members", command: "bee project users PROJECT_KEY" },
-    { description: "Output as JSON", command: "bee project users PROJECT_KEY --json" },
+    { description: "List project members", command: "bee project users -p PROJECT_KEY" },
+    { description: "Output as JSON", command: "bee project users -p PROJECT_KEY --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const members = await client.getProjectUsers(project);
+    const members = await client.getProjectUsers(opts.project);
 
     const jsonArg = opts.json === true ? "" : opts.json;
     outputResult(members, { ...opts, json: jsonArg }, (data) => {

--- a/apps/cli/src/commands/project/view.test.ts
+++ b/apps/cli/src/commands/project/view.test.ts
@@ -40,7 +40,7 @@ describe("project view", () => {
   it("displays project details", async () => {
     mockClient.getProject.mockResolvedValue(sampleProject);
 
-    await parseCommand(() => import("./view"), ["PROJ1"]);
+    await parseCommand(() => import("./view"), ["-p", "PROJ1"]);
 
     expect(mockClient.getProject).toHaveBeenCalledWith("PROJ1");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Test Project"));
@@ -52,13 +52,13 @@ describe("project view", () => {
   it("shows Archived status for archived project", async () => {
     mockClient.getProject.mockResolvedValue({ ...sampleProject, archived: true });
 
-    await parseCommand(() => import("./view"), ["PROJ1"]);
+    await parseCommand(() => import("./view"), ["-p", "PROJ1"]);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Archived"));
   });
 
   it("opens browser with --web flag", async () => {
-    await parseCommand(() => import("./view"), ["PROJ1", "--web"]);
+    await parseCommand(() => import("./view"), ["-p", "PROJ1", "--web"]);
 
     expect(openOrPrintUrl).toHaveBeenCalledWith(
       "https://example.backlog.com/projects/PROJ1",
@@ -72,7 +72,7 @@ describe("project view", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./view"),
-      ["PROJ1", "--json"],
+      ["-p", "PROJ1", "--json"],
       "PROJ1",
       () => {
         mockClient.getProject.mockResolvedValue(sampleProject);

--- a/apps/cli/src/commands/project/view.ts
+++ b/apps/cli/src/commands/project/view.ts
@@ -3,31 +3,33 @@ import { outputResult, printDefinitionList } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const view = new BeeCommand("view")
   .summary("View a project")
   .description(`Use \`--web\` to open in the browser.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.web("project"))
   .addOption(opt.noBrowser())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "View project details", command: "bee project view PROJECT_KEY" },
-    { description: "Open project in browser", command: "bee project view PROJECT_KEY --web" },
-    { description: "Output as JSON", command: "bee project view PROJECT_KEY --json" },
+    { description: "View project details", command: "bee project view -p PROJECT_KEY" },
+    { description: "Open project in browser", command: "bee project view -p PROJECT_KEY --web" },
+    { description: "Output as JSON", command: "bee project view -p PROJECT_KEY --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client, host } = await getClient(opts.space);
 
     if (opts.web || opts.browser === false) {
-      const url = projectUrl(host, project);
+      const url = projectUrl(host, opts.project);
       await openOrPrintUrl(url, opts.browser === false, consola);
       return;
     }
 
-    const projectData = await client.getProject(project);
+    const projectData = await client.getProject(opts.project);
 
     const jsonArg = opts.json === true ? "" : opts.json;
     outputResult(projectData, { ...opts, json: jsonArg }, (data) => {

--- a/apps/cli/src/commands/repo/list.test.ts
+++ b/apps/cli/src/commands/repo/list.test.ts
@@ -38,7 +38,7 @@ describe("repo list", () => {
   it("displays repository list in tabular format", async () => {
     mockClient.getGitRepositories.mockResolvedValue(sampleRepos);
 
-    await parseCommand(() => import("./list"), ["PROJ"]);
+    await parseCommand(() => import("./list"), ["-p", "PROJ"]);
 
     expect(mockClient.getGitRepositories).toHaveBeenCalledWith("PROJ");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("NAME"));
@@ -62,7 +62,7 @@ describe("repo list", () => {
       },
     ]);
 
-    await parseCommand(() => import("./list"), ["PROJ"]);
+    await parseCommand(() => import("./list"), ["-p", "PROJ"]);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("empty-repo"));
   });
@@ -70,7 +70,7 @@ describe("repo list", () => {
   it("shows message when no repositories found", async () => {
     mockClient.getGitRepositories.mockResolvedValue([]);
 
-    await parseCommand(() => import("./list"), ["PROJ"]);
+    await parseCommand(() => import("./list"), ["-p", "PROJ"]);
 
     expect(consola.info).toHaveBeenCalledWith("No repositories found.");
   });
@@ -79,7 +79,7 @@ describe("repo list", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./list"),
-      ["PROJ", "--json"],
+      ["-p", "PROJ", "--json"],
       "api-server",
       () => mockClient.getGitRepositories.mockResolvedValue(sampleRepos),
     ),

--- a/apps/cli/src/commands/repo/list.ts
+++ b/apps/cli/src/commands/repo/list.ts
@@ -3,22 +3,24 @@ import { type Row, outputResult, printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const list = new BeeCommand("list")
   .summary("List repositories in a project")
   .description(`Repositories are listed in the configured display order.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List repositories in a project", command: "bee repo list PROJECT_KEY" },
-    { description: "Output as JSON", command: "bee repo list PROJECT_KEY --json" },
+    { description: "List repositories in a project", command: "bee repo list -p PROJECT_KEY" },
+    { description: "Output as JSON", command: "bee repo list -p PROJECT_KEY --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const repos = await client.getGitRepositories(project);
+    const repos = await client.getGitRepositories(opts.project);
 
     outputResult(repos, opts, (data) => {
       if (data.length === 0) {

--- a/apps/cli/src/commands/status/list.test.ts
+++ b/apps/cli/src/commands/status/list.test.ts
@@ -16,7 +16,7 @@ describe("status list", () => {
   it("displays status list in tabular format", async () => {
     mockClient.getProjectStatuses.mockResolvedValue(sampleStatuses);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(mockClient.getProjectStatuses).toHaveBeenCalledWith("TEST");
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("ID"));
@@ -27,7 +27,7 @@ describe("status list", () => {
   it("shows message when no statuses found", async () => {
     mockClient.getProjectStatuses.mockResolvedValue([]);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.info).toHaveBeenCalledWith("No statuses found.");
   });
@@ -35,7 +35,7 @@ describe("status list", () => {
   it("displays color column", async () => {
     mockClient.getProjectStatuses.mockResolvedValue(sampleStatuses);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("#e30000"));
   });
@@ -44,7 +44,7 @@ describe("status list", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./list"),
-      ["TEST", "--json"],
+      ["-p", "TEST", "--json"],
       "Open",
       () => {
         mockClient.getProjectStatuses.mockResolvedValue(sampleStatuses);

--- a/apps/cli/src/commands/status/list.ts
+++ b/apps/cli/src/commands/status/list.ts
@@ -3,22 +3,24 @@ import { type Row, outputResult, printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const list = new BeeCommand("list")
   .summary("List statuses")
   .description(`Statuses define the workflow states that issues move through.`)
-  .argument("[project]", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List all statuses", command: "bee status list PROJECT" },
-    { description: "Output as JSON", command: "bee status list PROJECT --json" },
+    { description: "List all statuses", command: "bee status list -p PROJECT" },
+    { description: "Output as JSON", command: "bee status list -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const statuses = await client.getProjectStatuses(project);
+    const statuses = await client.getProjectStatuses(opts.project);
 
     outputResult(statuses, opts, (data) => {
       if (data.length === 0) {

--- a/apps/cli/src/commands/wiki/count.test.ts
+++ b/apps/cli/src/commands/wiki/count.test.ts
@@ -16,7 +16,7 @@ describe("wiki count", () => {
   it("displays wiki page count", async () => {
     mockClient.getWikisCount.mockResolvedValue({ count: 42 });
 
-    await parseCommand(() => import("./count"), ["TEST"]);
+    await parseCommand(() => import("./count"), ["-p", "TEST"]);
 
     expect(mockClient.getWikisCount).toHaveBeenCalledWith("TEST");
     expect(consola.log).toHaveBeenCalledWith("42");
@@ -26,7 +26,7 @@ describe("wiki count", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./count"),
-      ["TEST", "--json"],
+      ["-p", "TEST", "--json"],
       "42",
       () => {
         mockClient.getWikisCount.mockResolvedValue({ count: 42 });

--- a/apps/cli/src/commands/wiki/count.ts
+++ b/apps/cli/src/commands/wiki/count.ts
@@ -3,22 +3,24 @@ import { outputResult } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const count = new BeeCommand("count")
   .summary("Count wiki pages")
   .description(`Counts all wiki pages regardless of tag or keyword.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "Count wiki pages", command: "bee wiki count PROJECT" },
-    { description: "Output as JSON", command: "bee wiki count PROJECT --json" },
+    { description: "Count wiki pages", command: "bee wiki count -p PROJECT" },
+    { description: "Output as JSON", command: "bee wiki count -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const result = await client.getWikisCount(project);
+    const result = await client.getWikisCount(opts.project);
 
     const json = opts.json === true ? "" : opts.json;
     outputResult(result, { json }, (data) => {

--- a/apps/cli/src/commands/wiki/list.test.ts
+++ b/apps/cli/src/commands/wiki/list.test.ts
@@ -19,7 +19,7 @@ describe("wiki list", () => {
       { id: 2, name: "Setup Guide", updated: "2025-01-02T00:00:00Z" },
     ]);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(mockClient.getWikis).toHaveBeenCalledWith({
       projectIdOrKey: "TEST",
@@ -33,7 +33,7 @@ describe("wiki list", () => {
   it("shows message when no wiki pages found", async () => {
     mockClient.getWikis.mockResolvedValue([]);
 
-    await parseCommand(() => import("./list"), ["TEST"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST"]);
 
     expect(consola.info).toHaveBeenCalledWith("No wiki pages found.");
   });
@@ -41,7 +41,7 @@ describe("wiki list", () => {
   it("passes keyword parameter", async () => {
     mockClient.getWikis.mockResolvedValue([]);
 
-    await parseCommand(() => import("./list"), ["TEST", "--keyword", "setup"]);
+    await parseCommand(() => import("./list"), ["-p", "TEST", "--keyword", "setup"]);
 
     expect(mockClient.getWikis).toHaveBeenCalledWith({
       projectIdOrKey: "TEST",
@@ -53,7 +53,7 @@ describe("wiki list", () => {
     "outputs JSON when --json flag is set",
     itOutputsJson(
       () => import("./list"),
-      ["TEST", "--json"],
+      ["-p", "TEST", "--json"],
       "Home",
       () => {
         mockClient.getWikis.mockResolvedValue([

--- a/apps/cli/src/commands/wiki/list.ts
+++ b/apps/cli/src/commands/wiki/list.ts
@@ -3,28 +3,30 @@ import { type Row, outputResult, printTable } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const list = new BeeCommand("list")
   .summary("List wiki pages")
   .description(`Use \`--keyword\` to filter pages by name or content.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.keyword())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List all wiki pages in a project", command: "bee wiki list PROJECT" },
+    { description: "List all wiki pages in a project", command: "bee wiki list -p PROJECT" },
     {
       description: "Search wiki pages by keyword",
-      command: 'bee wiki list PROJECT --keyword "setup"',
+      command: 'bee wiki list -p PROJECT --keyword "setup"',
     },
-    { description: "Output as JSON", command: "bee wiki list PROJECT --json" },
+    { description: "Output as JSON", command: "bee wiki list -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
     const wikis = await client.getWikis({
-      projectIdOrKey: project,
+      projectIdOrKey: opts.project,
       keyword: opts.keyword,
     });
 

--- a/apps/cli/src/commands/wiki/tags.test.ts
+++ b/apps/cli/src/commands/wiki/tags.test.ts
@@ -26,7 +26,7 @@ describe("wiki tags", () => {
     ]);
 
     const { default: tags } = await import("./tags");
-    await tags.parseAsync(["TEST"], { from: "user" });
+    await tags.parseAsync(["-p", "TEST"], { from: "user" });
 
     expect(getClient).toHaveBeenCalled();
     expect(mockClient.getWikisTags).toHaveBeenCalledWith("TEST");
@@ -38,7 +38,7 @@ describe("wiki tags", () => {
     mockClient.getWikisTags.mockResolvedValue([]);
 
     const { default: tags } = await import("./tags");
-    await tags.parseAsync(["TEST"], { from: "user" });
+    await tags.parseAsync(["-p", "TEST"], { from: "user" });
 
     expect(consola.info).toHaveBeenCalledWith("No wiki tags found.");
   });
@@ -48,7 +48,7 @@ describe("wiki tags", () => {
 
     await expectStdoutContaining(async () => {
       const { default: tags } = await import("./tags");
-      await tags.parseAsync(["TEST", "--json"], { from: "user" });
+      await tags.parseAsync(["-p", "TEST", "--json"], { from: "user" });
     }, "guide");
   });
 });

--- a/apps/cli/src/commands/wiki/tags.ts
+++ b/apps/cli/src/commands/wiki/tags.ts
@@ -3,22 +3,24 @@ import { outputResult } from "@repo/cli-utils";
 import consola from "consola";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
+import { resolveOptions } from "../../lib/required-option";
 
 const tags = new BeeCommand("tags")
   .summary("List wiki tags")
   .description(`Tags are labels attached to wiki pages for organization.`)
-  .argument("<project>", "Project ID or project key")
+  .addOption(opt.project())
   .addOption(opt.json())
   .addOption(opt.space())
   .envVars([...ENV_AUTH, ENV_PROJECT])
   .examples([
-    { description: "List wiki tags", command: "bee wiki tags PROJECT" },
-    { description: "Output as JSON", command: "bee wiki tags PROJECT --json" },
+    { description: "List wiki tags", command: "bee wiki tags -p PROJECT" },
+    { description: "Output as JSON", command: "bee wiki tags -p PROJECT --json" },
   ])
-  .action(async (project, opts) => {
+  .action(async (opts, cmd) => {
+    await resolveOptions(cmd);
     const { client } = await getClient(opts.space);
 
-    const result = await client.getWikisTags(project);
+    const result = await client.getWikisTags(opts.project);
 
     const json = opts.json === true ? "" : opts.json;
     outputResult(result, { json }, (data) => {

--- a/apps/docs/src/content/docs/recipes/pr-lifecycle-sync.mdx
+++ b/apps/docs/src/content/docs/recipes/pr-lifecycle-sync.mdx
@@ -39,7 +39,7 @@ permissions: {}
 env:
   BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
   BACKLOG_SPACE: ${{ secrets.BACKLOG_SPACE }}
-  # 「処理中」ステータスの ID（bee status list <PROJECT> で確認）
+  # 「処理中」ステータスの ID（bee status list -p <PROJECT> で確認）
   STATUS_IN_PROGRESS: "2"
 
 jobs:
@@ -125,7 +125,7 @@ jobs:
 ## カスタマイズ
 
 ステータス ID を確認するには
-: `bee status list <PROJECT>` でプロジェクトのステータス一覧と ID を確認できます。`STATUS_IN_PROGRESS` の値をプロジェクトに合わせて変更してください。
+: `bee status list -p <PROJECT>` でプロジェクトのステータス一覧と ID を確認できます。`STATUS_IN_PROGRESS` の値をプロジェクトに合わせて変更してください。
 
 ステータス変更が不要
 : `bee issue edit` の行と `STATUS_IN_PROGRESS` 環境変数を削除すれば、リンクのコメントだけになります。
@@ -134,7 +134,7 @@ jobs:
 : 「Close linked issues」ステップを削除してください。
 
 クローズではなく別のステータスにしたい
-: `bee issue close` を `bee issue edit --status <ステータスID>` に変更してください。ステータス ID は `bee status list <PROJECT>` で確認できます。
+: `bee issue close` を `bee issue edit --status <ステータスID>` に変更してください。ステータス ID は `bee status list -p <PROJECT>` で確認できます。
 
 `edited` イベントが不要
 : トリガーの `types` から `edited` を削除し、「Comment PR link on newly added issues」ステップを削除してください。


### PR DESCRIPTION
## Summary
- Converted 14 commands that used positional `<project>` or `[project]` arguments to use the `-p, --project` flag via `opt.project()` + `resolveOptions`
- This unifies the project specification pattern across all commands, improving consistency and reducing confusion for AI agents
- Commands affected: `project view/edit/users/activities/delete`, `repo list`, `wiki count/list/tags`, `status list`, `category list`, `milestone list`, `issue-type list`, `document tree`

## Test plan
- [x] All 720 tests pass
- [x] Build succeeds
- [x] Manual verification: run a few commands with `-p PROJECT_KEY` to confirm they work as expected
- [x] Verify interactive prompt works when `--project` is omitted and `BACKLOG_PROJECT` env var is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)