### PR TITLE
fix(api): only infer a number when it prints back identically

### DIFF
--- a/apps/cli/src/commands/api.test.ts
+++ b/apps/cli/src/commands/api.test.ts
@@ -188,6 +188,39 @@ describe("api", () => {
     writeSpy.mockRestore();
   });
 
+  it("infers negative and fractional numbers", async () => {
+    mockClient.get.mockResolvedValue({});
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await parseCommand(() => import("./api"), ["/issues", "-f", "a=-7", "-f", "b=0.5"]);
+
+    expect(mockClient.get).toHaveBeenCalledWith("/issues", { a: -7, b: 0.5 });
+    writeSpy.mockRestore();
+  });
+
+  it.each([
+    ["1.0", "a version number keeps its minor part"],
+    ["0042", "a leading zero is not dropped"],
+    ["0120117117", "a phone number keeps its leading zero"],
+    ["+5", "an explicit plus sign is preserved"],
+    ["-0", "negative zero is not flattened"],
+    [".5", "a bare decimal point is preserved"],
+    ["5.", "a trailing decimal point is preserved"],
+    ["0x10", "hex notation is not converted to decimal"],
+    ["1e3", "exponent notation is not expanded"],
+    ["12345678901234567890", "an id past 2^53 keeps every digit"],
+  ])("keeps %j as a string so %s", async (value) => {
+    mockClient.post.mockResolvedValue({ id: 1 });
+
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+
+    await parseCommand(() => import("./api"), ["/issues", "-X", "POST", "-f", `summary=${value}`]);
+
+    expect(mockClient.post).toHaveBeenCalledWith("/issues", { summary: value });
+    writeSpy.mockRestore();
+  });
+
   it("sends -F value with @ literally (no file reference)", async () => {
     mockClient.post.mockResolvedValue({ id: 1 });
 

--- a/apps/cli/src/commands/api.ts
+++ b/apps/cli/src/commands/api.ts
@@ -15,7 +15,7 @@ const api = new BeeCommand("api")
   .description(
     `The endpoint is a Backlog API path (e.g. \`users/myself\`). A leading \`/api/v2/\` prefix is stripped automatically.
 
-\`-f\` infers types (number, boolean, string); \`-F\` always sends strings. Repeated keys become arrays. Append \`[]\` for a single-element array (e.g. \`-f projectId[]=12345\`).
+\`-f\` infers types (number, boolean, string); \`-F\` always sends strings. A value is only inferred as a number when the number prints back identically, so \`1.0\`, \`0042\` and \`0x10\` stay strings. Repeated keys become arrays. Append \`[]\` for a single-element array (e.g. \`-f projectId[]=12345\`).
 
 If a \`-f\` value starts with \`@\`, the rest of the value is interpreted as a filename to read the value from. Pass \`-\` to read from standard input (e.g. \`-f 'key=@-'\`). File and stdin content is always sent as a string, without type inference.
 
@@ -178,6 +178,14 @@ const buildParams = async (fields: string[], rawFields: string[]): Promise<Param
 
 /**
  * Infer type from a string value.
+ *
+ * A value is only treated as a number when it survives the round trip through
+ * one — `String(Number(value)) === value`. Everything `Number()` accepts is a
+ * wider set than the spellings it can reproduce, and the difference is sent
+ * over the wire: `1.0` became `1`, `0042` became `42`, `0x10` became `16`, and
+ * an id past 2^53 lost digits, all without an error. Since the API takes
+ * form-encoded params, an inferred number is stringified again anyway, so
+ * declining to infer here costs nothing and keeps the value intact.
  */
 const inferType = (value: string): ParamValue => {
   if (value === "true") {
@@ -188,7 +196,7 @@ const inferType = (value: string): ParamValue => {
   }
   if (value !== "") {
     const result = v.safeParse(vFiniteNumber, value);
-    if (result.success) {
+    if (result.success && String(result.output) === value) {
       return result.output;
     }
   }

--- a/skills/using-bee/SKILL.md
+++ b/skills/using-bee/SKILL.md
@@ -87,6 +87,8 @@ bee api issues -X POST -f projectId=12345 -f summary="New issue" -f issueTypeId=
 
 File and stdin content is always sent as a string, as-is — no type inference and no trimming (same as `gh api`).
 
+`-f` only infers a number when the value prints back identically, so `1.0`, `0042`, `0x10`, `1e3` and ids past 2^53 stay strings. Use `-F` when you want a value left alone regardless.
+
 ```sh
 bee api issues/KEY -X PATCH -f 'description=@desc.md'          # read from file
 echo 'content' | bee api issues/KEY/comments -X POST -f 'body=@-'  # read from stdin


### PR DESCRIPTION
Closes #123. Follow-up to #122, which is now merged — this PR is rebased onto `main` and its diff is just the one commit.

## The bug

`-f 'key=value'` inferred a number whenever `Number()` accepted the string. That set is wider than the spellings a number can *reproduce*, and since the API takes form-encoded parameters the inferred number is stringified again on the way out — so the difference goes over the wire with nothing to signal it:

```console
$ bee api issues -X POST -f summary=1.0 ...
{"summary":"1"}                      # version number loses its minor part

$ bee api issues/KEY/comments -X POST -f content=0120117117
{"content":"120117117"}              # leading zero dropped

$ bee api issues/KEY/comments -X POST -f content=12345678901234567890
{"content":"12345678901234567000"}   # precision lost past 2^53
```

## The fix

Infer only when the value round-trips — `String(Number(value)) === value`:

| input | before | after |
| ----- | ------ | ----- |
| `42`, `-7`, `0.5` | number | number (unchanged) |
| `1.0` | `1` | `"1.0"` |
| `0042` | `42` | `"0042"` |
| `+5` | `5` | `"+5"` |
| `-0` | `0` | `"-0"` |
| `.5` / `5.` | `0.5` / `5` | `".5"` / `"5."` |
| `0x10` / `0b11` | `16` / `3` | `"0x10"` / `"0b11"` |
| `1e3` | `1000` | `"1e3"` |
| `12345678901234567890` | `12345678901234567000` | unchanged string |

Numeric parameters keep working either way, because form encoding stringifies the value regardless — verified below by creating an issue with `issueTypeId` typed inline.

### Why not match `gh` exactly

`gh` uses `strconv.Atoi`, which I ran to check rather than assume:

```
NUM  "42"      -> 42
str  "1.0"     -> kept as string
NUM  "0042"    -> 42   <== VALUE CHANGED
NUM  "+5"      -> 5    <== VALUE CHANGED
str  "0x10"    -> kept as string
str  "1e3"     -> kept as string
str  "0.5"     -> kept as string
```

So `gh` has the same bug for `0042` and `+5`, and it also refuses fractions — `-f 'estimatedHours=0.5'` would become a string. bee documents `-f` as inferring numbers including fractions, so adopting Atoi would narrow the documented behaviour to fix a narrower slice of the problem. Round-tripping is stricter than `gh` and keeps `0.5` a number.

`vFiniteNumber` is deliberately left alone: options like `--estimated-hours` parse into a number and use it, so the lenient parse is correct there. Only `api` forwards the value onward as-is.

## Compatibility

The inference used to normalise some non-canonical spellings into what the API wants, and that no longer happens. A request the API rejects on integer parameters:

```console
$ bee api issues -f 'projectId[]=...' -f count=3.0
{"errors":[{"message":"error.number : count","code":7}]}   # used to be sent as count=3
```

Same for `offset=3.0`, `count=1e1`, and `projectId[]=12345.0`. Worth weighing, but it does not look like a real regression:

- `-F 'count=3.0'` already fails this way today, so rejecting non-canonical numbers is existing bee behaviour — the inference merely masked it for `-f`.
- There is no reason to spell an integer as `3.0`. All 13 `bee api` examples in this repo pass canonical integers (`count=5`, `projectId=12345`, `statusId=1`), and integers coming from a shell or `jq` arrive as `3`, not `3.0`.
- What the current behaviour breaks — a version number, a leading-zero id, a phone number, a long numeric id landing in `summary`/`content`/`description` — happens just by holding such a string, and silently.

So this trades a spelling nobody writes for values people actually have.

## Test plan

- [x] `pnpm test` — 767 passed (116 files)
- [x] `pnpm lint` — 0 warnings, 0 errors (CI runs `--max-warnings 0`)
- [x] `pnpm typecheck` / `pnpm run format:check` — clean
- [x] Mutation-checked: dropping the round-trip guard fails all 10 new cases
- [x] Re-ran the suite after rebasing onto the merged #122
- [x] Built the CLI and ran it against a real space (issues cleaned up afterwards):
  - `-f summary=1.0` → `"1.0"`, `-f content=0120117117` → `"0120117117"`, `-f content=12345678901234567890` unchanged, `-f content=0x10` → `"0x10"`
  - `-f count=3` still paginates, and an issue still creates with `issueTypeId` / `priorityId` given inline
  - #122's `@file` behaviour still holds (a whitespace-only file writes `"\n"`), and `-F content=1.0` stays literal

New tests state one behaviour each, table-driven over the ten inputs above, plus a case pinning that negative and fractional numbers are still inferred.
