### PR TITLE
feat: add HTTP proxy support via environment variables

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,11 +1,11 @@
 import consola from "consola";
-import { installHttpLogger } from "@repo/backlog-utils";
+import { installHttpDispatcher } from "@repo/backlog-utils";
 import { BeeCommand } from "./lib/bee-command";
 import { handleError } from "./lib/error";
 import pkg from "../package.json" with { type: "json" };
 
 consola.options.formatOptions.date = false;
-installHttpLogger();
+installHttpDispatcher();
 
 const program = new BeeCommand("bee").version(pkg.version).description(pkg.description ?? "");
 

--- a/apps/docs/src/content/docs/guides/environment-variables.mdx
+++ b/apps/docs/src/content/docs/guides/environment-variables.mdx
@@ -33,6 +33,12 @@ description: |-
 `BACKLOG_OAUTH_PORT`
 : OAuth 認証で使用するコールバックサーバーのポート番号。デフォルトは `5033`。別のアプリケーションとポートが競合する場合に変更できます。
 
+`HTTPS_PROXY` / `HTTP_PROXY`
+: アウトバウンドの HTTPS / HTTP リクエストを指定したプロキシ経由でルーティングします（例: `http://proxy.corp.example.com:8080`）。社内プロキシ環境や制限されたネットワークでの利用に必要です。
+
+`NO_PROXY`
+: プロキシをバイパスするホストをカンマ区切りで指定します（例: `internal.example.com,localhost`）。サブドメイン（`.example.com`）、ポート指定（`example.com:8080`）、ワイルドカード（`*`）にも対応しています。
+
 ## よく使うパターン
 
 ### プロジェクトの固定

--- a/packages/backlog-utils/src/http-dispatcher.test.ts
+++ b/packages/backlog-utils/src/http-dispatcher.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
+
+vi.mock("undici", () => {
+  const MockAgent = vi.fn();
+  MockAgent.prototype.compose = vi.fn(function (this: unknown) {
+    return this;
+  });
+  return {
+    EnvHttpProxyAgent: MockAgent,
+    setGlobalDispatcher: vi.fn(),
+  };
+});
+
+describe("installHttpDispatcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls setGlobalDispatcher with a composed EnvHttpProxyAgent", async () => {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
+    const { installHttpDispatcher } = await import("./http-dispatcher");
+
+    installHttpDispatcher();
+
+    expect(EnvHttpProxyAgent).toHaveBeenCalled();
+    expect(vi.mocked(EnvHttpProxyAgent).prototype.compose).toHaveBeenCalled();
+    expect(setGlobalDispatcher).toHaveBeenCalled();
+  });
+});

--- a/packages/backlog-utils/src/http-dispatcher.ts
+++ b/packages/backlog-utils/src/http-dispatcher.ts
@@ -1,0 +1,15 @@
+import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+import { createLoggingInterceptor } from "./http-logger";
+
+/** Installs the global fetch dispatcher with logging and proxy support.
+ *
+ * Respects the standard HTTP proxy environment variables:
+ *   HTTPS_PROXY / https_proxy, HTTP_PROXY / http_proxy,
+ *   NO_PROXY / no_proxy (comma-separated list of hosts to bypass).
+ */
+const installHttpDispatcher = (): void => {
+  const agent = new EnvHttpProxyAgent().compose(createLoggingInterceptor());
+  setGlobalDispatcher(agent);
+};
+
+export { installHttpDispatcher };

--- a/packages/backlog-utils/src/http-logger.test.ts
+++ b/packages/backlog-utils/src/http-logger.test.ts
@@ -3,18 +3,6 @@ import consola from "consola";
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
-vi.mock("undici", () => {
-  const MockAgent = vi.fn();
-  MockAgent.prototype.compose = vi.fn(function (this: unknown) {
-    return this;
-  });
-  return {
-    Agent: MockAgent,
-    EnvHttpProxyAgent: MockAgent,
-    setGlobalDispatcher: vi.fn(),
-  };
-});
-
 const newHandler = () => ({
   onRequestStart: vi.fn(),
   onResponseStart: vi.fn(),
@@ -131,22 +119,5 @@ describe("createLoggingInterceptor", () => {
     wrappedDispatch(opts as never, newHandler() as never);
 
     expect(consola.debug).toHaveBeenCalledWith("→ GET /api/v2/issues?apiKey=***&projectId[]=1");
-  });
-});
-
-describe("installHttpLogger", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("calls setGlobalDispatcher with a composed EnvHttpProxyAgent", async () => {
-    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
-    const { installHttpLogger } = await import("./http-logger");
-
-    installHttpLogger();
-
-    expect(EnvHttpProxyAgent).toHaveBeenCalled();
-    expect(vi.mocked(EnvHttpProxyAgent).prototype.compose).toHaveBeenCalled();
-    expect(setGlobalDispatcher).toHaveBeenCalled();
   });
 });

--- a/packages/backlog-utils/src/http-logger.test.ts
+++ b/packages/backlog-utils/src/http-logger.test.ts
@@ -10,6 +10,7 @@ vi.mock("undici", () => {
   });
   return {
     Agent: MockAgent,
+    EnvHttpProxyAgent: MockAgent,
     setGlobalDispatcher: vi.fn(),
   };
 });
@@ -138,14 +139,14 @@ describe("installHttpLogger", () => {
     vi.clearAllMocks();
   });
 
-  it("calls setGlobalDispatcher with a composed agent", async () => {
-    const { Agent, setGlobalDispatcher } = await import("undici");
+  it("calls setGlobalDispatcher with a composed EnvHttpProxyAgent", async () => {
+    const { EnvHttpProxyAgent, setGlobalDispatcher } = await import("undici");
     const { installHttpLogger } = await import("./http-logger");
 
     installHttpLogger();
 
-    expect(Agent).toHaveBeenCalled();
-    expect(vi.mocked(Agent).prototype.compose).toHaveBeenCalled();
+    expect(EnvHttpProxyAgent).toHaveBeenCalled();
+    expect(vi.mocked(EnvHttpProxyAgent).prototype.compose).toHaveBeenCalled();
     expect(setGlobalDispatcher).toHaveBeenCalled();
   });
 });

--- a/packages/backlog-utils/src/http-logger.ts
+++ b/packages/backlog-utils/src/http-logger.ts
@@ -1,5 +1,5 @@
 import consola from "consola";
-import { EnvHttpProxyAgent, type Dispatcher, setGlobalDispatcher } from "undici";
+import { type Dispatcher } from "undici";
 
 type Interceptor = (dispatch: Dispatcher["dispatch"]) => Dispatcher["dispatch"];
 
@@ -65,14 +65,4 @@ const createLoggingInterceptor = (): Interceptor => {
   };
 };
 
-/** Installs the logging interceptor as the global fetch dispatcher.
- *
- * Respects the standard HTTP proxy environment variables:
- *   HTTPS_PROXY / https_proxy, HTTP_PROXY / http_proxy,
- *   NO_PROXY / no_proxy (comma-separated list of hosts to bypass).
- */
-const installHttpLogger = (): void => {
-  setGlobalDispatcher(new EnvHttpProxyAgent().compose(createLoggingInterceptor()));
-};
-
-export { createLoggingInterceptor, installHttpLogger };
+export { createLoggingInterceptor };

--- a/packages/backlog-utils/src/http-logger.ts
+++ b/packages/backlog-utils/src/http-logger.ts
@@ -1,5 +1,5 @@
 import consola from "consola";
-import { Agent, type Dispatcher, setGlobalDispatcher } from "undici";
+import { EnvHttpProxyAgent, type Dispatcher, setGlobalDispatcher } from "undici";
 
 type Interceptor = (dispatch: Dispatcher["dispatch"]) => Dispatcher["dispatch"];
 
@@ -65,10 +65,14 @@ const createLoggingInterceptor = (): Interceptor => {
   };
 };
 
-/** Installs the logging interceptor as the global fetch dispatcher. */
+/** Installs the logging interceptor as the global fetch dispatcher.
+ *
+ * Respects the standard HTTP proxy environment variables:
+ *   HTTPS_PROXY / https_proxy, HTTP_PROXY / http_proxy,
+ *   NO_PROXY / no_proxy (comma-separated list of hosts to bypass).
+ */
 const installHttpLogger = (): void => {
-  const agent = new Agent().compose(createLoggingInterceptor());
-  setGlobalDispatcher(agent);
+  setGlobalDispatcher(new EnvHttpProxyAgent().compose(createLoggingInterceptor()));
 };
 
 export { createLoggingInterceptor, installHttpLogger };

--- a/packages/backlog-utils/src/index.ts
+++ b/packages/backlog-utils/src/index.ts
@@ -46,4 +46,4 @@ export {
   getRepoRelativePath,
   parseBacklogRemoteUrl,
 } from "./git-context";
-export { installHttpLogger } from "./http-logger";
+export { installHttpDispatcher } from "./http-dispatcher";


### PR DESCRIPTION
## Summary

In corporate environments, all outbound HTTPS traffic is typically required to pass through a proxy. Without proxy support, bee cannot reach the Backlog API at all in such networks, making this a hard requirement for adoption in those environments.

Routes all Backlog API requests through an HTTP proxy when standard proxy environment variables are set.

- Replaces `Agent` with undici's `EnvHttpProxyAgent` as the global fetch dispatcher, which automatically reads `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` (and their lowercase variants) from the environment
- No configuration changes required — proxy is opt-in via env vars
- `NO_PROXY` exclusions (exact host, subdomain, port-specific, wildcard `*`) are handled by `EnvHttpProxyAgent` natively
- Zero behaviour change when no proxy env vars are set
- Splits `http-logger` and `http-dispatcher` into separate modules: the logger owns the interceptor logic, the dispatcher owns the wiring

### Usage

```sh
# Route all requests through a corporate proxy
HTTPS_PROXY=http://proxy.corp.example.com:8080 bee issue list

# Bypass the proxy for a specific host
NO_PROXY=your-space.backlog.com HTTPS_PROXY=http://proxy.corp.example.com:8080 bee issue list

# Or set permanently in your shell profile
export HTTPS_PROXY=http://proxy.corp.example.com:8080
bee issue list
```

### Why env vars rather than a CLI flag or config option

Env vars are the standard convention (`curl`, `git`, `npm` all follow `HTTPS_PROXY`/`NO_PROXY`), so users in corporate environments typically already have them set — zero extra configuration needed.

### Relationship to nulab/backlog-js#149

An alternative would be injecting a proxy-aware `fetch` per `Backlog` client, as nulab/backlog-js#149 enables. Since all of bee's outbound HTTP targets the Backlog API, a global dispatcher is simpler and avoids per-client wiring.

## Test plan

### Verified against a real corporate proxy

```sh
HTTP_PROXY=example.com:1234
HTTPS_PROXY=example.com:1234
NO_PROXY=localhost,intra.example.com

git clone https://github.com/iray-tno/bee.git
cd bee
git checkout feat/proxy-support
mise self-update
mise use pnpm@latest
pnpm install
pnpm build
cd apps/cli && pnpm pack
npm install -g ./nulab-bee-0.0.0.tgz
bee auth login
bee issue list
```

Confirmed `bee issue list` succeeds through the proxy with the target host excluded via `NO_PROXY`.

### Local testing

I've verified manually with `HTTPS_PROXY` pointing at a local non-listening port:

```sh
# Proxy routing confirmed — ECONNREFUSED from the proxy address, not Backlog
HTTPS_PROXY=http://127.0.0.1:9999 bee issue list
# → connect ECONNREFUSED 127.0.0.1:9999

# Bypass confirmed — request reaches Backlog directly, auth error not proxy error
NO_PROXY=<space>.backlog.com HTTPS_PROXY=http://127.0.0.1:9999 bee issue list
# → Backlog API error (invalid credentials, expected in test env)
```

### Integration test?

We initially wrote an integration test that spun up a local HTTP server and verified proxy routing and `NO_PROXY` bypass using the real `EnvHttpProxyAgent`. It passed, but we removed it — it was exercising undici's behaviour rather than our own code. The unit tests already prove the wiring (`EnvHttpProxyAgent` constructed, composed with the interceptor, `setGlobalDispatcher` called).

