### PR TITLE
docs: fix flag names in using-bee skill tip

### DIFF
--- a/skills/using-bee/SKILL.md
+++ b/skills/using-bee/SKILL.md
@@ -111,4 +111,4 @@ When `--json` is used, errors are output as JSON to stderr, making them easy to 
 - Use `--json` for all data retrieval so you can parse and process the results.
 - Combine multiple bee calls to build reports, batch-update issues, or automate workflows.
 - When creating or editing resources interactively, bee prompts for required fields. Use flags to skip prompts in automated workflows.
-- bee uses `--title` and `--body` — not Backlog API names like `--summary`, `--description`, or `--content`.
+- Issues use `--title` / `--description`; pull requests use `--title` / `--body`. The flag names differ between the two — `bee issue create` has no `--body`.


### PR DESCRIPTION
## Summary

- The last tip in `skills/using-bee/SKILL.md` said bee uses `--title`/`--body` universally, which is wrong for issues — `bee issue create` has no `--body` flag, only `--description`. Pull requests use `--body` instead.
- Following the old text sends `bee issue create --body ...` into an unknown-option failure.
- Verified against `bee issue create --help` / `bee pr create --help` on bee 1.0.0, and against https://nulab.github.io/bee/llms-full.txt (which was already correct).

## Test plan

- [x] Read-only doc fix, no code changes — confirmed the corrected flags against `--help` output for both commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbxcgqGQPrZR5cuUEpgm2G