### PR TITLE
docs(recipes): rewrite PR lifecycle sync for branch-name issue keys

### DIFF
--- a/apps/docs/src/content/docs/recipes/pr-lifecycle-sync.mdx
+++ b/apps/docs/src/content/docs/recipes/pr-lifecycle-sync.mdx
@@ -1,25 +1,29 @@
 ---
 title: Pull Request と課題を連動させる
 description: |-
-  bee CLI と GitHub Actions で、PR の作成・編集・マージに連動して Backlog 課題のステータス更新やクローズを自動化するワークフロー。
+  bee CLI と GitHub Actions で、PR の作成・再オープン・マージに連動して Backlog 課題のステータス更新やクローズを自動化するワークフロー。
 ---
 
 import { Steps, LinkCard, CardGrid } from "@astrojs/starlight/components";
 
-GitHub Issues では、PR に `Closes #123` と書くだけで Issue のリンク・ステータス更新・クローズが自動で行われます。このレシピで Backlog 課題でも同じ操作感を実現できます。PR 本文に `PROJECT-123` のような課題キーを書くだけで動作します。
+GitHub Issues では、PR に `Closes #123` と書くだけで Issue のリンク・ステータス更新・クローズが自動で行われます。このレシピで Backlog 課題でも同じ操作感を実現できます。`PROJECT-123/fix-login` のように、ブランチ名の先頭に課題キーを付けるだけで動作します。
 
 <Steps>
 1. **PR 作成**
 
-   課題に PR リンクをコメント＋ステータスを「処理中」に
+   課題を「処理中」にして、PR へのリンクをコメント
 
-2. **PR 本文の編集**
+2. **PR 再オープン**
 
-   新たに追加された課題キーにだけコメント
+   課題を「処理中」に戻してコメント
 
 3. **PR マージ**
 
    課題を自動クローズ
+
+4. **マージされずにクローズ**
+
+   ステータスは変えずにコメントだけを残す
 </Steps>
 
 :::note[前提]
@@ -27,13 +31,13 @@ GitHub Issues では、PR に `Closes #123` と書くだけで Issue のリン�
 :::
 
 ```yaml
-name: Sync PR Lifecycle to Backlog Issues
+name: Sync PR Lifecycle to Backlog Issue
 on:
   pull_request:
-    types: [opened, edited, closed]
+    types: [opened, reopened, closed]
     branches: [main]
 
-# リポジトリへの書き込みは不要なので全権限を無効化
+# Backlog 側だけを更新するので GITHUB_TOKEN の権限は一切不要
 permissions: {}
 
 env:
@@ -47,97 +51,92 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # PR 本文から課題キーを抽出する
-      # edited イベントでは変更前の本文からもキーを取得して差分を計算する
-      - name: Collect issue keys from PR body
-        id: collect
-        run: |
-          KEYS=$(echo "$PR_BODY" | grep -oE '[A-Z_]+-[0-9]+' | sort -u | tr '\n' ' ')
-          echo "Detected issue keys: ${KEYS:-(none)}"
-          echo "keys=$KEYS" >> "$GITHUB_OUTPUT"
-
-          if [ "$EVENT_ACTION" = "edited" ]; then
-            PREV=$(echo "$PREV_BODY" | grep -oE '[A-Z_]+-[0-9]+' | sort -u | tr '\n' ' ')
-            echo "Previous issue keys: ${PREV:-(none)}"
-            echo "prev=$PREV" >> "$GITHUB_OUTPUT"
-          fi
+      # ブランチ名の先頭から課題キーを取り出す（PROJECT-123/fix-login → PROJECT-123）
+      - name: Extract issue key from branch name
+        id: issue
+        run: echo "key=$(echo "$BRANCH" | grep -oE '^[A-Z][A-Z0-9_]*-[0-9]+')" >> "$GITHUB_OUTPUT"
         env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PREV_BODY: ${{ github.event.changes.body.from }}
-          EVENT_ACTION: ${{ github.event.action }}
+          BRANCH: ${{ github.head_ref }}
 
+      # 後続のステップで bee コマンドを使えるようにする
+      - name: Install bee CLI
+        if: steps.issue.outputs.key != ''
+        run: npm install -g @nulab/bee@1
+
+      # コメント本文に埋め込むプルリクエストへのリンク
       - name: Build PR link text
         id: pr-link
-        run: |
-          echo "md=[${REPO}#${PR_NUMBER}](${PR_URL})" >> "$GITHUB_OUTPUT"
+        if: steps.issue.outputs.key != ''
+        run: echo "md=[${REPO}#${PR_NUMBER}](${PR_URL})" >> "$GITHUB_OUTPUT"
         env:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
 
-      # PR 作成 → 課題にリンク＋ステータスを「処理中」に
-      - name: Update status to "In Progress" and comment PR link
-        if: github.event.action == 'opened' && steps.collect.outputs.keys != ''
+      # PR 作成 → 課題を「処理中」にして、どのブランチの PR とリンクしたかを残す
+      - name: Link issue to the opened PR
+        if: steps.issue.outputs.key != '' && github.event.action == 'opened'
         run: |
-          for KEY in $KEYS; do
-            echo "Updating status: $KEY -> In Progress"
-            npx @nulab/bee issue edit "$KEY" --status "$STATUS_IN_PROGRESS" || echo "::warning::Failed to process $KEY"
-            echo "Commenting on: $KEY"
-            npx @nulab/bee issue comment "$KEY" \
-              --body "PR ${PR_LINK} が作成されました" || echo "::warning::Failed to process $KEY"
-          done
+          bee issue edit "$KEY" --status "$STATUS_IN_PROGRESS" \
+            --comment "GitHub プルリクエスト $PR_LINK とリンクしました（$HEAD → $BASE）"
         env:
-          KEYS: ${{ steps.collect.outputs.keys }}
+          KEY: ${{ steps.issue.outputs.key }}
           PR_LINK: ${{ steps.pr-link.outputs.md }}
+          HEAD: ${{ github.head_ref }}
+          BASE: ${{ github.base_ref }}
 
-      # PR 本文の編集 → 新しく追加された課題キーにだけコメント
-      - name: Comment PR link on newly added issues
-        if: github.event.action == 'edited' && steps.collect.outputs.keys != ''
+      # PR 再オープン → レビュー再開なので課題も処理中に戻す
+      - name: Mark issue as in progress again on PR reopen
+        if: steps.issue.outputs.key != '' && github.event.action == 'reopened'
         run: |
-          for KEY in $KEYS; do
-            if echo "$PREV_KEYS" | grep -qw "$KEY"; then
-              echo "Skipping: $KEY (already linked)"
-              continue
-            fi
-            echo "Commenting on: $KEY"
-            npx @nulab/bee issue comment "$KEY" \
-              --body "PR ${PR_LINK} にリンクされました" || echo "::warning::Failed to process $KEY"
-          done
+          bee issue edit "$KEY" --status "$STATUS_IN_PROGRESS" \
+            --comment "GitHub プルリクエスト $PR_LINK が再オープンされました"
         env:
-          KEYS: ${{ steps.collect.outputs.keys }}
-          PREV_KEYS: ${{ steps.collect.outputs.prev }}
+          KEY: ${{ steps.issue.outputs.key }}
           PR_LINK: ${{ steps.pr-link.outputs.md }}
 
       # PR マージ → 課題をクローズ
-      - name: Close linked issues
-        if: github.event.action == 'closed' && github.event.pull_request.merged == true && steps.collect.outputs.keys != ''
+      - name: Close issue on merge
+        if: steps.issue.outputs.key != '' && github.event.action == 'closed' && github.event.pull_request.merged == true
         run: |
-          for KEY in $KEYS; do
-            echo "Closing: $KEY"
-            npx @nulab/bee issue close "$KEY" \
-              --comment "PR ${PR_LINK} のマージにより自動クローズ" || echo "::warning::Failed to process $KEY"
-          done
+          bee issue close "$KEY" \
+            --comment "GitHub プルリクエスト $PR_LINK が $BASE にマージされました"
         env:
-          KEYS: ${{ steps.collect.outputs.keys }}
+          KEY: ${{ steps.issue.outputs.key }}
+          PR_LINK: ${{ steps.pr-link.outputs.md }}
+          BASE: ${{ github.base_ref }}
+
+      # マージされずにクローズ → 対応は済んでいないので記録だけ残し、ステータスは変えない
+      - name: Note that the PR was closed without merging
+        if: steps.issue.outputs.key != '' && github.event.action == 'closed' && github.event.pull_request.merged == false
+        run: |
+          bee issue comment "$KEY" \
+            --body "GitHub プルリクエスト $PR_LINK はマージされずにクローズされました"
+        env:
+          KEY: ${{ steps.issue.outputs.key }}
           PR_LINK: ${{ steps.pr-link.outputs.md }}
 ```
+
+:::tip[ステータス変更とコメントは 1 コマンドで]
+Backlog API は、ステータスの変わらない更新をコメントなしでは受け付けません（`No comment content.` エラー）。`issue edit` の `--comment` オプションでステータス変更とコメントを一度に行うと、このエラーを避けられ、Backlog 上でも 1 つの履歴にまとまります。
+:::
 
 ## カスタマイズ
 
 ステータス ID を確認するには
 : `bee status list -p <PROJECT>` でプロジェクトのステータス一覧と ID を確認できます。`STATUS_IN_PROGRESS` の値をプロジェクトに合わせて変更してください。
 
-ステータス変更が不要
-: `bee issue edit` の行と `STATUS_IN_PROGRESS` 環境変数を削除すれば、リンクのコメントだけになります。
+クローズではなく「処理済み」で止めたい
+: `bee issue close` を `bee issue edit --status <ステータスID> --comment <コメント>` に変更してください。
 
-自動クローズが不要
-: 「Close linked issues」ステップを削除してください。
+完了理由を変えたい
+: `bee issue close` は完了理由が「対応済み」になります。別の完了理由にする場合は `--resolution` オプションを指定してください。
 
-クローズではなく別のステータスにしたい
-: `bee issue close` を `bee issue edit --status <ステータスID>` に変更してください。ステータス ID は `bee status list -p <PROJECT>` で確認できます。
+課題キーを PR 本文から拾いたい
+: 抽出ステップの `BRANCH: ${{ github.head_ref }}` を `BODY: ${{ github.event.pull_request.body }}` に変え、`grep` の対象と正規表現を合わせて調整してください。
 
-`edited` イベントが不要
-: トリガーの `types` から `edited` を削除し、「Comment PR link on newly added issues」ステップを削除してください。
+再オープンとの連動が不要
+: トリガーの `types` から `reopened` を削除し、「Mark issue as in progress again on PR reopen」ステップを削除してください。
 
 ## 関連するコマンド
 


### PR DESCRIPTION
## Why

The PR lifecycle sync recipe took issue keys from the PR body. That forced the workflow to diff the previous body on `edited` events, loop over multiple keys, and swallow failures with `|| echo "::warning::"` because the key pattern also matches strings like `UTF-8`.

Taking the key from the branch name prefix (`PROJECT-123/fix-login`) gives exactly one key per PR, so all of that goes away.

## What changed

- Extract the issue key from `github.head_ref` instead of the PR body
- Handle `reopened` and closed-without-merge; drop the `edited` event
- Install bee once with `npm install -g @nulab/bee@1` instead of `npx` per step
- Merge the status update with its comment via `issue edit --comment`
- Refresh the customization section, keeping a note for readers who want the PR-body behaviour

## Note on `issue edit --comment`

Backlog rejects a status update that changes nothing and carries no comment:

```json
{"errors":[{"message":"No comment content.","code":7,"moreInfo":""}]}
```

Reopening a PR hits this every time, since the issue is already in progress. Passing `--comment` avoids it and keeps the change and its comment in one history entry.

## Verified

Ran all four events against a public demo repository:

| Event | Result |
| --- | --- |
| opened | 未対応 → 処理中 |
| closed (not merged) | status unchanged, comment only |
| reopened | → 処理中 |
| merged | → 完了 (対応済み) |

https://github.com/lollipop-onl/backlog-pr-sync-demo/pull/6

🤖 Generated with [Claude Code](https://claude.com/claude-code)