### PR TITLE
docs: fix incorrect login command on homepage (`bee login` → `bee auth login`)

### DIFF
--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -30,7 +30,7 @@ import HeroTilt from "../../components/HeroTilt.astro";
 <CardGrid stagger>
   <Card title="すぐに使える" icon="rocket">
     [npm でインストール](/bee/getting-started/)したら、
-    `bee login` するだけ。
+    `bee auth login` するだけ。
 
     ブラウザを開かなくても課題の確認や作成がターミナルで完結します。
   </Card>


### PR DESCRIPTION
## Summary

The homepage (`apps/docs/src/content/docs/index.mdx`) tells new users that after installing they can "just run `bee login`". However, there is no top-level `login` command — running it errors:

```
$ bee login
error: unknown command 'login'
```

The correct command is `bee auth login`. This was confusing when following the docs as a first-time user.

## Change

- `apps/docs/src/content/docs/index.mdx`: `bee login` → `bee auth login`

This brings the homepage in line with the actual CLI and the rest of the docs — the [Getting Started](apps/docs/src/content/docs/getting-started.mdx) and [Authentication](apps/docs/src/content/docs/guides/authentication.mdx) pages already use `bee auth login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)