### PR TITLE
refactor(cli): add projectOptional helper for env-wired --project options

### DIFF
--- a/apps/cli/src/commands/browse.test.ts
+++ b/apps/cli/src/commands/browse.test.ts
@@ -1,6 +1,6 @@
 import { openOrPrintUrl } from "@repo/backlog-utils";
 import consola from "consola";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { parseCommand } from "@repo/test-utils";
 
 vi.mock("@repo/backlog-utils", () => ({
@@ -23,6 +23,22 @@ vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 const { resolveUrl: mockResolveUrl } = vi.mocked(await import("./browse-url"));
 
 describe("browse", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads project from the BACKLOG_PROJECT environment variable", async () => {
+    vi.stubEnv("BACKLOG_PROJECT", "ENVPROJ");
+
+    await parseCommand(() => import("./browse"), ["--issues"]);
+
+    expect(mockResolveUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ project: "ENVPROJ" }),
+      expect.anything(),
+    );
+  });
+
   it("opens resolved URL in browser", async () => {
     await parseCommand(() => import("./browse"));
 

--- a/apps/cli/src/commands/browse.ts
+++ b/apps/cli/src/commands/browse.ts
@@ -20,7 +20,7 @@ const browse = new BeeCommand("browse")
 Accepts an issue key (\`PROJECT-123\`), bare number (\`123\`, project inferred from Git remote), file path (\`src/main.ts\`), or path with line (\`src/main.ts:42\`). Paths ending with \`/\` open the directory tree. Use \`--project\` with section flags (e.g. \`--issues\`, \`--board\`) for project pages.`,
   )
   .argument("[target]", "Issue key, issue number, file path, or project key")
-  .addOption(opt.project().makeOptionMandatory(false).default(undefined))
+  .addOption(opt.projectOptional())
   .option("-b, --branch <name>", "View file at a specific branch")
   .option("-c, --commit", "View file at the latest commit")
   .addOption(opt.noBrowser())

--- a/apps/cli/src/commands/document/create.ts
+++ b/apps/cli/src/commands/document/create.ts
@@ -1,7 +1,6 @@
 import { documentUrl, getClient, resolveProjectIds } from "@repo/backlog-utils";
 import { outputResult, promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
-import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
@@ -10,7 +9,7 @@ const create = new BeeCommand("create")
   .description(
     `Omitted required fields will be prompted interactively. When input is piped, it is used as the body automatically.`,
   )
-  .addOption(new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT"))
+  .addOption(opt.projectOptional())
   .option("-t, --title <text>", "Document title")
   .option("-b, --body <text>", "Document body content")
   .option("--emoji <emoji>", "Emoji for the document")

--- a/apps/cli/src/commands/document/view.ts
+++ b/apps/cli/src/commands/document/view.ts
@@ -1,7 +1,6 @@
 import { documentUrl, getClient, openOrPrintUrl } from "@repo/backlog-utils";
 import { UserError, formatDate, outputResult, printDefinitionList } from "@repo/cli-utils";
 import consola from "consola";
-import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
@@ -9,11 +8,7 @@ const view = new BeeCommand("view")
   .summary("View a document")
   .description(`Use \`--web\` to open in the browser (\`--project\` is required for \`--web\`).`)
   .argument("<document>", "Document ID")
-  .addOption(
-    new Option("-p, --project <id>", "Project ID or project key (required for --web)").env(
-      "BACKLOG_PROJECT",
-    ),
-  )
+  .addOption(opt.projectOptional("Project ID or project key (required for --web)"))
   .addOption(opt.web("document"))
   .addOption(opt.noBrowser())
   .addOption(opt.json())

--- a/apps/cli/src/commands/issue/count.test.ts
+++ b/apps/cli/src/commands/issue/count.test.ts
@@ -1,5 +1,5 @@
 import consola from "consola";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { itOutputsJson, mockGetClient, parseCommand, setupCommandTest } from "@repo/test-utils";
 
 const { mockClient, host } = setupCommandTest({ getIssuesCount: vi.fn() });
@@ -13,6 +13,21 @@ vi.mock("@repo/backlog-utils", async (importOriginal) => ({
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("issue count", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads project from the BACKLOG_PROJECT environment variable", async () => {
+    vi.stubEnv("BACKLOG_PROJECT", "ENVPROJ");
+    mockClient.getIssuesCount.mockResolvedValue({ count: 7 });
+
+    await parseCommand(() => import("./count"), []);
+
+    expect(mockClient.getIssuesCount).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: ["ENVPROJ"] }),
+    );
+  });
+
   it("outputs issue count", async () => {
     mockClient.getIssuesCount.mockResolvedValue({ count: 42 });
 

--- a/apps/cli/src/commands/issue/count.ts
+++ b/apps/cli/src/commands/issue/count.ts
@@ -7,7 +7,6 @@ import {
 } from "@repo/backlog-utils";
 import { outputResult } from "@repo/cli-utils";
 import consola from "consola";
-import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 import { collect, collectNum } from "../../lib/common-options";
@@ -24,12 +23,7 @@ const resolvePriorityIds = (priorities: string[]): number[] =>
 const count = new BeeCommand("count")
   .summary("Count issues")
   .description(`Accepts the same filter flags as \`bee issue list\`.`)
-  .addOption(
-    new Option(
-      "-p, --project <id>",
-      "Project ID or project key (comma-separated for multiple)",
-    ).env("BACKLOG_PROJECT"),
-  )
+  .addOption(opt.projectOptional("Project ID or project key (comma-separated for multiple)"))
   .addOption(opt.assigneeList())
   .option("-S, --status <id>", "Status ID (repeatable)", collectNum, [] satisfies number[])
   .option("-P, --priority <name>", "Priority name (repeatable)", collect, [] satisfies string[])

--- a/apps/cli/src/commands/issue/create.test.ts
+++ b/apps/cli/src/commands/issue/create.test.ts
@@ -1,6 +1,6 @@
 import { promptRequired } from "@repo/cli-utils";
 import consola from "consola";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { itOutputsJson, mockGetClient, parseCommand, setupCommandTest } from "@repo/test-utils";
 
 const { mockClient, host } = setupCommandTest({
@@ -19,6 +19,23 @@ vi.mock("@repo/cli-utils", async (importOriginal) => ({
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("issue create", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads project from the BACKLOG_PROJECT environment variable", async () => {
+    vi.stubEnv("BACKLOG_PROJECT", "PROJECT");
+    mockClient.postIssue.mockResolvedValue({ issueKey: "TEST-1", summary: "Fix bug" });
+
+    await parseCommand(
+      () => import("./create"),
+      ["--title", "Fix bug", "--type", "1", "--priority", "normal"],
+    );
+
+    expect(promptRequired).toHaveBeenCalledWith("Project:", "PROJECT");
+    expect(mockClient.postIssue).toHaveBeenCalledWith(expect.objectContaining({ projectId: 100 }));
+  });
+
   it("creates an issue with provided fields", async () => {
     vi.mocked(promptRequired)
       .mockResolvedValueOnce("100")

--- a/apps/cli/src/commands/issue/create.ts
+++ b/apps/cli/src/commands/issue/create.ts
@@ -9,7 +9,6 @@ import {
 import { outputResult, parseArg, promptRequired, vFiniteNumber, vInteger } from "@repo/cli-utils";
 import consola from "consola";
 import * as v from "valibot";
-import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
@@ -18,7 +17,7 @@ const create = new BeeCommand("create")
   .description(
     `Omitted required fields will be prompted interactively. Priority accepts a name: \`high\`, \`normal\`, or \`low\`.`,
   )
-  .addOption(new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT"))
+  .addOption(opt.projectOptional())
   .option("-t, --title <text>", "Issue title")
   .option("-T, --type <id>", "Issue type ID")
   .option("-P, --priority <name>", "Priority")

--- a/apps/cli/src/commands/issue/list.test.ts
+++ b/apps/cli/src/commands/issue/list.test.ts
@@ -1,8 +1,11 @@
 import consola from "consola";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { itOutputsJson, mockGetClient, parseCommand, setupCommandTest } from "@repo/test-utils";
 
-const { mockClient, host } = setupCommandTest({ getIssues: vi.fn() });
+const { mockClient, host } = setupCommandTest({
+  getIssues: vi.fn(),
+  getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "ENVPROJ" }]),
+});
 
 vi.mock("@repo/backlog-utils", async (importOriginal) => ({
   ...(await importOriginal()),
@@ -30,6 +33,21 @@ const sampleIssues = [
 ];
 
 describe("issue list", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reads project from the BACKLOG_PROJECT environment variable", async () => {
+    vi.stubEnv("BACKLOG_PROJECT", "ENVPROJ");
+    mockClient.getIssues.mockResolvedValue(sampleIssues);
+
+    await parseCommand(() => import("./list"), []);
+
+    expect(mockClient.getIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: [100] }),
+    );
+  });
+
   it("displays issue list in tabular format", async () => {
     mockClient.getIssues.mockResolvedValue(sampleIssues);
 

--- a/apps/cli/src/commands/issue/list.ts
+++ b/apps/cli/src/commands/issue/list.ts
@@ -8,7 +8,6 @@ import {
 import { type Row, outputResult, parseArg, printTable, vInteger } from "@repo/cli-utils";
 import consola from "consola";
 import * as v from "valibot";
-import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 import { collect, collectNum } from "../../lib/common-options";
@@ -27,12 +26,7 @@ const list = new BeeCommand("list")
   .description(
     `By default, sorted by last updated date in descending order. Multiple project keys can be comma-separated.`,
   )
-  .addOption(
-    new Option(
-      "-p, --project <id>",
-      "Project ID or project key (comma-separated for multiple)",
-    ).env("BACKLOG_PROJECT"),
-  )
+  .addOption(opt.projectOptional("Project ID or project key (comma-separated for multiple)"))
   .addOption(opt.assigneeList())
   .option("-S, --status <id>", "Status ID (repeatable)", collectNum, [] satisfies number[])
   .option("-P, --priority <name>", "Priority name (repeatable)", collect, [] satisfies string[])

--- a/apps/cli/src/commands/wiki/create.ts
+++ b/apps/cli/src/commands/wiki/create.ts
@@ -1,14 +1,13 @@
 import { getClient, resolveProjectIds, wikiUrl } from "@repo/backlog-utils";
 import { outputResult, promptRequired, resolveStdinArg } from "@repo/cli-utils";
 import consola from "consola";
-import { Option } from "commander";
 import { BeeCommand, ENV_AUTH, ENV_PROJECT } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
 const create = new BeeCommand("create")
   .summary("Create a wiki page")
   .description(`When input is piped, it is used as the body automatically.`)
-  .addOption(new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT"))
+  .addOption(opt.projectOptional())
   .option("-n, --name <name>", "Wiki page name")
   .option("-b, --body <text>", "Wiki page content")
   .option("--mail-notify", "Send notification email")

--- a/apps/cli/src/lib/common-options.ts
+++ b/apps/cli/src/lib/common-options.ts
@@ -10,6 +10,8 @@ const collectNum = (val: string, prev: number[]): number[] => [
 
 const project = () =>
   new RequiredOption("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT");
+const projectOptional = (description = "Project ID or project key") =>
+  new Option("-p, --project <id>", description).env("BACKLOG_PROJECT");
 const repo = () =>
   new RequiredOption("-R, --repo <name>", "Repository name or ID").env("BACKLOG_REPO");
 const count = () => new Option("-L, --count <n>", "Number of results (default: 20)");
@@ -50,6 +52,7 @@ export {
   collectNum,
   space,
   project,
+  projectOptional,
   repo,
   count,
   offset,


### PR DESCRIPTION
## Why

`--project` / `BACKLOG_PROJECT` was defined by two different idioms:

- **A** — `.addOption(opt.project())`, ~40 commands. Uses `RequiredOption`, relying on `await resolveOptions(cmd)` in the action to prompt for a missing value.
- **B** — `.addOption(new Option("-p, --project <id>", …).env("BACKLOG_PROJECT"))`, 6 sites. Commands that prompt on their own via `promptRequired`, or where the flag is genuinely optional.

Idiom A had a helper in `apps/cli/src/lib/common-options.ts`. Idiom B had none, so every site hand-wrote `.env("BACKLOG_PROJECT")`.

That asymmetry made omitting `.env()` a silent, easy mistake — and it happened: `document create`, `wiki create`, and `document view` shipped without it and ignored `BACKLOG_PROJECT` entirely (#115, fixed in #116).

#116 fixed those three call sites. This PR removes the shape of the bug: with a helper for idiom B, there is no hand-written `.env()` left to forget. The three sites #116 touched are collected here too, so all six now share one definition.

## What

- Add `projectOptional()` to `common-options.ts`:
  ```ts
  const projectOptional = (description = "Project ID or project key") =>
    new Option("-p, --project <id>", description).env("BACKLOG_PROJECT");
  ```
- Route all 6 idiom-B sites through it — `issue list`, `issue count`, `issue create`, `document create`, `wiki create`, `document view` — passing a description only where it differs from the default.
- Drop the now-unused `import { Option } from "commander"` from those files.
- Add `BACKLOG_PROJECT` regression tests for the four sites that lacked them (see below).

After this change, no command under `apps/cli/src/commands/` writes `.env("BACKLOG_PROJECT")` by hand.

## Bundled help fix: `browse`

`browse` opted out of the required behaviour with:

```ts
.addOption(opt.project().makeOptionMandatory(false).default(undefined))
```

`RequiredOption`'s constructor appends `" (required)"` to the description unconditionally, so `browse --help` advertised a mandatory flag that was not one — in both the option list and the ENVIRONMENT VARIABLES section. It now uses `opt.projectOptional()`.

Runtime behaviour is unchanged. `browse` never called `resolveOptions`, so the `RequiredOption` marker did nothing at runtime, and I verified the parse result is identical for all four combinations (no flag / flag / env / flag-beats-env), including the `"project" in opts` distinction that `.default(undefined)` could have affected.

## Test coverage

#116 added env-var tests for the three commands it fixed, but `issue list`, `issue count`, `issue create`, and `browse` had none — they could lose their `.env()` wiring, reintroducing exactly the #115 defect, with the suite still fully green. That gap matters more after this PR, not less: now that all seven sites share one helper, a single edit to it can break every one of them at once.

Second commit adds one test per uncovered command, in the same shape as the three from #116 — assert the project value reaches the API call (or, for `browse`, the URL builder) with no `-p` flag present.

Verified by mutation rather than by the tests merely passing: dropping `.env()` from `projectOptional()` fails all **7** env tests (these 4 plus the 3 from #116); restoring it makes them pass.

## Verification

- `pnpm test` (728 tests, up from 724), `pnpm typecheck`, `pnpm lint` (0 errors; the 15 warnings are pre-existing and none are in the changed files), `pnpm format:check` — all pass.
- Captured `--help` for all 7 affected commands before and after. The **only** diff in the whole set is browse's `(required)` removal:
  ```diff
  -  -p, --project <id>      Project ID or project key (required) (env:
  -                          BACKLOG_PROJECT)
  +  -p, --project <id>      Project ID or project key (env: BACKLOG_PROJECT)
  ```
  ```diff
   ENVIRONMENT VARIABLES
  -  BACKLOG_PROJECT   Project ID or project key (required)
  +  BACKLOG_PROJECT   Project ID or project key
  ```
  The other 6 commands are byte-identical.
- Docs (`llms.txt`, `llms-full.txt`, command pages) are generated at build time by loading the live command tree via jiti — there is no checked-in snapshot, so nothing needs regenerating. They pick up the browse help fix on the next build.

## Out of scope

Deliberately left for separate issues, to stay reviewable and to leave good first issues for outside contributors:

- Unifying `envVars()` and `Option.env()` into one ledger (deriving the ENVIRONMENT VARIABLES section from the option definitions).
- A generic test that walks the command tree and checks declared env vars against actual wiring. The per-command tests added here cover the seven sites this PR touches; they are not a substitute for that sweep.
- Extending the same treatment to `--repo` / `BACKLOG_REPO`, `--space`, and other options.

Refs #115, #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)