### PR TITLE
feat(config): accept any domain as a space host

### DIFF
--- a/apps/cli/src/commands/auth/login.test.ts
+++ b/apps/cli/src/commands/auth/login.test.ts
@@ -32,13 +32,74 @@ vi.mock("@repo/cli-utils", async (importOriginal) => ({
   readStdin: vi.fn(),
 }));
 
-vi.mock("@repo/config", () => ({
+vi.mock("@repo/config", async (importOriginal) => ({
+  ...(await importOriginal()),
   updateConfig: vi.fn(),
 }));
 
 vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("auth login", () => {
+  describe("hostname", () => {
+    it("authenticates against a self-hosted domain", async () => {
+      mockGetMyself.mockResolvedValue({ name: "Test User", userId: "testuser" });
+      vi.mocked(promptRequired)
+        .mockResolvedValueOnce("backlog.example.internal")
+        .mockResolvedValueOnce("test-api-key");
+      vi.mocked(updateConfig).mockImplementation((updater) =>
+        updater({ spaces: [], defaultSpace: undefined, aliases: {} }),
+      );
+
+      await parseCommand(() => import("./login"), ["--method", "api-key"]);
+
+      expect(Backlog).toHaveBeenCalledWith({
+        host: "backlog.example.internal",
+        apiKey: "test-api-key",
+      });
+      const result = vi.mocked(updateConfig).mock.results[0]?.value;
+      expect(result.spaces).toEqual([
+        {
+          host: "backlog.example.internal",
+          auth: { method: "api-key", apiKey: "test-api-key" },
+        },
+      ]);
+    });
+
+    it("normalizes an uppercase hostname to lowercase", async () => {
+      mockGetMyself.mockResolvedValue({ name: "Test User", userId: "testuser" });
+      vi.mocked(promptRequired)
+        .mockResolvedValueOnce("Example.Backlog.COM")
+        .mockResolvedValueOnce("test-api-key");
+      vi.mocked(updateConfig).mockImplementation((updater) =>
+        updater({ spaces: [], defaultSpace: undefined, aliases: {} }),
+      );
+
+      await parseCommand(() => import("./login"), ["--method", "api-key"]);
+
+      expect(Backlog).toHaveBeenCalledWith({
+        host: "example.backlog.com",
+        apiKey: "test-api-key",
+      });
+    });
+
+    // A hostname carrying userinfo or a path would move the request origin, and
+    // with it the API key, to another server.
+    it.each([
+      "example.backlog.com@evil.com",
+      "https://example.backlog.com",
+      "backlog.example.internal/backlog",
+    ])("rejects %s without contacting the server", async (hostname) => {
+      vi.mocked(promptRequired).mockResolvedValueOnce(hostname);
+
+      await expect(parseCommand(() => import("./login"), ["--method", "api-key"])).rejects.toThrow(
+        "is not a valid hostname",
+      );
+
+      expect(Backlog).not.toHaveBeenCalled();
+      expect(updateConfig).not.toHaveBeenCalled();
+    });
+  });
+
   describe("api-key", () => {
     it("authenticates new space with API key", async () => {
       mockGetMyself.mockResolvedValue({ name: "Test User", userId: "testuser" });

--- a/apps/cli/src/commands/auth/login.test.ts
+++ b/apps/cli/src/commands/auth/login.test.ts
@@ -41,10 +41,10 @@ vi.mock("consola", () => import("@repo/test-utils/mock-consola"));
 
 describe("auth login", () => {
   describe("hostname", () => {
-    it("authenticates against a self-hosted domain", async () => {
+    it("authenticates with the normalized hostname", async () => {
       mockGetMyself.mockResolvedValue({ name: "Test User", userId: "testuser" });
       vi.mocked(promptRequired)
-        .mockResolvedValueOnce("backlog.example.internal")
+        .mockResolvedValueOnce("Backlog.Example.INTERNAL")
         .mockResolvedValueOnce("test-api-key");
       vi.mocked(updateConfig).mockImplementation((updater) =>
         updater({ spaces: [], defaultSpace: undefined, aliases: {} }),
@@ -65,31 +65,8 @@ describe("auth login", () => {
       ]);
     });
 
-    it("normalizes an uppercase hostname to lowercase", async () => {
-      mockGetMyself.mockResolvedValue({ name: "Test User", userId: "testuser" });
-      vi.mocked(promptRequired)
-        .mockResolvedValueOnce("Example.Backlog.COM")
-        .mockResolvedValueOnce("test-api-key");
-      vi.mocked(updateConfig).mockImplementation((updater) =>
-        updater({ spaces: [], defaultSpace: undefined, aliases: {} }),
-      );
-
-      await parseCommand(() => import("./login"), ["--method", "api-key"]);
-
-      expect(Backlog).toHaveBeenCalledWith({
-        host: "example.backlog.com",
-        apiKey: "test-api-key",
-      });
-    });
-
-    // A hostname carrying userinfo or a path would move the request origin, and
-    // with it the API key, to another server.
-    it.each([
-      "example.backlog.com@evil.com",
-      "https://example.backlog.com",
-      "backlog.example.internal/backlog",
-    ])("rejects %s without contacting the server", async (hostname) => {
-      vi.mocked(promptRequired).mockResolvedValueOnce(hostname);
+    it("rejects an unusable hostname before contacting the server", async () => {
+      vi.mocked(promptRequired).mockResolvedValueOnce("example.backlog.com@evil.com");
 
       await expect(parseCommand(() => import("./login"), ["--method", "api-key"])).rejects.toThrow(
         "is not a valid hostname",

--- a/apps/cli/src/commands/auth/login.ts
+++ b/apps/cli/src/commands/auth/login.ts
@@ -1,8 +1,9 @@
 import { exchangeAuthorizationCode, openUrl, startCallbackServer } from "@repo/backlog-utils";
 import { UserError, promptRequired, readStdin } from "@repo/cli-utils";
-import { type RcAuth, updateConfig } from "@repo/config";
+import { type RcAuth, RcHostSchema, updateConfig } from "@repo/config";
 import { Backlog, OAuth2 } from "backlog-js";
 import consola from "consola";
+import * as v from "valibot";
 import { BeeCommand } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
@@ -37,12 +38,30 @@ Use \`--method oauth\` for OAuth authentication via the browser.`,
       throw new UserError('Invalid auth method. Use "api-key" or "oauth".');
     }
 
-    const hostname = await promptRequired("Backlog space hostname:", opts.space, {
-      placeholder: "xxx.backlog.com",
-    });
+    const hostname = parseHostname(
+      await promptRequired("Backlog space hostname:", opts.space, {
+        placeholder: "xxx.backlog.com",
+      }),
+    );
 
     await (method === "api-key" ? loginWithApiKey(hostname, opts) : loginWithOAuth(hostname));
   });
+
+/**
+ * Rejects a hostname before it reaches the network, so an unusable value fails
+ * with an actionable message instead of a connection or schema error later on.
+ */
+const parseHostname = (input: string): string => {
+  const result = v.safeParse(RcHostSchema, input.trim());
+
+  if (!result.success) {
+    throw new UserError(
+      `"${input}" is not a valid hostname. Pass the space's bare hostname, without a scheme or path (e.g. xxx.backlog.com).`,
+    );
+  }
+
+  return result.output;
+};
 
 const loginWithApiKey = async (hostname: string, opts: { withToken?: boolean }): Promise<void> => {
   if (!opts.withToken) {

--- a/apps/cli/src/lib/common-options.ts
+++ b/apps/cli/src/lib/common-options.ts
@@ -38,7 +38,11 @@ const comment = () => new Option("-c, --comment <text>", "Comment to add with th
 const web = (resource: string) => new Option("-w, --web", `Open the ${resource} in the browser`);
 const noBrowser = () =>
   new Option("-n, --no-browser", "Print the URL instead of opening the browser");
-const space = () => new Option("-s, --space <hostname>", "Space hostname").env("BACKLOG_SPACE");
+const space = () =>
+  new Option(
+    "-s, --space <hostname>",
+    "Space hostname (e.g. xxx.backlog.com, or your own domain)",
+  ).env("BACKLOG_SPACE");
 const json = () =>
   new Option(
     "--json [fields]",

--- a/packages/config/src/config.test.ts
+++ b/packages/config/src/config.test.ts
@@ -79,6 +79,21 @@ describe("writeConfig", () => {
 
     expect(mockChmodSync).toHaveBeenCalledWith(expect.stringContaining(".beerc"), 0o600);
   });
+
+  it("rejects an invalid host instead of persisting it", () => {
+    const config = {
+      ...sampleConfig,
+      spaces: [
+        {
+          host: "example.backlog.com@evil.com",
+          auth: { method: "api-key" as const, apiKey: "abc123" },
+        },
+      ],
+    };
+
+    expect(() => writeConfig(config)).toThrow("Configuration Error");
+    expect(mockWriteUser).not.toHaveBeenCalled();
+  });
 });
 
 describe("updateConfig", () => {

--- a/packages/config/src/config.ts
+++ b/packages/config/src/config.ts
@@ -8,8 +8,7 @@ import { type Rc, RcSchema } from "./schema";
 
 const CONFIG_FILE_NAME = ".beerc";
 
-const loadConfig = (): Rc => {
-  const raw = readUser(CONFIG_FILE_NAME);
+const parseConfig = (raw: unknown): Rc => {
   const result = v.safeParse(RcSchema, raw);
 
   if (!result.success) {
@@ -20,11 +19,18 @@ const loadConfig = (): Rc => {
   return result.output;
 };
 
+const loadConfig = (): Rc => parseConfig(readUser(CONFIG_FILE_NAME));
+
 const configFilePath = (): string =>
   resolve(process.env.XDG_CONFIG_HOME || homedir(), CONFIG_FILE_NAME);
 
+/**
+ * Validates before writing rather than trusting the caller, so an invalid host
+ * cannot be persisted by a command that writes the rc file directly (such as
+ * `bee auth login`) only to break every later read.
+ */
 const writeConfig = (config: Rc): void => {
-  writeUser(config, CONFIG_FILE_NAME);
+  writeUser(parseConfig(config), CONFIG_FILE_NAME);
   chmodSync(configFilePath(), 0o600);
 };
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,3 +1,4 @@
 export { loadConfig, updateConfig, writeConfig } from "./config";
 export { addSpace, findSpace, removeAllSpaces, removeSpace, updateSpaceAuth } from "./space";
+export { RcHostSchema } from "./schema";
 export type { Rc, RcAuth, RcSpace } from "./schema";

--- a/packages/config/src/schema.test.ts
+++ b/packages/config/src/schema.test.ts
@@ -105,7 +105,7 @@ describe("RcSpaceSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it.each(["backlog.example.internal", "my-backlog.corp.local", "backlog.example.co.jp"])(
+  it.each(["backlog.example.internal", "backlog.example.co.jp"])(
     "accepts the self-hosted domain %s",
     (host) => {
       const result = v.safeParse(RcSpaceSchema, { host, auth: validAuth });
@@ -136,6 +136,10 @@ describe("RcSpaceSchema", () => {
     ["a port", "example.backlog.com:8969"],
     ["a space", "exa mple.backlog.com"],
     ["no dot", "backlog"],
+    // Not attacks, but shapes a self-hosted user may reasonably try. They are
+    // unsupported today rather than deliberately forbidden.
+    ["an IP address", "192.168.1.1"],
+    ["a trailing dot", "example.backlog.com."],
   ])("rejects a host with %s", (_description, host) => {
     const result = v.safeParse(RcSpaceSchema, { host, auth: validAuth });
     expect(result.success).toBe(false);

--- a/packages/config/src/schema.test.ts
+++ b/packages/config/src/schema.test.ts
@@ -97,19 +97,47 @@ describe("RcSpaceSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  it("rejects invalid host domain", () => {
+  it("accepts a backlogtool.com host", () => {
     const result = v.safeParse(RcSpaceSchema, {
-      host: "example.invalid.com",
+      host: "example.backlogtool.com",
       auth: validAuth,
     });
-    expect(result.success).toBe(false);
+    expect(result.success).toBe(true);
   });
 
-  it("rejects host with uppercase letters", () => {
+  it.each(["backlog.example.internal", "my-backlog.corp.local", "backlog.example.co.jp"])(
+    "accepts the self-hosted domain %s",
+    (host) => {
+      const result = v.safeParse(RcSpaceSchema, { host, auth: validAuth });
+      expect(result.success).toBe(true);
+    },
+  );
+
+  it("normalizes an uppercase host to lowercase", () => {
     const result = v.safeParse(RcSpaceSchema, {
-      host: "Example.backlog.com",
+      host: "Example.Backlog.COM",
       auth: validAuth,
     });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.host).toBe("example.backlog.com");
+    }
+  });
+
+  // A host is interpolated into `https://${host}`, so anything that can shift the
+  // resulting origin would send the stored credentials to another server.
+  it.each([
+    ["userinfo that redirects the origin", "example.backlog.com@evil.com"],
+    ["a path that redirects the origin", "evil.com/#@example.backlog.com"],
+    ["a query that redirects the origin", "evil.com?x=.backlog.com"],
+    ["a scheme", "https://example.backlog.com"],
+    ["a trailing slash", "example.backlog.com/"],
+    ["a path prefix", "backlog.example.internal/backlog"],
+    ["a port", "example.backlog.com:8969"],
+    ["a space", "exa mple.backlog.com"],
+    ["no dot", "backlog"],
+  ])("rejects a host with %s", (_description, host) => {
+    const result = v.safeParse(RcSpaceSchema, { host, auth: validAuth });
     expect(result.success).toBe(false);
   });
 
@@ -127,6 +155,18 @@ describe("RcSchema", () => {
       expect(result.output.spaces).toEqual([]);
       expect(result.output.aliases).toEqual({});
       expect(result.output.defaultSpace).toBeUndefined();
+    }
+  });
+
+  it("normalizes defaultSpace to lowercase so it matches the stored host", () => {
+    const result = v.safeParse(RcSchema, {
+      defaultSpace: "Example.Backlog.COM",
+      spaces: [{ host: "Example.Backlog.COM", auth: { method: "api-key", apiKey: "key" } }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.output.defaultSpace).toBe("example.backlog.com");
+      expect(result.output.spaces[0]?.host).toBe("example.backlog.com");
     }
   });
 

--- a/packages/config/src/schema.ts
+++ b/packages/config/src/schema.ts
@@ -15,13 +15,26 @@ const OAuthAuthSchema = v.object({
 
 const RcAuthSchema = v.variant("method", [ApiKeyAuthSchema, OAuthAuthSchema]);
 
+/**
+ * A Backlog space hostname.
+ *
+ * Any domain is accepted so that self-hosted spaces work, but the value must be
+ * a bare hostname: it is interpolated into `https://${host}` by both
+ * `buildBacklogUrl` and backlog-js, so a value carrying userinfo, a path, or a
+ * scheme (e.g. `example.backlog.com@evil.com`) would silently redirect requests
+ * — and the credentials in them — to another origin.
+ */
+const RcHostSchema = v.pipe(v.string(), v.toLowerCase(), v.domain());
+
 const RcSpaceSchema = v.object({
-  host: v.pipe(v.string(), v.regex(/^[a-z0-9-]+\.backlog\.(com|jp)$/)),
+  host: RcHostSchema,
   auth: RcAuthSchema,
 });
 
 const RcSchema = v.object({
-  defaultSpace: v.optional(v.string()),
+  // Lowercased to match the normalized `host` values it is compared against.
+  // Not a full host: it may also be a shorthand that `findSpace` expands.
+  defaultSpace: v.optional(v.pipe(v.string(), v.toLowerCase())),
   spaces: v.optional(v.array(RcSpaceSchema), []),
   aliases: v.optional(v.record(v.string(), v.string()), {}),
 });
@@ -32,5 +45,5 @@ type RcSpace = v.InferOutput<typeof RcSpaceSchema>;
 
 type Rc = v.InferOutput<typeof RcSchema>;
 
-export { RcAuthSchema, RcSchema, RcSpaceSchema };
+export { RcAuthSchema, RcHostSchema, RcSchema, RcSpaceSchema };
 export type { Rc, RcAuth, RcSpace };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ catalogs:
       specifier: ^7.22.0
       version: 7.22.0
     valibot:
-      specifier: ^1.2.0
-      version: 1.2.0
+      specifier: ^1.4.2
+      version: 1.4.2
     vitest:
       specifier: ^4.0.18
       version: 4.0.18
@@ -145,7 +145,7 @@ importers:
         version: 11.0.0
       valibot:
         specifier: 'catalog:'
-        version: 1.2.0(typescript@6.0.0-dev.20260308)
+        version: 1.4.2(typescript@6.0.0-dev.20260308)
     devDependencies:
       '@repo/backlog-utils':
         specifier: workspace:*
@@ -222,7 +222,7 @@ importers:
         version: 7.22.0
       valibot:
         specifier: 'catalog:'
-        version: 1.2.0(typescript@5.9.3)
+        version: 1.4.2(typescript@5.9.3)
     devDependencies:
       '@repo/test-utils':
         specifier: workspace:*
@@ -244,7 +244,7 @@ importers:
         version: 8.2.0
       valibot:
         specifier: 'catalog:'
-        version: 1.2.0(typescript@5.9.3)
+        version: 1.4.2(typescript@5.9.3)
     devDependencies:
       '@repo/test-utils':
         specifier: workspace:*
@@ -269,7 +269,7 @@ importers:
         version: 3.0.0
       valibot:
         specifier: 'catalog:'
-        version: 1.2.0(typescript@5.9.3)
+        version: 1.4.2(typescript@5.9.3)
     devDependencies:
       '@repo/test-utils':
         specifier: workspace:*
@@ -3360,8 +3360,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@1.2.0:
-    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -7006,11 +7006,11 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.4.2(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 
-  valibot@1.2.0(typescript@6.0.0-dev.20260308):
+  valibot@1.4.2(typescript@6.0.0-dev.20260308):
     optionalDependencies:
       typescript: 6.0.0-dev.20260308
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -30,5 +30,5 @@ catalog:
   typescript: 6.0.0-dev.20260308
   unbuild: ^3.5.0
   undici: ^7.22.0
-  valibot: ^1.2.0
+  valibot: ^1.4.2
   vitest: ^4.0.18


### PR DESCRIPTION
Refs #104. Follow-up for the rest of that report: #119.

## Summary

The `host` field only accepted `*.backlog.com` and `*.backlog.jp`, so a space served from any other domain was unusable — reading the rc file failed on every command:

```console
$ bee issue list
 ERROR  Configuration Error:
Invalid format: Expected /^[a-z0-9-]+\.backlog\.(com|jp)$/ but received "backlog.example.internal"
```

Replaced the SaaS-only pattern with valibot's `domain()`, so any domain is accepted:

```console
$ bee auth status
  backlog.example.internal (default)
    Method  api-key
```

The value still has to be a **bare hostname**. It is interpolated into `https://${host}` both here (`buildBacklogUrl`) and in backlog-js (`request.ts`), so a value carrying userinfo, a path, or a scheme moves the request origin — and the stored credentials with it — to another server:

```
example.backlog.com@evil.com   → origin https://evil.com, path /api/v2/issues
evil.com/#@example.backlog.com → origin https://evil.com
```

Both are now rejected. This is why the check was relaxed rather than removed: a suffix or substring test (`host.endsWith(".backlog.com")`) would let the first one through.

## Changes

- **`packages/config/src/schema.ts`** — `host` is `v.pipe(v.string(), v.toLowerCase(), v.domain())`. Uppercase is normalized instead of rejected, since DNS is case-insensitive. `defaultSpace` is lowercased too, so it still matches the host it points at (otherwise the `(default)` marker silently stopped rendering).
- **`packages/config/src/config.ts`** — `writeConfig` validates what it writes. `bee auth login` wrote the rc file through a path that only validated the config it had *read*, which is why login appeared to succeed and the next command failed instead — the second half of the repro in #104.
- **`apps/cli/src/commands/auth/login.ts`** — rejects the hostname before authenticating, so a bad value fails with an actionable message rather than a connection error:
  ```console
  $ BACKLOG_SPACE='https://example.backlog.com' bee auth login
   ERROR  "https://example.backlog.com" is not a valid hostname. Pass the space's bare hostname, without a scheme or path (e.g. xxx.backlog.com).
  ```
- **`apps/cli/src/lib/common-options.ts`** — `--space` help mentions that a custom domain is allowed.
- **`pnpm-workspace.yaml`** — valibot `^1.2.0` → `^1.4.2`; `domain()` was added in 1.3.0 and the catalog was resolving to 1.2.0.

## Out of scope

#104 also asks for a path prefix (`backlog.example.internal/backlog`). That needs a base URL rather than a host, because backlog-js hardcodes `https://${host}/api/v2` — Nulab's own `backlog4j` splits exactly this way (`BacklogComConfigure(spaceKey)` vs `BacklogPackageConfigure(url)`). Ports and self-hosted git remotes have the same root cause. All three are in #119, so this PR is scoped to the domain, and #104 stays open as the tracking issue.

Note that a self-hosted instance is served under a fixed `/backlog` context path, so this change alone does not make one work end to end — hence the framing as "any domain" rather than enterprise support.

## Test plan

- [x] `pnpm test` — 741 passed (116 files)
- [x] `pnpm lint` — 0 errors; 15 warnings, matching the pre-change baseline verified via `git stash`
- [x] `pnpm typecheck` — clean
- [x] Built the CLI and reproduced #104 against a real rc file, before and after (output above)
- [x] Confirmed `example.backlog.com@evil.com` in the rc file is rejected (`Invalid domain`), and that a scheme via `BACKLOG_SPACE` is rejected at login
- [x] Confirmed uppercase input normalizes and still renders `(default)`
- [x] Mutation-checked the new tests: reverting the host rule to the SaaS-only regex, dropping the rule entirely, un-validating `writeConfig`, and un-lowercasing `defaultSpace` are each caught

Tests cover, one behaviour each: `backlogtool.com` (documented by backlog-js, rejected by the old rule), self-hosted domains, uppercase normalization for `host` and `defaultSpace`, `writeConfig` refusing an invalid host, login rejecting one before the network call, and rejection of userinfo / path / query / scheme / trailing slash / path prefix / port / space / dotless / IP / trailing-dot hosts. The last two are unsupported rather than forbidden, and are pinned so the limitation is stated where a reader will look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)