### PR TITLE
fix: read BACKLOG_PROJECT env var in document create, wiki create, and document view

### DIFF
--- a/apps/cli/src/commands/document/create.test.ts
+++ b/apps/cli/src/commands/document/create.test.ts
@@ -1,6 +1,6 @@
 import { promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { itOutputsJson, mockGetClient, parseCommand, setupCommandTest } from "@repo/test-utils";
 
 const { mockClient, host } = setupCommandTest({
@@ -20,6 +20,22 @@ vi.mock("@repo/cli-utils", async (importOriginal) => ({
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("document create", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads project from the BACKLOG_PROJECT environment variable", async () => {
+    vi.stubEnv("BACKLOG_PROJECT", "PROJECT");
+    mockClient.addDocument.mockResolvedValue({ id: "6", title: "Title" });
+
+    await parseCommand(() => import("./create"), ["-t", "Title"]);
+
+    expect(promptRequired).toHaveBeenCalledWith("Project:", "PROJECT");
+    expect(mockClient.addDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: 100 }),
+    );
+  });
+
   it("creates a document with provided fields", async () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("100").mockResolvedValueOnce("Meeting Notes");
     mockClient.addDocument.mockResolvedValue({

--- a/apps/cli/src/commands/document/create.ts
+++ b/apps/cli/src/commands/document/create.ts
@@ -1,6 +1,7 @@
 import { documentUrl, getClient, resolveProjectIds } from "@repo/backlog-utils";
 import { outputResult, promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
+import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
@@ -9,7 +10,7 @@ const create = new BeeCommand("create")
   .description(
     `Omitted required fields will be prompted interactively. When input is piped, it is used as the body automatically.`,
   )
-  .option("-p, --project <id>", "Project ID or project key")
+  .addOption(new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT"))
   .option("-t, --title <text>", "Document title")
   .option("-b, --body <text>", "Document body content")
   .option("--emoji <emoji>", "Emoji for the document")

--- a/apps/cli/src/commands/document/view.test.ts
+++ b/apps/cli/src/commands/document/view.test.ts
@@ -1,6 +1,6 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { itOutputsJson, parseCommand } from "@repo/test-utils";
 
 const mockClient = vi.hoisted(() => ({
@@ -36,6 +36,10 @@ const sampleDocument = {
 };
 
 describe("document view", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it("displays document details", async () => {
     mockClient.getDocument.mockResolvedValue(sampleDocument);
 
@@ -74,6 +78,18 @@ describe("document view", () => {
       consola,
     );
     expect(mockClient.getDocument).not.toHaveBeenCalled();
+  });
+
+  it("reads project from the BACKLOG_PROJECT environment variable for --web", async () => {
+    vi.stubEnv("BACKLOG_PROJECT", "ENVPROJ");
+
+    await parseCommand(() => import("./view"), ["doc-1", "--web"]);
+
+    expect(openOrPrintUrl).toHaveBeenCalledWith(
+      "https://example.backlog.com/document/ENVPROJ/doc-1",
+      false,
+      consola,
+    );
   });
 
   it(

--- a/apps/cli/src/commands/document/view.ts
+++ b/apps/cli/src/commands/document/view.ts
@@ -1,6 +1,7 @@
 import { documentUrl, getClient, openOrPrintUrl } from "@repo/backlog-utils";
 import { UserError, formatDate, outputResult, printDefinitionList } from "@repo/cli-utils";
 import consola from "consola";
+import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
@@ -8,7 +9,11 @@ const view = new BeeCommand("view")
   .summary("View a document")
   .description(`Use \`--web\` to open in the browser (\`--project\` is required for \`--web\`).`)
   .argument("<document>", "Document ID")
-  .option("-p, --project <id>", "Project ID or project key (required for --web)")
+  .addOption(
+    new Option("-p, --project <id>", "Project ID or project key (required for --web)").env(
+      "BACKLOG_PROJECT",
+    ),
+  )
   .addOption(opt.web("document"))
   .addOption(opt.noBrowser())
   .addOption(opt.json())

--- a/apps/cli/src/commands/wiki/create.test.ts
+++ b/apps/cli/src/commands/wiki/create.test.ts
@@ -1,6 +1,6 @@
 import { promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { itOutputsJson, mockGetClient, parseCommand, setupCommandTest } from "@repo/test-utils";
 
 const { mockClient, host } = setupCommandTest({
@@ -20,6 +20,21 @@ vi.mock("@repo/cli-utils", async (importOriginal) => ({
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("wiki create", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads project from the BACKLOG_PROJECT environment variable", async () => {
+    vi.stubEnv("BACKLOG_PROJECT", "TEST");
+    mockClient.getProjects.mockResolvedValue([{ id: 100, projectKey: "TEST" }]);
+    mockClient.postWiki.mockResolvedValue({ id: 3, name: "My Page" });
+
+    await parseCommand(() => import("./create"), ["-n", "My Page", "-b", "Hello"]);
+
+    expect(promptRequired).toHaveBeenCalledWith("Project:", "TEST");
+    expect(mockClient.postWiki).toHaveBeenCalledWith(expect.objectContaining({ projectId: 100 }));
+  });
+
   it("creates a wiki page with provided arguments", async () => {
     vi.mocked(promptRequired).mockResolvedValueOnce("TEST").mockResolvedValueOnce("My Page");
     mockClient.getProjects.mockResolvedValue([{ id: 100, projectKey: "TEST" }]);

--- a/apps/cli/src/commands/wiki/create.ts
+++ b/apps/cli/src/commands/wiki/create.ts
@@ -1,13 +1,14 @@
 import { getClient, resolveProjectIds, wikiUrl } from "@repo/backlog-utils";
 import { outputResult, promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
+import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
 const create = new BeeCommand("create")
   .summary("Create a wiki page")
   .description(`When input is piped, it is used as the body automatically.`)
-  .option("-p, --project <id>", "Project ID or project key")
+  .addOption(new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT"))
   .option("-n, --name <name>", "Wiki page name")
   .option("-b, --body <text>", "Wiki page content")
   .option("--mail-notify", "Send notification email")

--- a/apps/cli/src/lib/bee-command.test.ts
+++ b/apps/cli/src/lib/bee-command.test.ts
@@ -41,6 +41,14 @@ describe("BeeCommand", () => {
       expect(help).toContain("BACKLOG_PROJECT");
       expect(help).toContain("BACKLOG_API_KEY");
     });
+
+    it("lists an env var only once when declared on both an option and envVars", () => {
+      const cmd = new BeeCommand("test")
+        .addOption(new Option("-p, --project <id>", "Project ID").env("BACKLOG_PROJECT"))
+        .envVars([["BACKLOG_PROJECT", "Default project ID or project key"]]);
+      const [, envSection] = cmd.helpInformation().split("ENVIRONMENT VARIABLES");
+      expect(envSection.match(/BACKLOG_PROJECT/g)).toHaveLength(1);
+    });
   });
 
   describe("addCommands", () => {

--- a/apps/cli/src/lib/bee-command.ts
+++ b/apps/cli/src/lib/bee-command.ts
@@ -55,7 +55,14 @@ class BeeCommand extends Command {
     const fromOptions: [string, string][] = this.options
       .filter((opt) => opt.envVar)
       .map((opt) => [opt.envVar!, opt.description ?? ""]);
-    const vars = [...fromOptions, ...this.beeEnvVars];
+    const seen = new Set<string>();
+    const vars = [...fromOptions, ...this.beeEnvVars].filter(([name]) => {
+      if (seen.has(name)) {
+        return false;
+      }
+      seen.add(name);
+      return true;
+    });
     if (vars.length === 0) {
       return "";
     }


### PR DESCRIPTION
Fixes #115

## Summary

`document create`, `wiki create`, and `document view` did not read the `BACKLOG_PROJECT` environment variable, even though their help text advertises it via `envVars()`. For the create commands, non-interactive runs (piped stdin or CI) failed with an error, and interactive runs showed an unnecessary prompt:

```console
$ export BACKLOG_PROJECT=MY_PROJECT
$ echo "body" | bee document create -t "Title"
 ERROR  Project is required. Use arguments to provide it in non-interactive mode.

$ bee document list   # works fine with the same environment variable
```

For `document view`, `--web` failed with `The --project flag is required when using --web.` under the same conditions.

The `--project` option of these commands was defined with a plain `.option()` call, missing `.env("BACKLOG_PROJECT")`. `envVars()` only affects help rendering and does not wire the environment variable to the option.

This PR wires the option to the environment variable using the same pattern as `issue create`:

```ts
.addOption(new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT"))
```

It also fixes a related help-rendering issue: `_renderEnvVars()` concatenated env vars auto-collected from `Option.env()` with the manually declared `envVars()` entries, so commands declaring `BACKLOG_PROJECT` in both places (e.g. `issue create` and every `opt.project()` user) listed it twice in the ENVIRONMENT VARIABLES section. It is now deduplicated by variable name.

This is a minimal targeted fix for the affected commands. The underlying issue — `envVars()` (help rendering) and `Option.env()` (actual wiring) being independent, so a mismatch between them is not detected anywhere — remains. If you are interested, I would be happy to follow up with a separate PR that adds a consistency test walking the command tree and asserting that every command declaring `BACKLOG_PROJECT` in `envVars()` actually wires it to its `--project` option.

## Test plan

- Added a test per command asserting that the project is resolved from `BACKLOG_PROJECT` when `--project` is omitted, and a `BeeCommand` test asserting each env var is listed only once in help output.
- `pnpm test` (724 tests), `pnpm typecheck`, `pnpm lint`, and `pnpm format --check` all pass.
- Verified manually against a real Backlog space with `BACKLOG_PROJECT` set and `--project` omitted:
  - `document create` succeeded end-to-end: the project was resolved from the environment and the document was created (previously it aborted immediately in non-interactive mode).
  - `wiki create` resolved the project from the environment and reached the API call (creation itself returned 403 because the wiki feature is disabled on the test space, which is unrelated to this change).
  - `document view <id> --web --no-browser` now prints the document URL containing the project key from the environment.
  - `--help` shows `(env: BACKLOG_PROJECT)` on the option, and the ENVIRONMENT VARIABLES section lists `BACKLOG_PROJECT` exactly once.
