### PR TITLE
chore: add CODEOWNERS so outside pull requests reach a reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Requesting a review requires write access, so contributors from outside the
+# organization cannot pick a reviewer for their own pull request. Without an
+# owner listed here, nobody is notified and those pull requests go unread.
+#
+# Patterns are last-match-wins, so a single catch-all covers the repository.
+
+* @lollipop-onl


### PR DESCRIPTION
## Summary

Third parties currently cannot request a review on their pull requests. This is **not** something a repository setting can grant — requesting a review requires **write access**, so a contributor from outside the organization cannot pick a reviewer even on their own PR. That part is GitHub's permission model and cannot be changed.

What *can* be fixed is the consequence. Today:

- The `main` ruleset sets `required_approving_review_count: 1` but does not say *whose* approval.
- No `CODEOWNERS` exists anywhere in the repo.

So an outside pull request needs an approval, notifies nobody, and waits until a maintainer happens to notice it. Adding an owner makes the review request **automatic**, which removes the need for the contributor to make one at all.

```
* @lollipop-onl
```

### Two caveats worth knowing before merging

**1. This file alone does not enforce anything.** The ruleset has `require_code_owner_review: false`, so after this merges, code-owner review is *requested automatically* but is not *required* — any single approval still satisfies the rule. That is probably the right default for now, and enabling the setting is a separate decision made in repo settings rather than in this PR.

**2. Bus factor of one.** `@lollipop-onl` holds 243 of the repo's commits; every other contributor has exactly one. An individual is named here only because the repo has no team with write access today. If review load is ever shared, replacing this with `@nulab/<team>` means membership changes no longer require editing this file — worth doing at that point.

## Test plan

- [x] Verified no `CODEOWNERS` already exists at any of the three valid paths (root, `.github/`, `docs/`)
- [x] Confirmed `@lollipop-onl` has `admin` permission — CODEOWNERS entries for users below write access are silently ignored by GitHub
- [x] Single catch-all pattern, so last-match-wins ordering cannot leave any path unowned
- [x] Read the active ruleset to confirm the interaction described above (`required_approving_review_count: 1`, `require_code_owner_review: false`)

Automatic review requests only start on pull requests opened **after** this lands on `main`, so the effect is visible on the next PR rather than this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
