### PR TITLE
fix(api): stop coercing @file and @- content to number or boolean

### DIFF
--- a/apps/cli/src/commands/api.test.ts
+++ b/apps/cli/src/commands/api.test.ts
@@ -120,7 +120,7 @@ describe("api", () => {
     writeSpy.mockRestore();
   });
 
-  it("reads -f value from file with @path (like gh -F)", async () => {
+  it("reads -f value from the file named after @", async () => {
     vi.mocked(readFile).mockResolvedValue("line1\nline2\nline3");
     mockClient.patch.mockResolvedValue({ id: 1 });
 
@@ -138,7 +138,7 @@ describe("api", () => {
     writeSpy.mockRestore();
   });
 
-  it("applies type inference to file content in -f", async () => {
+  it("sends numeric file content as a string, not a number", async () => {
     vi.mocked(readFile).mockResolvedValue("42");
     mockClient.get.mockResolvedValue({});
 
@@ -146,7 +146,45 @@ describe("api", () => {
 
     await parseCommand(() => import("./api"), ["/issues", "-f", "count=@/tmp/num.txt"]);
 
-    expect(mockClient.get).toHaveBeenCalledWith("/issues", { count: 42 });
+    expect(mockClient.get).toHaveBeenCalledWith("/issues", { count: "42" });
+    writeSpy.mockRestore();
+  });
+
+  it("keeps a whitespace-only file as whitespace instead of 0", async () => {
+    vi.mocked(readFile).mockResolvedValue("\n");
+    mockClient.patch.mockResolvedValue({ id: 1 });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await parseCommand(
+      () => import("./api"),
+      ["/issues/TEST-1", "-X", "PATCH", "-f", "description=@/tmp/blank.txt"],
+    );
+
+    expect(mockClient.patch).toHaveBeenCalledWith("/issues/TEST-1", { description: "\n" });
+    writeSpy.mockRestore();
+  });
+
+  it("sends file content that reads as a boolean as a string", async () => {
+    vi.mocked(readFile).mockResolvedValue("true");
+    mockClient.get.mockResolvedValue({});
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await parseCommand(() => import("./api"), ["/issues", "-f", "flag=@/tmp/bool.txt"]);
+
+    expect(mockClient.get).toHaveBeenCalledWith("/issues", { flag: "true" });
+    writeSpy.mockRestore();
+  });
+
+  it("still infers types for values given inline", async () => {
+    mockClient.get.mockResolvedValue({});
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await parseCommand(() => import("./api"), ["/issues", "-f", "count=42", "-f", "archived=true"]);
+
+    expect(mockClient.get).toHaveBeenCalledWith("/issues", { count: 42, archived: true });
     writeSpy.mockRestore();
   });
 

--- a/apps/cli/src/commands/api.ts
+++ b/apps/cli/src/commands/api.ts
@@ -17,7 +17,7 @@ const api = new BeeCommand("api")
 
 \`-f\` infers types (number, boolean, string); \`-F\` always sends strings. Repeated keys become arrays. Append \`[]\` for a single-element array (e.g. \`-f projectId[]=12345\`).
 
-The \`-f\` flag has magic type conversion based on the format of the value: if the value starts with \`@\`, the rest of the value is interpreted as a filename to read the value from. Pass \`-\` to read from standard input (e.g. \`-f 'key=@-'\`).
+If a \`-f\` value starts with \`@\`, the rest of the value is interpreted as a filename to read the value from. Pass \`-\` to read from standard input (e.g. \`-f 'key=@-'\`). File and stdin content is always sent as a string, without type inference.
 
 For GET, fields are query parameters. For POST/PUT/PATCH/DELETE, fields are the request body.`,
   )
@@ -99,20 +99,13 @@ const normalizeEndpoint = (endpoint: string): string => {
 };
 
 /**
- * Resolve a field value that may reference a file or stdin.
- *
- * Following the gh CLI convention for the magic `-f`/`--field` flag:
- * - `@path` reads the file at `path`
- * - `@-` reads from stdin (raw, without trimming)
- * - anything else is returned as-is
+ * Read a field value from a file (`@path`) or stdin (`@-`) reference.
+ * The content is sent as-is: no trimming, and no type inference — gh's
+ * magicFieldValue does the same. Inferring here would coerce content that
+ * only looks numeric: a file holding just a newline became `0`, because
+ * Number("\n") is 0.
  */
-const resolveFieldValue = async (value: string): Promise<string> => {
-  if (!value.startsWith("@")) {
-    return value;
-  }
-
-  const ref = value.slice(1);
-
+const readFieldValue = async (ref: string): Promise<string> => {
   if (ref === "-") {
     return text(process.stdin);
   }
@@ -139,8 +132,8 @@ const resolveFieldValue = async (value: string): Promise<string> => {
 
 /**
  * Build params object from --field and --raw-field values.
- * --field infers types and supports @file references (like gh's -F).
- * --raw-field always uses literal strings (like gh's -f).
+ * --field infers types (number, boolean, string) and supports @file references.
+ * --raw-field always uses literal strings.
  * When the same key appears multiple times, values are collected into an array.
  */
 const buildParams = async (fields: string[], rawFields: string[]): Promise<Params> => {
@@ -166,8 +159,10 @@ const buildParams = async (fields: string[], rawFields: string[]): Promise<Param
       throw new UserError(`Invalid field format: "${pair}". Expected key=value.`);
     }
     const rawValue = pair.slice(eqIndex + 1);
-    const resolved = await resolveFieldValue(rawValue);
-    addParam(pair.slice(0, eqIndex), inferType(resolved));
+    const value = rawValue.startsWith("@")
+      ? await readFieldValue(rawValue.slice(1))
+      : inferType(rawValue);
+    addParam(pair.slice(0, eqIndex), value);
   }
 
   for (const pair of rawFields) {

--- a/skills/using-bee/SKILL.md
+++ b/skills/using-bee/SKILL.md
@@ -82,8 +82,10 @@ bee api issues -X POST -f projectId=12345 -f summary="New issue" -f issueTypeId=
 
 | Flag | Types                          | `@file` support                      | Use case                                           |
 | ---- | ------------------------------ | ------------------------------------ | -------------------------------------------------- |
-| `-f` | Infers number, boolean, string | `@path` reads file, `@-` reads stdin | Typed values or file/stdin content                 |
+| `-f` | Infers number, boolean, string | `@path` reads file, `@-` reads stdin | Typed values, or content read from a file / stdin  |
 | `-F` | Always string                  | No (literal)                         | Literal strings including values starting with `@` |
+
+File and stdin content is always sent as a string, as-is — no type inference and no trimming (same as `gh api`).
 
 ```sh
 bee api issues/KEY -X PATCH -f 'description=@desc.md'          # read from file


### PR DESCRIPTION
Follow-up to #98, as mentioned in the review there.

## The bug

`-f 'key=@path'` passed the file content through `inferType`, so content that merely *looks* numeric was sent as a number. The worst case is a file holding only whitespace — `Number("\n")` is `0`, so clearing a description with an empty file wrote the string `"0"`:

```console
$ printf '\n' > blank.txt
$ bee api issues/KEY -X PATCH -f 'description=@blank.txt'
{"description":"0"}
```

That is a realistic path to hit: emptying a field, or passing a generated file that happened to come out blank.

## The fix

`gh`'s `magicFieldValue` reads the `@` reference **before** any coercion and returns the content as-is:

```go
func magicFieldValue(v string, opts *ApiOptions) (interface{}, error) {
	if strings.HasPrefix(v, "@") {
		b, err := opts.IO.ReadUserFile(v[1:])
		if err != nil {
			return "", err
		}
		return string(b), nil   // no inference
	}
	if n, err := strconv.Atoi(v); err == nil { return n, nil }
	// ...
}
```

Matching that is also the behaviour `@file` exists for: passing literal content that is awkward to quote in a shell. Inference still applies to values written inline, so `-f count=42` is unchanged.

Since the Backlog API takes form-encoded parameters, sending `"42"` where a number is expected still works — verified below with `issueTypeId` read from a file.

## Test plan

- [x] `pnpm test` — 759 passed (116 files)
- [x] `pnpm lint` — 0 warnings, 0 errors (CI runs `--max-warnings 0`)
- [x] `pnpm typecheck` — clean
- [x] `pnpm run format:check` — clean
- [x] Mutation-checked: restoring `inferType` on the resolved value fails the three new tests
- [x] Built the CLI and ran it against a real space (issues created and cleaned up afterwards):
  - a 182-byte multi-line Markdown file (backticks, quotes, `$HOME`, Japanese, a nested code block) round-trips byte for byte, trailing newline included
  - the repro above now writes `"\n"` instead of `"0"`
  - `-f 'issueTypeId=@id.txt'` still creates the issue, so the string does not break a numeric parameter
  - `@-` from stdin, `-F 'summary=@literal'` staying literal, inline `-f count=3`, and the `ENOENT` / `EISDIR` / bare-`@` errors all behave as before

Tests cover one behaviour each: numeric file content staying a string, a whitespace-only file staying whitespace, `true` in a file staying a string, and inline values still being inferred.