### PR TITLE
fix(issue view): omit estimated/actual hours rows when unset

### DIFF
--- a/apps/cli/src/commands/issue/view.test.ts
+++ b/apps/cli/src/commands/issue/view.test.ts
@@ -119,6 +119,49 @@ describe("issue view", () => {
     expect(consola.log).toHaveBeenCalledWith(expect.stringContaining("Unknown"));
   });
 
+  it("omits estimated and actual hours rows when they are unset", async () => {
+    mockClient.getIssue.mockResolvedValue({
+      ...sampleIssue,
+      estimatedHours: null,
+      actualHours: null,
+    });
+
+    await parseCommand(() => import("./view"), ["PROJ-1"]);
+
+    const allCalls = vi.mocked(consola.log).mock.calls.map((c) => String(c[0]));
+    expect(allCalls.every((c) => !c.includes("null"))).toBe(true);
+    expect(allCalls.every((c) => !c.includes("Estimated"))).toBe(true);
+    expect(allCalls.every((c) => !c.includes("Actual"))).toBe(true);
+  });
+
+  it("shows the row for whichever of estimated or actual hours is set", async () => {
+    mockClient.getIssue.mockResolvedValue({
+      ...sampleIssue,
+      estimatedHours: null,
+      actualHours: 8,
+    });
+
+    await parseCommand(() => import("./view"), ["PROJ-1"]);
+
+    const allCalls = vi.mocked(consola.log).mock.calls.map((c) => String(c[0]));
+    expect(allCalls.every((c) => !c.includes("Estimated"))).toBe(true);
+    expect(allCalls.some((c) => c.includes("Actual") && c.includes("8h"))).toBe(true);
+  });
+
+  it("shows zero hours instead of omitting the row", async () => {
+    mockClient.getIssue.mockResolvedValue({
+      ...sampleIssue,
+      estimatedHours: 0,
+      actualHours: 0,
+    });
+
+    await parseCommand(() => import("./view"), ["PROJ-1"]);
+
+    const allCalls = vi.mocked(consola.log).mock.calls.map((c) => String(c[0]));
+    expect(allCalls.some((c) => c.includes("Estimated") && c.includes("0h"))).toBe(true);
+    expect(allCalls.some((c) => c.includes("Actual") && c.includes("0h"))).toBe(true);
+  });
+
   it("handles null startDate and dueDate gracefully", async () => {
     mockClient.getIssue.mockResolvedValue({
       ...sampleIssue,

--- a/apps/cli/src/commands/issue/view.ts
+++ b/apps/cli/src/commands/issue/view.ts
@@ -4,6 +4,9 @@ import consola from "consola";
 import { BeeCommand, ENV_AUTH } from "../../lib/bee-command";
 import * as opt from "../../lib/common-options";
 
+const formatHours = (hours: number | null | undefined): string | undefined =>
+  hours === null || hours === undefined ? undefined : `${hours}h`;
+
 const view = new BeeCommand("view")
   .summary("View an issue")
   .description(`Use \`--comments\` to include comments. Use \`--web\` to open in the browser.`)
@@ -47,8 +50,8 @@ const view = new BeeCommand("view")
         ["Updated", formatDate(data.updated)],
         ["Start Date", data.startDate ? formatDate(data.startDate) : undefined],
         ["Due Date", data.dueDate ? formatDate(data.dueDate) : undefined],
-        ["Estimated", data.estimatedHours === undefined ? undefined : `${data.estimatedHours}h`],
-        ["Actual", data.actualHours === undefined ? undefined : `${data.actualHours}h`],
+        ["Estimated", formatHours(data.estimatedHours)],
+        ["Actual", formatHours(data.actualHours)],
         [
           "Categories",
           data.category.length > 0 ? data.category.map((c) => c.name).join(", ") : undefined,


### PR DESCRIPTION
## Why

`bee issue view` printed the literal string `nullh` for issues with no estimated or actual hours:

```
    Estimated   nullh
    Actual      nullh
```

The Backlog API returns unset `estimatedHours` / `actualHours` as `null`, not `undefined`, so the `=== undefined` guard let `null` fall through into the template literal.

Every other optional field in the same list (Start Date, Due Date, Categories, Milestones) is omitted entirely when unset — these two rows were the only inconsistent ones.

Closes #147

## What changed

Extracted a `formatHours` helper that returns `undefined` for both `null` and `undefined`. `printDefinitionList` already drops `null`/`undefined` values, so the rows now disappear like the other optional fields.

A `== null` shorthand would have been the only instance of that idiom in the repo and trips oxlint's `eqeqeq` rule, hence the explicit helper.

## Tests

Three specs added to `view.test.ts`:

- both unset → neither row renders, no `"null"` in output
- only one set → just that row renders, as `8h`
- value of `0` → renders `0h` rather than being omitted (the boundary a truthiness or `??` implementation would regress)

Verified the new specs fail against the pre-fix code (2 failed) and pass after — so they pin the bug rather than passing vacuously.

`oxlint`, `oxfmt --check`, and `tsc --noEmit` are clean; all 103 issue-command tests pass.

Note: `packages/backlog-utils/src/oauth-callback.test.ts` > "defaults to port 5033" fails locally, but it fails identically on an unmodified checkout — a pre-existing failure unrelated to this change (port 5033 occupied), left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)