### PR TITLE
fix: authenticate from BACKLOG_API_KEY and BACKLOG_SPACE without a config file

### DIFF
--- a/apps/cli/src/lib/bee-command.ts
+++ b/apps/cli/src/lib/bee-command.ts
@@ -72,7 +72,10 @@ class BeeCommand extends Command {
   }
 }
 
-const ENV_AUTH: [string, string][] = [["BACKLOG_API_KEY", "Authenticate with an API key"]];
+const ENV_AUTH: [string, string][] = [
+  ["BACKLOG_API_KEY", "Authenticate with an API key"],
+  ["BACKLOG_SPACE", "Space hostname"],
+];
 const ENV_PROJECT: [string, string] = ["BACKLOG_PROJECT", "Default project ID or project key"];
 const ENV_REPO: [string, string] = ["BACKLOG_REPO", "Default repository name"];
 

--- a/apps/docs/src/content/docs/guides/authentication.mdx
+++ b/apps/docs/src/content/docs/guides/authentication.mdx
@@ -19,7 +19,7 @@ bee auth login
 対話形式でスペースのホスト名（例: `xxx.backlog.com`）と API キーの入力を求められます。API キーは Backlog の **個人設定 > API** から発行できます。
 
 :::tip
-`BACKLOG_API_KEY` と `BACKLOG_SPACE` 環境変数を設定しておけば、`bee auth login` を実行しなくても認証済みの状態で bee を使えます。
+`BACKLOG_API_KEY` と `BACKLOG_SPACE` 環境変数を設定しておけば、`bee auth login` を実行しなくても認証済みの状態で bee を使えます。`~/.beerc` に該当スペースの設定がある場合はそちらの認証情報が優先されるため、認証情報をディスクに残したくない CI や sandbox 環境に向いています。
 :::
 
 ```sh

--- a/packages/backlog-utils/src/client.test.ts
+++ b/packages/backlog-utils/src/client.test.ts
@@ -28,6 +28,9 @@ vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 describe("getClient", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    vi.stubEnv("BACKLOG_API_KEY", undefined);
+    vi.stubEnv("BACKLOG_SPACE", undefined);
   });
 
   it("creates client with API Key authentication when host is provided", async () => {
@@ -108,5 +111,90 @@ describe("getClient", () => {
     await expect(async () => getClient("unknown.backlog.com")).rejects.toThrow(
       'Space "unknown.backlog.com" not found',
     );
+  });
+
+  it("authenticates with BACKLOG_API_KEY and BACKLOG_SPACE when the config file has no space", async () => {
+    vi.stubEnv("BACKLOG_API_KEY", "env-key");
+    vi.stubEnv("BACKLOG_SPACE", "env.backlog.com");
+    vi.mocked(loadConfig).mockReturnValue({
+      spaces: [],
+      aliases: {},
+    });
+    vi.mocked(findSpace).mockReturnValue(null);
+
+    const result = await getClient();
+
+    expect(Backlog).toHaveBeenCalledWith({
+      host: "env.backlog.com",
+      apiKey: "env-key",
+    });
+    expect(result.host).toBe("env.backlog.com");
+  });
+
+  it("authenticates with BACKLOG_API_KEY for a host given as an argument", async () => {
+    vi.stubEnv("BACKLOG_API_KEY", "env-key");
+    vi.mocked(loadConfig).mockReturnValue({
+      spaces: [],
+      aliases: {},
+    });
+    vi.mocked(findSpace).mockReturnValue(null);
+
+    const result = await getClient("flag.backlog.com");
+
+    expect(Backlog).toHaveBeenCalledWith({
+      host: "flag.backlog.com",
+      apiKey: "env-key",
+    });
+    expect(result.host).toBe("flag.backlog.com");
+  });
+
+  it("prefers the config file credentials over BACKLOG_API_KEY for a configured space", async () => {
+    vi.stubEnv("BACKLOG_API_KEY", "env-key");
+    vi.mocked(loadConfig).mockReturnValue({
+      defaultSpace: "example.backlog.com",
+      spaces: [],
+      aliases: {},
+    });
+    vi.mocked(findSpace).mockReturnValue({
+      host: "example.backlog.com",
+      auth: { method: "api-key" as const, apiKey: "config-key" },
+    });
+
+    const result = await getClient();
+
+    expect(Backlog).toHaveBeenCalledWith({
+      host: "example.backlog.com",
+      apiKey: "config-key",
+    });
+    expect(result.host).toBe("example.backlog.com");
+  });
+
+  it("prefers BACKLOG_SPACE over the config file defaultSpace", async () => {
+    vi.stubEnv("BACKLOG_SPACE", "env.backlog.com");
+    vi.mocked(loadConfig).mockReturnValue({
+      defaultSpace: "default.backlog.com",
+      spaces: [],
+      aliases: {},
+    });
+    vi.mocked(findSpace).mockReturnValue({
+      host: "env.backlog.com",
+      auth: { method: "api-key" as const, apiKey: "env-space-key" },
+    });
+
+    const result = await getClient();
+
+    expect(findSpace).toHaveBeenCalledWith([], "env.backlog.com");
+    expect(result.host).toBe("env.backlog.com");
+  });
+
+  it("throws error when BACKLOG_SPACE is set but no credentials are available", async () => {
+    vi.stubEnv("BACKLOG_SPACE", "env.backlog.com");
+    vi.mocked(loadConfig).mockReturnValue({
+      spaces: [],
+      aliases: {},
+    });
+    vi.mocked(findSpace).mockReturnValue(null);
+
+    await expect(async () => getClient()).rejects.toThrow('Space "env.backlog.com" not found');
   });
 });

--- a/packages/backlog-utils/src/client.ts
+++ b/packages/backlog-utils/src/client.ts
@@ -12,12 +12,13 @@ type BacklogClient = Backlog;
 /**
  * Resolves the active space and creates an authenticated API client.
  *
- * When `host` is provided, uses it directly. Otherwise falls back to
- * `defaultSpace` from the config file.
+ * Host resolution order: the `host` argument, `BACKLOG_SPACE`, then `defaultSpace`
+ * from the config file. Credentials come from the config file, falling back to
+ * `BACKLOG_API_KEY` when the resolved host has no entry there.
  *
  * For OAuth authentication, automatically refreshes the access token when it expires (401 error).
  *
- * @param host - Optional Backlog host (e.g. "example.backlog.com"). Defaults to config's defaultSpace.
+ * @param host - Optional Backlog host (e.g. "example.backlog.com").
  * @returns The authenticated client and host string.
  */
 const getClient = async (
@@ -27,7 +28,9 @@ const getClient = async (
   host: string;
 }> => {
   const config = loadConfig();
-  const resolvedHost = host ?? config.defaultSpace;
+  const envApiKey = process.env.BACKLOG_API_KEY;
+  const envSpace = process.env.BACKLOG_SPACE;
+  const resolvedHost = host ?? envSpace ?? config.defaultSpace;
 
   if (!resolvedHost) {
     throw new UserError("No space configured. Run `bee auth login` to authenticate.");
@@ -36,6 +39,11 @@ const getClient = async (
   const resolved = findSpace(config.spaces, resolvedHost);
 
   if (!resolved) {
+    if (envApiKey) {
+      const client = new Backlog({ host: resolvedHost, apiKey: envApiKey });
+      return { client, host: resolvedHost };
+    }
+
     throw new UserError(
       `Space "${resolvedHost}" not found. Run \`bee auth login\` to authenticate.`,
     );


### PR DESCRIPTION
## Summary

Docs (authentication / CI-CD guides) say `BACKLOG_API_KEY` + `BACKLOG_SPACE` is enough to use bee without `bee auth login`, but `getClient()` only read credentials from `~/.beerc`, so every command failed with `No space configured. Run bee auth login to authenticate.` unless the config file existed. `BACKLOG_API_KEY` was referenced only by the `--help` renderer.

This implements option 1 from #113.

## Changes

- `getClient()` resolves the host as `host` arg → `BACKLOG_SPACE` → `config.defaultSpace`, and falls back to a `BACKLOG_API_KEY` client when the resolved host has no entry in `~/.beerc`. Config-file credentials still win for a configured space.
- `ENV_AUTH` lists `BACKLOG_SPACE` so it shows in `--help` for commands without a `-s` flag.
- Authentication guide tip notes the precedence and the disk-free CI/sandbox use case.

## Test plan

- `pnpm test` — 729 passed, incl. 5 new `getClient` cases (env-only auth, env host, config-wins precedence, `BACKLOG_SPACE` over `defaultSpace`, space-not-found without a key)
- `pnpm lint` / `pnpm format:check` / `pnpm typecheck` clean
- Built CLI against an empty `XDG_CONFIG_HOME`: with `BACKLOG_API_KEY` set the call reaches the API instead of erroring on config; without it the existing errors are unchanged

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)