### PR TITLE
docs: replace unofficial-product disclaimer with GitHub Issues contact

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,8 +8,10 @@ body:
         Issues are accepted in **English or Japanese** — please use whichever you prefer.
         **英語・日本語のどちらでも**受け付けています。書きやすい方でご記入ください。
 
-        Please do not include API keys, OAuth tokens, or other credentials in this issue.
-        すべての出力から API キーや OAuth トークンなどの認証情報を取り除いてください。
+        Issues are public. Please do not include credentials, personal information, or confidential data
+        (API keys, OAuth tokens, space URLs, user names) — replace them with placeholders.
+        issue は公開されます。認証情報・個人情報・機密情報（API キー、OAuth トークン、スペース URL、
+        ユーザー名など）は含めず、ダミー値に置き換えてください。
   - type: checkboxes
     id: checks
     attributes:
@@ -37,7 +39,7 @@ body:
     id: steps
     attributes:
       label: Steps to reproduce
-      description: The exact commands you ran, with credentials removed.
+      description: The exact commands you ran, with any sensitive values replaced.
       placeholder: |
         1. bee auth login
         2. bee issue list --project ...
@@ -86,7 +88,7 @@ body:
     id: logs
     attributes:
       label: Logs or additional context
-      description: Anything else that helps — full output, screenshots, related issues. Remove credentials first.
+      description: Anything else that helps — full output, screenshots, related issues. Redact sensitive values first.
       render: shell
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,24 +1,92 @@
 name: Bug report
-description: Report a bug
+description: Report something that does not work as documented
 labels: [bug]
 body:
   - type: markdown
     attributes:
       value: |
-        You can write in English or Japanese. / 英語または日本語で記述できます。
+        Issues are accepted in **English or Japanese** — please use whichever you prefer.
+        **英語・日本語のどちらでも**受け付けています。書きやすい方でご記入ください。
+
+        Please do not include API keys, OAuth tokens, or other credentials in this issue.
+        すべての出力から API キーや OAuth トークンなどの認証情報を取り除いてください。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched [existing issues](https://github.com/nulab/bee/issues?q=is%3Aissue) and did not find a duplicate.
+          required: true
+        - label: I am running the latest version of bee (`npm install -g @nulab/bee`).
+          required: false
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: What happened? What did you expect?
+      label: What happened?
+      description: Describe the actual behavior, including any error message.
+      placeholder: Running `bee issue list` exits with ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
     validations:
       required: true
   - type: textarea
     id: steps
     attributes:
       label: Steps to reproduce
+      description: The exact commands you ran, with credentials removed.
+      placeholder: |
+        1. bee auth login
+        2. bee issue list --project ...
+        3. See error
+      render: shell
+    validations:
+      required: true
   - type: input
     id: version
     attributes:
       label: bee version
+      description: Output of `bee --version`.
       placeholder: e.g. 0.1.0
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js version
+      description: Output of `node --version`.
+      placeholder: e.g. v24.0.0
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - macOS
+        - Linux
+        - Windows
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: auth
+    attributes:
+      label: Authentication method
+      options:
+        - API key
+        - OAuth
+        - Not sure / not relevant
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or additional context
+      description: Anything else that helps — full output, screenshots, related issues. Remove credentials first.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://nulab.github.io/bee
+    about: Command reference and guides for bee. / bee のコマンドリファレンスとガイド。
+  - name: Backlog support
+    url: https://support.backlog.com/
+    about: For questions about Backlog itself rather than the bee CLI. / bee CLI ではなく Backlog 自体に関する問い合わせ先。
+  - name: Backlog API documentation
+    url: https://developer.nulab.com/docs/backlog/
+    about: Reference for the Backlog API that bee calls. / bee が呼び出す Backlog API のリファレンス。

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,10 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Before you post — issues are public
+    url: https://github.com/nulab/bee/blob/main/CONTRIBUTING.md#questions-and-bug-reports
+    about: >-
+      Do not include credentials, personal information, or confidential data.
+      / 認証情報・個人情報・機密情報は含めないでください。
   - name: Documentation
     url: https://nulab.github.io/bee
     about: Command reference and guides for bee. / bee のコマンドリファレンスとガイド。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,15 +1,54 @@
 name: Feature request
-description: Suggest a feature
+description: Suggest a new command, flag, or behavior
 labels: [enhancement]
 body:
   - type: markdown
     attributes:
       value: |
-        You can write in English or Japanese. / 英語または日本語で記述できます。
+        Issues are accepted in **English or Japanese** — please use whichever you prefer.
+        **英語・日本語のどちらでも**受け付けています。書きやすい方でご記入ください。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I searched [existing issues](https://github.com/nulab/bee/issues?q=is%3Aissue) and did not find a duplicate.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Describe the workflow that is difficult today, not the solution you have in mind.
+      placeholder: When I review pull requests from the terminal, I cannot ...
+    validations:
+      required: true
   - type: textarea
     id: description
     attributes:
-      label: Description
-      description: What would you like to see?
+      label: Proposed solution
+      description: What should bee do? If it is a new command or flag, show how you would invoke it.
+      placeholder: |
+        bee pr review PROJECT/repo 123 --approve
     validations:
       required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives you considered
+      description: Other commands, scripts, or workarounds you tried.
+    validations:
+      required: false
+  - type: input
+    id: api
+    attributes:
+      label: Related Backlog API
+      description: If you know which [Backlog API](https://developer.nulab.com/docs/backlog/) this needs, link it here.
+    validations:
+      required: false
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a pull request for this.
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,6 +7,11 @@ body:
       value: |
         Issues are accepted in **English or Japanese** — please use whichever you prefer.
         **英語・日本語のどちらでも**受け付けています。書きやすい方でご記入ください。
+
+        Issues are public. Please do not include credentials, personal information, or confidential data
+        (API keys, OAuth tokens, space URLs, user names) — replace them with placeholders.
+        issue は公開されます。認証情報・個人情報・機密情報（API キー、OAuth トークン、スペース URL、
+        ユーザー名など）は含めず、ダミー値に置き換えてください。
   - type: checkboxes
     id: checks
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,44 @@
+name: Question
+description: Ask how to do something with bee
+labels: [question]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Issues are accepted in **English or Japanese** — please use whichever you prefer.
+        **英語・日本語のどちらでも**受け付けています。書きやすい方でご記入ください。
+
+        Please do not include API keys, OAuth tokens, or other credentials in this issue.
+        すべての出力から API キーや OAuth トークンなどの認証情報を取り除いてください。
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before you start
+      options:
+        - label: I checked the [documentation site](https://nulab.github.io/bee) and the [command reference](https://nulab.github.io/bee/commands/).
+          required: true
+        - label: I searched [existing issues](https://github.com/nulab/bee/issues?q=is%3Aissue) and did not find an answer.
+          required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to do, and where did you get stuck?
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you have tried
+      description: Commands you ran and what happened, with credentials removed.
+      render: shell
+    validations:
+      required: false
+  - type: input
+    id: version
+    attributes:
+      label: bee version
+      description: Output of `bee --version`.
+      placeholder: e.g. 0.1.0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -8,8 +8,10 @@ body:
         Issues are accepted in **English or Japanese** — please use whichever you prefer.
         **英語・日本語のどちらでも**受け付けています。書きやすい方でご記入ください。
 
-        Please do not include API keys, OAuth tokens, or other credentials in this issue.
-        すべての出力から API キーや OAuth トークンなどの認証情報を取り除いてください。
+        Issues are public. Please do not include credentials, personal information, or confidential data
+        (API keys, OAuth tokens, space URLs, user names) — replace them with placeholders.
+        issue は公開されます。認証情報・個人情報・機密情報（API キー、OAuth トークン、スペース URL、
+        ユーザー名など）は含めず、ダミー値に置き換えてください。
   - type: checkboxes
     id: checks
     attributes:
@@ -30,7 +32,7 @@ body:
     id: tried
     attributes:
       label: What you have tried
-      description: Commands you ran and what happened, with credentials removed.
+      description: Commands you ran and what happened, with any sensitive values replaced.
       render: shell
     validations:
       required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ Thank you for your interest in contributing to bee! This guide covers environmen
 
 Bug reports, feature requests, and questions are handled via [GitHub Issues](https://github.com/nulab/bee/issues/new/choose) — you can write in English or Japanese.
 
+Issues are public. Before you post, remove any credentials, personal information, or confidential data — API keys, OAuth tokens, space URLs, issue keys, user names, and anything else you would not publish. Replace them with placeholders in commands, logs, and screenshots.
+
 ## Prerequisites
 
 - [mise](https://mise.jdx.dev/) (manages Node.js version)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 Thank you for your interest in contributing to bee! This guide covers environment setup, development workflow, and release process. For coding conventions, architecture, and command patterns, see [AGENTS.md](AGENTS.md).
 
+## Questions and Bug Reports
+
+Bug reports, feature requests, and questions are handled via [GitHub Issues](https://github.com/nulab/bee/issues/new/choose) — you can write in English or Japanese.
+
 ## Prerequisites
 
 - [mise](https://mise.jdx.dev/) (manages Node.js version)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
 
 Bring [Backlog](https://backlog.com/) to your command line.
 
-> [!NOTE]
-> This is not an officially supported Nulab product. It is maintained by volunteers.
-
 **Looking to install and use bee?** See the [CLI package README](apps/cli/README.md) or the [documentation site](https://nulab.github.io/bee).
 
 ## Development
@@ -31,6 +28,11 @@ This is a pnpm workspace monorepo managed with [Turborepo](https://turbo.build/)
 
 For setup instructions, scripts, and contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Support
+
+Bug reports, feature requests, and questions are handled via [GitHub Issues](https://github.com/nulab/bee/issues/new/choose).
+You can write in English or Japanese.
+
 ## License
 
-MIT
+This project is licensed under the [MIT License](LICENSE).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -2,8 +2,6 @@
 
 Bring [Backlog](https://backlog.com/) to your command line.
 
-**Note:** This is not an officially supported Nulab product. It is maintained by volunteers.
-
 ## Install
 
 ```sh
@@ -34,6 +32,11 @@ See the [documentation site](https://nulab.github.io/bee) for the full command r
 
 See the [repository root README](https://github.com/nulab/bee) for development setup and contributing instructions.
 
+## Support
+
+Bug reports, feature requests, and questions are handled via [GitHub Issues](https://github.com/nulab/bee/issues/new/choose).
+You can write in English or Japanese.
+
 ## License
 
-MIT
+This project is licensed under the [MIT License](https://github.com/nulab/bee/blob/main/LICENSE).

--- a/apps/docs/src/components/Footer.astro
+++ b/apps/docs/src/components/Footer.astro
@@ -5,7 +5,11 @@ import Default from "@astrojs/starlight/components/Footer.astro";
 <Default><slot /></Default>
 
 <footer class="site-footer">
-  <p>This is not an officially supported Nulab product. It is maintained by volunteers.</p>
+  <p>
+    ご質問・不具合報告・機能要望は
+    <a href="https://github.com/nulab/bee/issues/new/choose">GitHub Issues</a>
+    で英語・日本語のどちらでも受け付けています。
+  </p>
 </footer>
 
 <style>
@@ -15,5 +19,9 @@ import Default from "@astrojs/starlight/components/Footer.astro";
     border-top: 1px solid var(--sl-color-hairline-light);
     font-size: var(--sl-text-xs);
     color: var(--sl-color-gray-3);
+  }
+
+  .site-footer a {
+    color: inherit;
   }
 </style>


### PR DESCRIPTION
## Summary

bee is now an official Nulab project, so the disclaimer "This is not an officially supported Nulab product. It is maintained by volunteers." is no longer accurate. It appeared in three places (root README, CLI package README, docs site footer) and is removed from all of them.

Removing it would leave users with no stated way to reach us, so each location now points at **GitHub Issues** and states that **English or Japanese** are both accepted.

### On what we deliberately do *not* say

I surveyed `nulab/*` for prior art and found no org-wide convention — three different patterns:

- `backlog-mcp-server` — "provided under the MIT License **without any warranty or official support**" + GitHub Issues
- `BacklogMigration-Redmine` / `BacklogMigration-Jira` — `## お問い合わせ` → https://backlog.com/contact/
- `backlog4j`, `backlog-js`, `backlog-power-ups` — no support/warranty section at all

This PR intentionally states **neither warranty nor support status**:

- The MIT **warranty** disclaimer is already binding via `LICENSE`; restating it in the README adds no protection.
- Restating "not officially supported" would reintroduce exactly the framing this PR sets out to remove.

Routing is the only thing readers actually need. The migration-tool pattern was rejected deliberately: bee is developer tooling, and sending CLI bugs to the Backlog product contact form would misroute them.

### Issue templates

The two existing templates were thin free-text forms, so triage had to ask for the same environment details every time. They are now YAML forms:

- **Bug report** — duplicate-search checkbox, expected vs. actual split, reproduction steps, and required `bee --version` / `node --version` / OS / auth method. Warns against pasting credentials.
- **Feature request** — separates the *problem* from the *proposed solution*, plus alternatives, related Backlog API, and a willing-to-PR checkbox.
- **Question** (new) — usage questions previously had no home and landed as `bug`. Uses the existing `question` label.
- **`config.yml`** (new) — disables blank issues and links out to the docs site, the Backlog API reference, and the Backlog support desk, so Backlog-product questions get directed there instead of being filed here.

bee is currently the only repo in the org with `.github/ISSUE_TEMPLATE/`, so there was no in-org template convention to follow.

### Sensitive data

The old templates warned only about API keys and OAuth tokens. But bee output routinely carries data that is sensitive for a different reason — space URLs identify the customer, and issue keys and user names are personal or internal information — so a reporter who stripped their API key could still paste all of that into a public issue.

Every template now leads with **issues are public** and names credentials, personal information, and confidential data together, with the same notice on the chooser via `config.yml` and the full version in `CONTRIBUTING.md`. Field-level hints were reworded from "with credentials removed" so they no longer read as a narrower rule than the notice above them.

## Test plan

- [x] `pnpm --filter @repo/docs build` — 105 pages built, "All internal links are valid"
- [x] Verified the new footer in the built output (`dist/getting-started/index.html`) renders the GitHub Issues link
- [x] All four issue templates parse via `yaml.safe_load`
- [x] Confirmed the `question` label already exists in the repo, so the template applies cleanly
- [x] `oxfmt --check` clean; `pnpm run lint` shows only pre-existing warnings in untouched files
- [x] Repo-wide grep for `unofficial|非公式|volunteer|ボランティア|officially supported` returns no matches
- [x] Confirmed the `CONTRIBUTING.md#questions-and-bug-reports` anchor that `config.yml` links to exists

Template rendering itself is only observable once these land on the default branch — worth a look at the issue chooser after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

