### PR TITLE
Generate the Agent Skill command table from the CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,6 @@ jobs:
 
       - name: Format check
         run: pnpm run format:check
+
+      - name: Check generated Skill is up to date
+        run: pnpm --filter @nulab/bee generate:skill:check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ TypeScript is configured with `module: "preserve"` / `moduleResolution: "bundler
 ## Architecture
 
 ```
-apps/cli             — CLI entry point (citty framework, consola logging)
+apps/cli             — CLI entry point (commander.js, consola logging)
 apps/docs            — Astro Starlight documentation site
 packages/backlog-utils — Backlog API client wrapper (backlog-js, OAuth auto-refresh, rate-limit handling)
 packages/cli-utils   — Shared CLI utilities (output formatting, table, splitArg, prompts)
@@ -62,9 +62,15 @@ packages/tsconfigs   — Shared TypeScript base config
 
 ### Documentation site (`apps/docs`)
 
-Command reference pages are **auto-generated** from CLI source code — do NOT create `.md` files under `apps/docs/src/content/docs/commands/`. The dynamic route `apps/docs/src/pages/commands/[...slug].astro` uses `loadCommands()` (in `apps/docs/src/lib/commands.ts`) to import each command's `commandUsage` and `defineCommand` metadata at build time and render documentation pages automatically.
+Command reference pages are **auto-generated** from CLI source code — do NOT create `.md` files under `apps/docs/src/content/docs/commands/`. The dynamic route `apps/docs/src/pages/commands/[...slug].astro` uses `loadCommands()` (in `apps/docs/src/lib/commands.ts`) to import each command's `BeeCommand` metadata at build time and render documentation pages automatically.
 
-**When adding or removing CLI commands**, also update the command table in `skills/using-bee/SKILL.md` to keep the Skill in sync with the CLI.
+**When adding or removing CLI commands**, regenerate the Skill's command table so it stays in sync with the CLI:
+
+```sh
+pnpm --filter @nulab/bee generate:skill
+```
+
+The region between the `BEGIN/END GENERATED COMMAND TABLE` markers in `skills/using-bee/SKILL.md` is generated from `apps/cli/src/commands/registry.ts` — do not hand-edit it. CI runs `generate:skill:check` and fails when the committed table differs from the generated one.
 
 ### Skills (`skills/`)
 
@@ -141,103 +147,82 @@ All internal links in documentation content (`apps/docs/src/content/docs/`) must
 
 `@repo/backlog-utils` exposes `getClient()` which returns a `backlog-js` `Backlog` instance with OAuth 401 auto-refresh (via Proxy) and rate-limit error handling. Commands call `client.getIssues()`, `client.getProjects()`, etc. directly.
 
-`@nulab/bee` uses citty's `defineCommand` / `runMain` with subcommand registration and a custom help system (see below).
+`@nulab/bee` builds its command tree from `commander`, via a `BeeCommand` subclass that adds a custom help system (see below).
 
 ## Command Help System
 
-CLI commands use a **single-source help system** inspired by gh CLI. Each command defines a `CommandUsage` object that drives both `--help` output and documentation generation from the same data.
+CLI commands use a **single-source help system** inspired by gh CLI. Each command is a `BeeCommand` (a `commander` `Command` subclass) whose metadata drives `--help` output, the generated docs pages, and the generated Skill command table from the same data.
 
 ### How it works
 
-1. Each command file exports `commandUsage: CommandUsage` alongside the command definition
-2. The command is wrapped with `withUsage(defineCommand({ ... }), commandUsage)` to attach the usage data
-3. `runMain` receives `showCommandUsage` as a custom `showUsage` handler, which renders gh-cli style help for commands with attached usage and falls back to citty's default for others
+1. Each command file builds a `BeeCommand` and exports it as the **default export**
+2. `BeeCommand` extends commander's help with `EXAMPLES` and `ENVIRONMENT VARIABLES` sections, populated by `.examples()` and `.envVars()` plus any option bound with `.env()`
+3. `apps/cli/src/commands/registry.ts` lists every top-level command; `src/index.ts` and the generators all read that one list
 
-### Adding help to a command
+### Adding a command
 
 ```ts
-import { defineCommand } from "citty";
-import { type CommandUsage, withUsage } from "./lib/command-usage";
+import { BeeCommand } from "../lib/bee-command";
+import * as opt from "../lib/common-options";
 
-export const commandUsage: CommandUsage = {
-  long: "Detailed multi-line description of the command.",
-  examples: [{ description: "Do something", command: "bee foo bar" }],
-  annotations: {
-    environment: [["ENV_VAR_NAME", "Description of what it does"]],
-  },
-};
+const bar = new BeeCommand("bar")
+  .summary("Short one-liner")
+  .description(`Detailed multi-line description of the command.`)
+  .argument("<target>", "What to act on")
+  .addOption(opt.project())
+  .option("-m, --method <method>", "The authentication method to use", "api-key")
+  .envVars([["ENV_VAR_NAME", "Description of what it does"]])
+  .examples([{ description: "Do something", command: "bee foo bar" }])
+  .action(async (target, opts) => {
+    /* ... */
+  });
 
-export const myCommand = withUsage(
-  defineCommand({
-    meta: { name: "bar", description: "Short one-liner" },
-    args: {/* ... */},
-    async run({ args }) {
-      /* ... */
-    },
-  }),
-  commandUsage,
-);
+export default bar;
 ```
+
+Register it in its group's `index.ts` (or in `registry.ts` for a top-level command).
 
 ### Writing help content
 
-- **Every new command must have `commandUsage`** — all commands export `commandUsage: CommandUsage` and wrap with `withUsage`.
+- **Every command needs `.summary()`** — it is the short description shown in parent help, the docs index, and the Skill command table.
 - **Reference `gh <command> --help`** for tone and structure — run the corresponding gh CLI help (e.g., `gh auth login --help`) and adapt the content to Backlog's context.
-- **`long`**: Multi-paragraph description. First line is a standalone summary. Subsequent paragraphs explain behavior, caveats, and related commands.
-- **`examples`**: 2–4 practical examples covering common use cases (interactive, flags, piping).
-- **`annotations.environment`**: `[string, string][]` — list relevant environment variables as `[key, description]` pairs. Columns are auto-aligned.
+- **`.description()`**: Multi-paragraph long text explaining behavior, caveats, and related commands. Omit it when `.summary()` already says everything.
+- **`.examples()`**: 2–4 practical examples covering common use cases (interactive, flags, piping).
+- **`.envVars()`**: `[string, string][]` — environment variables as `[key, description]` pairs, for vars not already bound to an option via `.env()`. Columns are auto-aligned.
 
 ### Writing argument descriptions
 
-Follow gh CLI conventions for `args` description strings:
+Follow gh CLI conventions for option and argument description strings:
 
 - **`description` is pure prose** — keep it a short, human-readable explanation. Do not embed format hints, examples, or choice lists in the description.
-- **Use `valueHint` for supplementary value information** — choices, formats, examples, and type hints go in the `valueHint` property, not in `description`. `valueHint` is rendered in `--help` (flag column / arguments section), docs, and interactive prompts automatically.
-- **Same-meaning arguments share the same description across commands** — if `--space` means the same thing in `auth login` and `auth logout`, use the identical description string. Do not vary wording per command context.
+- **Put value information in the flags string or `.choices()`** — the value placeholder (`<id>`, `<yyyy-MM-dd>`) belongs in the flags string, and fixed choice sets belong in `.choices()`. Both are rendered in `--help` and in the generated docs automatically.
+- **Same-meaning arguments share the same description across commands** — if `--space` means the same thing in `auth login` and `auth logout`, use the identical description string. Do not vary wording per command context. Prefer a shared factory from `src/lib/common-options.ts`.
 - **Edit/update flags signal intent in the description** — in `edit` / `update` commands, descriptions must make it clear the flag sets a new value:
   - String flags: `"New X of the Y"` (e.g., `"New name of the project"`)
   - Boolean toggles: `"Change whether X"` (e.g., `"Change whether the chart is enabled"`)
-  - Enum flags: `"Change X"` with `valueHint: "{a|b}"` (e.g., `description: "Change text formatting rule"`, `valueHint: "{backlog|markdown}"`)
+  - Enum flags: `"Change X"` plus `.choices([...])` (e.g., `description: "Change text formatting rule"`, `.choices(["backlog", "markdown"])`)
 
-### `valueHint` conventions
+### Value placeholder conventions
 
-`valueHint` provides machine-readable value metadata that is displayed across `--help`, docs, and prompts. Use it for any argument where users need guidance on what values to enter.
+The placeholder in an option's flags string is machine-readable value metadata, displayed in `--help`, the docs, and prompts. Use one for any option that takes a value.
 
-| Pattern       | `valueHint`      | Example                                  |
-| ------------- | ---------------- | ---------------------------------------- |
-| Fixed choices | `"{x\|y\|z}"`    | `"{api-key\|oauth}"`, `"{asc\|desc}"`    |
-| Date format   | `"<yyyy-MM-dd>"` | Date fields                              |
-| Example value | `"<example>"`    | `"<PROJECT-123>"`, `"<xxx.backlog.com>"` |
-| Numeric range | `"<min-max>"`    | `"<1-100>"`                              |
-| Type hint     | `"<type>"`       | `"<number>"`                             |
+| Pattern       | Placeholder    | Example                              |
+| ------------- | -------------- | ------------------------------------ |
+| Date format   | `<yyyy-MM-dd>` | Date fields                          |
+| Example value | `<example>`    | `<PROJECT-123>`, `<xxx.backlog.com>` |
+| Numeric range | `<min-max>`    | `<1-100>`                            |
+| Type hint     | `<type>`       | `<n>`, `<id>`, `<name>`              |
+
+Fixed choice sets use `.choices()` rather than a placeholder listing them:
 
 ```ts
-// Choices
-method: {
-  type: "string",
-  description: "The authentication method to use",
-  valueHint: "{api-key|oauth}",
-},
+// Choices — commander validates the value and renders the set in help
+.option("--order <dir>", "Sort order").choices(["asc", "desc"])
 // Date format
-"start-date": {
-  type: "string",
-  description: "Start date",
-  valueHint: "<yyyy-MM-dd>",
-},
+.option("--start-date <yyyy-MM-dd>", "Start date")
 // Example value (positional)
-issue: {
-  type: "positional",
-  description: "Issue ID or issue key",
-  valueHint: "<PROJECT-123>",
-},
+.argument("<issue>", "Issue ID or issue key")
 ```
-
-Where `valueHint` is rendered:
-
-- **`--help` flags**: after the flag name (e.g., `--sort {issueType|category|...}`)
-- **`--help` arguments**: after the description text
-- **Docs**: as `<code>` next to the description
-- **`promptRequired`**: appended to the prompt label (e.g., `Priority {high|normal|low}:`)
 
 ### Short flag aliases
 
@@ -249,27 +234,25 @@ Following gh CLI conventions, only assign single-letter aliases (`-n`, `-d`, etc
 
 When two flags in the same command would collide on the same letter, one (or both) must stay long-form. Prefer giving the alias to the more frequently used flag.
 
-### Environment variable defaults for arguments
+### Environment variable defaults for options
 
-When a command argument can be provided via an environment variable (e.g., `BACKLOG_PROJECT`), use citty's `default` property instead of runtime fallback logic:
+When an option can be provided via an environment variable (e.g., `BACKLOG_PROJECT`), bind it with commander's `.env()` instead of runtime fallback logic:
 
 ```ts
-project: {
-  type: "positional",
-  description: "Project ID or project key",
-  required: true,
-  default: process.env.BACKLOG_PROJECT,
-},
+new Option("-p, --project <id>", "Project ID or project key").env("BACKLOG_PROJECT");
 ```
 
-citty skips the `required` check when `default` is not `undefined`, so this naturally makes the argument optional when the env var is set and required when it is not. No runtime fallback code (`||` / `??`) is needed.
+commander reads the env var when the flag is absent, so no runtime fallback code (`||` / `??`) is needed. `.env()`-bound vars are collected into the `ENVIRONMENT VARIABLES` help section automatically — do not also list them in `.envVars()`.
 
-Also add the env var to `commandUsage.annotations.environment` so it appears in `--help` output.
+For options that must have a value, use `RequiredOption` (`src/lib/required-option.ts`), which prompts interactively when the value is still missing after env resolution.
 
 ### Key files
 
-- `apps/cli/src/lib/command-usage.ts` — `CommandUsage` type, `withUsage`, `renderCommandUsage`, `showCommandUsage`
-- `apps/cli/src/index.ts` — wires `showCommandUsage` into `runMain`
+- `apps/cli/src/lib/bee-command.ts` — `BeeCommand`, `.examples()`, `.envVars()`, help rendering, shared `ENV_*` constants
+- `apps/cli/src/lib/common-options.ts` — shared option factories (`project()`, `json()`, `count()`, …)
+- `apps/cli/src/lib/required-option.ts` — `RequiredOption` and `resolveOptions`
+- `apps/cli/src/commands/registry.ts` — the one list of top-level commands
+- `apps/cli/src/index.ts` — builds the root program from the registry
 
 ## Command Implementation Patterns
 
@@ -377,7 +360,7 @@ Following [CLI Guidelines (clig.dev)](https://clig.dev/), command tests should f
 
 **DO NOT test (library/framework responsibility):**
 
-- citty/Commander option parsing (e.g., `--keyword "x"` → `keyword: "x"`)
+- commander option parsing (e.g., `--keyword "x"` → `keyword: "x"`)
 - `splitArg` / `collect` / `collectNum` array collection behavior
 - Boolean flag parsing (`--archived` → `true`)
 - Simple option forwarding where the handler passes the parsed value to the API unchanged

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is a pnpm workspace monorepo managed with [Turborepo](https://turbo.build/)
 
 | Package               | Path                     | Description                                       |
 | --------------------- | ------------------------ | ------------------------------------------------- |
-| `@nulab/bee`          | `apps/cli`               | CLI entry point (citty + consola)                 |
+| `@nulab/bee`          | `apps/cli`               | CLI entry point (commander + consola)             |
 | `@repo/docs`          | `apps/docs`              | Documentation site (Astro Starlight)              |
 | `@repo/backlog-utils` | `packages/backlog-utils` | Backlog API client wrapper                        |
 | `@repo/cli-utils`     | `packages/cli-utils`     | Shared CLI utilities (output formatting, prompts) |

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -33,6 +33,8 @@
   "scripts": {
     "build": "unbuild",
     "dev": "tsx --env-file=.env.development src/index.ts",
+    "generate:skill": "tsx src/scripts/generate-skill.ts",
+    "generate:skill:check": "tsx src/scripts/generate-skill.ts --check",
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },

--- a/apps/cli/src/commands/registry.ts
+++ b/apps/cli/src/commands/registry.ts
@@ -1,0 +1,36 @@
+import { type Command } from "commander";
+
+/**
+ * Every top-level command, in the order they are presented to users.
+ *
+ * Imports stay lazy so `bee <command>` only pays for the module it runs, and so
+ * the Skill generator can load the whole tree without executing the CLI entry
+ * point (which parses argv on import).
+ */
+const commandModules: (() => Promise<{ default: Command }>)[] = [
+  () => import("./auth/index.js"),
+  () => import("./project/index.js"),
+  () => import("./issue/index.js"),
+  () => import("./document/index.js"),
+  () => import("./notification/index.js"),
+  () => import("./pr/index.js"),
+  () => import("./repo/index.js"),
+  () => import("./team/index.js"),
+  () => import("./user/index.js"),
+  () => import("./wiki/index.js"),
+  () => import("./category/index.js"),
+  () => import("./milestone/index.js"),
+  () => import("./issue-type/index.js"),
+  () => import("./space/index.js"),
+  () => import("./status/index.js"),
+  () => import("./star/index.js"),
+  () => import("./watching/index.js"),
+  () => import("./dashboard.js"),
+  () => import("./browse.js"),
+  () => import("./api.js"),
+  () => import("./completion.js"),
+];
+
+const loadCommands = (): Promise<{ default: Command }>[] => commandModules.map((load) => load());
+
+export { loadCommands };

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,5 +1,6 @@
 import consola from "consola";
 import { installHttpDispatcher } from "@repo/backlog-utils";
+import { loadCommands } from "./commands/registry";
 import { BeeCommand } from "./lib/bee-command";
 import { handleError } from "./lib/error";
 import pkg from "../package.json" with { type: "json" };
@@ -9,29 +10,7 @@ installHttpDispatcher();
 
 const program = new BeeCommand("bee").version(pkg.version).description(pkg.description ?? "");
 
-await program.addCommands([
-  import("./commands/auth/index.js"),
-  import("./commands/project/index.js"),
-  import("./commands/issue/index.js"),
-  import("./commands/document/index.js"),
-  import("./commands/notification/index.js"),
-  import("./commands/pr/index.js"),
-  import("./commands/repo/index.js"),
-  import("./commands/team/index.js"),
-  import("./commands/user/index.js"),
-  import("./commands/wiki/index.js"),
-  import("./commands/category/index.js"),
-  import("./commands/milestone/index.js"),
-  import("./commands/issue-type/index.js"),
-  import("./commands/space/index.js"),
-  import("./commands/status/index.js"),
-  import("./commands/star/index.js"),
-  import("./commands/watching/index.js"),
-  import("./commands/dashboard.js"),
-  import("./commands/browse.js"),
-  import("./commands/api.js"),
-  import("./commands/completion.js"),
-]);
+await program.addCommands(loadCommands());
 
 program.exitOverride();
 

--- a/apps/cli/src/lib/command-table.test.ts
+++ b/apps/cli/src/lib/command-table.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { BeeCommand } from "./bee-command";
+import { MARKER_BEGIN, MARKER_END, applyCommandTable, renderCommandTable } from "./command-table";
+
+const program = (): BeeCommand => new BeeCommand("bee");
+
+describe("renderCommandTable", () => {
+  it("lists each subcommand of a parent command", () => {
+    const bee = program();
+    bee.addCommand(
+      new BeeCommand("issue")
+        .summary("Manage issues")
+        .addCommand(new BeeCommand("list").summary("List issues"))
+        .addCommand(new BeeCommand("view").summary("View an issue")),
+    );
+
+    expect(renderCommandTable(bee)).toContain("| `bee issue` | `list`, `view` |");
+  });
+
+  it("shows the summary instead of subcommands for a leaf command", () => {
+    const bee = program();
+    bee.addCommand(new BeeCommand("dashboard").summary("Show a summary of your Backlog activity"));
+
+    expect(renderCommandTable(bee)).toContain(
+      "| `bee dashboard` | Show a summary of your Backlog activity |",
+    );
+  });
+
+  it("omits commander's built-in help subcommand", () => {
+    const bee = program();
+    const issue = new BeeCommand("issue").summary("Manage issues");
+    issue.addCommand(new BeeCommand("list").summary("List issues"));
+    issue.addCommand(new BeeCommand("help").summary("display help"));
+    bee.addCommand(issue);
+    bee.addCommand(new BeeCommand("help").summary("display help"));
+
+    const table = renderCommandTable(bee);
+    expect(table).toContain("| `bee issue` |");
+    expect(table).toContain("`list`");
+    expect(table).not.toContain("`bee help`");
+  });
+
+  it("falls back to the description when a command has no summary", () => {
+    const bee = program();
+    bee.addCommand(new BeeCommand("api").description("Make an authenticated API request"));
+
+    expect(renderCommandTable(bee)).toContain("| `bee api` | Make an authenticated API request |");
+  });
+
+  it("escapes pipe characters so a summary cannot break the table", () => {
+    const bee = program();
+    bee.addCommand(new BeeCommand("pipe").summary("Reads a|b"));
+
+    expect(renderCommandTable(bee)).toContain(String.raw`Reads a\|b`);
+  });
+
+  it("pads every row to the same width", () => {
+    const bee = program();
+    bee.addCommand(
+      new BeeCommand("issue")
+        .summary("Manage issues")
+        .addCommand(new BeeCommand("list").summary("List issues")),
+    );
+    bee.addCommand(new BeeCommand("dashboard").summary("Show a summary of your Backlog activity"));
+
+    const widths = new Set(
+      renderCommandTable(bee)
+        .split("\n")
+        .map((line) => line.length),
+    );
+    expect(widths.size).toBe(1);
+  });
+});
+
+const withMarkers = (inner: string): string =>
+  `# Skill\n\n${MARKER_BEGIN}\n${inner}\n${MARKER_END}\n\nTrailing prose.\n`;
+
+describe("applyCommandTable", () => {
+  it("replaces stale table content between the markers", () => {
+    const bee = program();
+    bee.addCommand(new BeeCommand("dashboard").summary("Show a summary"));
+
+    const result = applyCommandTable(withMarkers("| `bee webhook` | `list` |"), bee);
+
+    expect(result).not.toContain("webhook");
+    expect(result).toContain("`bee dashboard`");
+  });
+
+  it("preserves content outside the markers", () => {
+    const bee = program();
+    bee.addCommand(new BeeCommand("dashboard").summary("Show a summary"));
+
+    const result = applyCommandTable(withMarkers("stale"), bee);
+
+    expect(result.startsWith("# Skill\n")).toBe(true);
+    expect(result.endsWith("Trailing prose.\n")).toBe(true);
+  });
+
+  it("is idempotent, so a second run produces no diff", () => {
+    const bee = program();
+    bee.addCommand(new BeeCommand("dashboard").summary("Show a summary"));
+
+    const once = applyCommandTable(withMarkers("stale"), bee);
+    expect(applyCommandTable(once, bee)).toBe(once);
+  });
+
+  it("throws when the markers are missing", () => {
+    expect(() => applyCommandTable("# Skill\n\nNo markers here.\n", program())).toThrow(
+      /Missing generated-table markers/,
+    );
+  });
+
+  it("throws when the end marker precedes the begin marker", () => {
+    expect(() => applyCommandTable(`${MARKER_END}\n${MARKER_BEGIN}\n`, program())).toThrow(
+      /Missing generated-table markers/,
+    );
+  });
+});

--- a/apps/cli/src/lib/command-table.ts
+++ b/apps/cli/src/lib/command-table.ts
@@ -1,0 +1,60 @@
+import { type Command } from "commander";
+
+const MARKER_BEGIN = "<!-- BEGIN GENERATED COMMAND TABLE -->";
+const MARKER_END = "<!-- END GENERATED COMMAND TABLE -->";
+
+type CommandRow = {
+  command: string;
+  subcommands: string[];
+  summary: string;
+};
+
+/**
+ * Commander lists `help` as a subcommand of every parent. It is not part of the
+ * CLI surface an agent chooses between, so it never reaches the table.
+ */
+const isListable = (cmd: Command): boolean => cmd.name() !== "help";
+
+const toRow = (cmd: Command): CommandRow => ({
+  command: `bee ${cmd.name()}`,
+  subcommands: cmd.commands.filter(isListable).map((sub) => sub.name()),
+  summary: cmd.summary() || cmd.description(),
+});
+
+const escapeCell = (text: string): string => text.replaceAll("|", String.raw`\|`);
+
+/** Render a row's second column: subcommands when it has them, else its summary. */
+const detailCell = (row: CommandRow): string =>
+  row.subcommands.length > 0
+    ? row.subcommands.map((name) => `\`${name}\``).join(", ")
+    : escapeCell(row.summary);
+
+const padCells = (rows: string[][], widths: number[]): string[] =>
+  rows.map((cells) => `| ${cells.map((cell, i) => cell.padEnd(widths[i])).join(" | ")} |`);
+
+const renderCommandTable = (program: Command): string => {
+  const rows = program.commands.filter(isListable).map(toRow);
+  const header = ["Command", "Subcommands"];
+  const body = rows.map((row) => [`\`${row.command}\``, detailCell(row)]);
+  const widths = header.map((_, i) => Math.max(...[header, ...body].map((r) => r[i].length)));
+  const separator = `| ${widths.map((w) => "-".repeat(w)).join(" | ")} |`;
+
+  return [...padCells([header], widths), separator, ...padCells(body, widths)].join("\n");
+};
+
+/** Replace the marked region of `source` with a freshly rendered table. */
+const applyCommandTable = (source: string, program: Command): string => {
+  const begin = source.indexOf(MARKER_BEGIN);
+  const end = source.indexOf(MARKER_END);
+  if (begin === -1 || end === -1 || end < begin) {
+    throw new Error(
+      `Missing generated-table markers. Expected both ${MARKER_BEGIN} and ${MARKER_END}, in that order.`,
+    );
+  }
+
+  const before = source.slice(0, begin + MARKER_BEGIN.length);
+  const after = source.slice(end);
+  return `${before}\n\n${renderCommandTable(program)}\n\n${after}`;
+};
+
+export { MARKER_BEGIN, MARKER_END, applyCommandTable, renderCommandTable };

--- a/apps/cli/src/scripts/generate-skill.ts
+++ b/apps/cli/src/scripts/generate-skill.ts
@@ -1,0 +1,42 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { loadCommands } from "../commands/registry";
+import { BeeCommand } from "../lib/bee-command";
+import { applyCommandTable } from "../lib/command-table";
+
+const SKILL_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../skills/using-bee/SKILL.md",
+);
+
+const buildProgram = async (): Promise<BeeCommand> => {
+  const program = new BeeCommand("bee");
+  await program.addCommands(loadCommands());
+  return program;
+};
+
+const main = async (): Promise<void> => {
+  const check = process.argv.includes("--check");
+  const program = await buildProgram();
+  const current = await readFile(SKILL_PATH, "utf8");
+  const next = applyCommandTable(current, program);
+
+  if (current === next) {
+    return;
+  }
+
+  if (check) {
+    process.exitCode = 1;
+    process.stderr.write(
+      "skills/using-bee/SKILL.md is out of date with the CLI commands.\n" +
+        "Run `pnpm --filter @nulab/bee generate:skill` and commit the result.\n",
+    );
+    return;
+  }
+
+  await writeFile(SKILL_PATH, next);
+  process.stdout.write("Updated skills/using-bee/SKILL.md\n");
+};
+
+await main();

--- a/skills/using-bee/SKILL.md
+++ b/skills/using-bee/SKILL.md
@@ -21,32 +21,35 @@ Set these environment variables to avoid repeating common flags:
 
 ## Commands
 
+<!-- BEGIN GENERATED COMMAND TABLE -->
+
 | Command            | Subcommands                                                                                                |
 | ------------------ | ---------------------------------------------------------------------------------------------------------- |
-| `bee issue`        | `list`, `view`, `create`, `edit`, `close`, `reopen`, `comment`, `delete`, `status`, `count`, `attachments` |
-| `bee pr`           | `list`, `view`, `create`, `edit`, `comment`, `comments`, `status`, `count`                                 |
-| `bee project`      | `list`, `view`, `create`, `edit`, `delete`, `users`, `activities`, `add-user`, `remove-user`               |
-| `bee wiki`         | `list`, `view`, `create`, `edit`, `delete`, `count`, `tags`, `history`, `attachments`                      |
-| `bee document`     | `list`, `view`, `create`, `delete`, `tree`, `attachments`                                                  |
-| `bee notification` | `list`, `count`, `read`, `read-all`                                                                        |
-| `bee repo`         | `list`, `view`, `clone`                                                                                    |
 | `bee auth`         | `login`, `logout`, `status`, `token`, `refresh`, `switch`                                                  |
+| `bee project`      | `list`, `view`, `create`, `edit`, `delete`, `users`, `activities`, `add-user`, `remove-user`               |
+| `bee issue`        | `list`, `view`, `status`, `create`, `edit`, `close`, `reopen`, `attachments`, `comment`, `count`, `delete` |
+| `bee document`     | `list`, `view`, `tree`, `attachments`, `create`, `delete`                                                  |
+| `bee notification` | `list`, `count`, `read`, `read-all`                                                                        |
+| `bee pr`           | `list`, `view`, `comments`, `status`, `create`, `edit`, `comment`, `count`                                 |
+| `bee repo`         | `list`, `view`, `clone`                                                                                    |
+| `bee team`         | `list`, `view`                                                                                             |
 | `bee user`         | `list`, `view`, `me`, `activities`                                                                         |
-| `bee team`         | `list`, `view`, `create`, `edit`, `delete`                                                                 |
+| `bee wiki`         | `list`, `view`, `count`, `tags`, `history`, `attachments`, `create`, `edit`, `delete`                      |
 | `bee category`     | `list`, `create`, `edit`, `delete`                                                                         |
 | `bee milestone`    | `list`, `create`, `edit`, `delete`                                                                         |
 | `bee issue-type`   | `list`, `create`, `edit`, `delete`                                                                         |
+| `bee space`        | `activities`                                                                                               |
 | `bee status`       | `list`, `create`, `edit`, `delete`                                                                         |
-| `bee webhook`      | `list`, `view`, `create`, `edit`, `delete`                                                                 |
-| `bee star`         | `list`, `add`, `remove`, `count`                                                                           |
+| `bee star`         | `add`, `list`, `count`, `remove`                                                                           |
 | `bee watching`     | `list`, `add`, `view`, `delete`, `read`                                                                    |
-| `bee space`        | `info`, `activities`, `disk-usage`, `notification`                                                         |
-| `bee browse`       | Open Backlog pages in browser                                                                              |
-| `bee api`          | Make raw API requests                                                                                      |
-| `bee dashboard`    | Show dashboard                                                                                             |
-| `bee completion`   | Shell completion                                                                                           |
+| `bee dashboard`    | Show a summary of your Backlog activity                                                                    |
+| `bee browse`       | Open a Backlog page in the browser                                                                         |
+| `bee api`          | Make an authenticated API request                                                                          |
+| `bee completion`   | Generate shell completion scripts                                                                          |
 
-This table may not reflect the latest version. Run `bee --help` and `bee <command> --help` to discover new commands and flags.
+<!-- END GENERATED COMMAND TABLE -->
+
+Run `bee --help` and `bee <command> --help` for the flags and arguments of each command.
 
 For the full command reference (all flags, arguments, examples, and environment variables), fetch:
 https://nulab.github.io/bee/llms-full.txt


### PR DESCRIPTION
## Summary

Fixes the drifted command table in `skills/using-bee/SKILL.md` and makes it impossible for it to drift again by generating it from the CLI.

The table was maintained by hand and had gone stale. It listed commands that do not exist:

- `bee webhook` (`list`, `view`, `create`, `edit`, `delete`) — not implemented
- `bee space info`, `disk-usage`, `notification` — only `bee space activities` exists

Two more drift items surfaced once the table was generated and compared:

- `bee team` was documented with `create`, `edit`, `delete`; only `list` and `view` exist
- several command summaries were inaccurate (e.g. `bee api` → "Make raw API requests" vs. the real "Make an authenticated API request")

This matters more than an ordinary doc bug: the Skill is the contract agents read to decide which command to run, so a stale entry makes an agent confidently invoke a command that cannot succeed, with no way to tell a documentation error from an environment problem. `AGENTS.md` already required syncing the Skill by hand whenever commands changed, which showed the coupling was real and that a manual rule was not holding.

### Changes

**Generation.** The top-level command list moves out of `apps/cli/src/index.ts` into `apps/cli/src/commands/registry.ts`, so the CLI entry point and the generator read one list rather than two. `apps/cli/src/lib/command-table.ts` builds the program from that registry and rewrites the region between marker comments in `SKILL.md`:

```sh
pnpm --filter @nulab/bee generate:skill
```

**CI check.** `generate:skill:check` fails when the committed table differs from the generated one, and runs in the `lint` job next to the existing format check — the same way `starlight-links-validator` fails the docs build on broken links. With generation in place, the `AGENTS.md` instruction to sync the Skill by hand is replaced by the regeneration command.

**citty → commander.** `README.md` and `AGENTS.md` still described the CLI as built on citty, though #53 migrated argument parsing to commander.js. While correcting those references, the "Command Help System" section turned out to document a `CommandUsage` / `withUsage` / `command-usage.ts` API that no longer exists anywhere in the tree, so it is rewritten around what the code actually does: `BeeCommand`, `.summary()`, `.examples()`, `.envVars()`, and commander's `.choices()` / `.env()`.

## Test plan

- `generate:skill:check` passes on the committed tree, and is idempotent (a second generate produces no diff)
- Verified the guard actually catches drift: injecting a fake `bee webhook` row makes it exit 1 with the remediation message, and it returns to 0 once reverted
- `pnpm run typecheck` — 5/5 packages
- `pnpm --filter @nulab/bee test` — 544 tests pass, including 11 new tests in `command-table.test.ts` covering `help`-subcommand exclusion, summary fallback for leaf commands, pipe escaping, row padding, idempotency, and missing / reversed markers
- `pnpm exec oxlint --ignore-pattern 'apps/docs' --max-warnings 0` and `pnpm run format:check` — clean (confirmed oxfmt and the generator agree on table formatting, so CI cannot deadlock between them)
- `pnpm --filter @repo/docs build` — 105 pages, all internal links valid; the docs site imports the same command modules, so the registry refactor is exercised there too
- `bee --help` still lists all 21 top-level commands in the original order

Note: `pnpm run test` also shows one failure in `packages/backlog-utils/src/oauth-callback.test.ts` (`EADDRINUSE` on port 5033). It reproduces on a clean `main` checkout and is caused by a local process holding that port — unrelated to this change, which touches no OAuth code.

Refs #127