### PR TITLE
fix(cli): generate shell completion command lists from the registry

### DIFF
--- a/apps/cli/src/commands/completion.ts
+++ b/apps/cli/src/commands/completion.ts
@@ -1,91 +1,21 @@
 import { UserError } from "@repo/cli-utils";
 import { BeeCommand } from "../lib/bee-command";
+import {
+  SUPPORTED_SHELLS,
+  isSupportedShell,
+  renderCompletionScript,
+} from "../lib/completion-script";
 
-const COMPLETION_SCRIPTS: Record<string, string> = {
-  bash: `# bash completion for bee
-# Add to ~/.bashrc:
-#   eval "$(bee completion bash)"
-
-_bee_completions() {
-  local cur="\${COMP_WORDS[COMP_CWORD]}"
-  local commands="auth project issue document notification pr repo team user wiki category milestone issue-type space status star watching dashboard browse api completion"
-
-  if [ "\${COMP_CWORD}" -eq 1 ]; then
-    COMPREPLY=( $(compgen -W "\${commands}" -- "\${cur}") )
-  fi
-}
-
-complete -F _bee_completions bee
-`,
-  zsh: `#compdef bee
-# zsh completion for bee
-# Add to ~/.zshrc:
-#   eval "$(bee completion zsh)"
-
-_bee() {
-  local -a commands
-  commands=(
-      'auth:auth commands' \\
-      'project:project commands' \\
-      'issue:issue commands' \\
-      'document:document commands' \\
-      'notification:notification commands' \\
-      'pr:pr commands' \\
-      'repo:repo commands' \\
-      'team:team commands' \\
-      'user:user commands' \\
-      'wiki:wiki commands' \\
-      'category:category commands' \\
-      'milestone:milestone commands' \\
-      'issue-type:issue-type commands' \\
-      'space:space commands' \\
-      'status:status commands' \\
-      'star:star commands' \\
-      'watching:watching commands' \\
-      'dashboard:dashboard commands' \\
-      'browse:browse commands' \\
-      'api:api commands' \\
-      'completion:completion commands'
-  )
-
-  _arguments '1: :->command' '*:: :->args'
-
-  case $state in
-    command)
-      _describe 'command' commands
-      ;;
-  esac
-}
-
-compdef _bee bee
-`,
-  fish: `# fish completion for bee
-# Add to ~/.config/fish/completions/bee.fish:
-#   bee completion fish > ~/.config/fish/completions/bee.fish
-
-complete -c bee -e
-complete -c bee -n "__fish_use_subcommand" -a "auth" -d "auth commands"
-complete -c bee -n "__fish_use_subcommand" -a "project" -d "project commands"
-complete -c bee -n "__fish_use_subcommand" -a "issue" -d "issue commands"
-complete -c bee -n "__fish_use_subcommand" -a "document" -d "document commands"
-complete -c bee -n "__fish_use_subcommand" -a "notification" -d "notification commands"
-complete -c bee -n "__fish_use_subcommand" -a "pr" -d "pr commands"
-complete -c bee -n "__fish_use_subcommand" -a "repo" -d "repo commands"
-complete -c bee -n "__fish_use_subcommand" -a "team" -d "team commands"
-complete -c bee -n "__fish_use_subcommand" -a "user" -d "user commands"
-complete -c bee -n "__fish_use_subcommand" -a "wiki" -d "wiki commands"
-complete -c bee -n "__fish_use_subcommand" -a "category" -d "category commands"
-complete -c bee -n "__fish_use_subcommand" -a "milestone" -d "milestone commands"
-complete -c bee -n "__fish_use_subcommand" -a "issue-type" -d "issue-type commands"
-complete -c bee -n "__fish_use_subcommand" -a "space" -d "space commands"
-complete -c bee -n "__fish_use_subcommand" -a "status" -d "status commands"
-complete -c bee -n "__fish_use_subcommand" -a "star" -d "star commands"
-complete -c bee -n "__fish_use_subcommand" -a "watching" -d "watching commands"
-complete -c bee -n "__fish_use_subcommand" -a "dashboard" -d "dashboard commands"
-complete -c bee -n "__fish_use_subcommand" -a "browse" -d "browse commands"
-complete -c bee -n "__fish_use_subcommand" -a "api" -d "api commands"
-complete -c bee -n "__fish_use_subcommand" -a "completion" -d "completion commands"
-`,
+/**
+ * The registry imports this module, so importing it back at the top level would
+ * close a cycle and leave `loadCommands` undefined here. Loading it inside the
+ * action defers the lookup until every module has finished evaluating.
+ */
+const buildProgram = async (): Promise<BeeCommand> => {
+  const { loadCommands } = await import("./registry.js");
+  const program = new BeeCommand("bee");
+  await program.addCommands(loadCommands());
+  return program;
 };
 
 const completion = new BeeCommand("completion")
@@ -106,14 +36,13 @@ const completion = new BeeCommand("completion")
       command: "bee completion fish > ~/.config/fish/completions/bee.fish",
     },
   ])
-  .action((shell: string) => {
-    const script = COMPLETION_SCRIPTS[shell];
-    if (!script) {
+  .action(async (shell: string) => {
+    if (!isSupportedShell(shell)) {
       throw new UserError(
-        `Unsupported shell: "${shell}". Supported shells: ${Object.keys(COMPLETION_SCRIPTS).join(", ")}.`,
+        `Unsupported shell: "${shell}". Supported shells: ${SUPPORTED_SHELLS.join(", ")}.`,
       );
     }
-    process.stdout.write(script);
+    process.stdout.write(renderCompletionScript(shell, await buildProgram()));
   });
 
 export default completion;

--- a/apps/cli/src/lib/completion-script.test.ts
+++ b/apps/cli/src/lib/completion-script.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { BeeCommand } from "./bee-command";
+import { SUPPORTED_SHELLS, isSupportedShell, renderCompletionScript } from "./completion-script";
+
+const program = (): BeeCommand => new BeeCommand("bee");
+
+const withCommands = (...commands: BeeCommand[]): BeeCommand => {
+  const bee = program();
+  for (const command of commands) {
+    bee.addCommand(command);
+  }
+  return bee;
+};
+
+describe("renderCompletionScript", () => {
+  it("lists every top-level command in registry order for bash", () => {
+    const bee = withCommands(
+      new BeeCommand("auth").summary("Authenticate bee with Backlog"),
+      new BeeCommand("issue").summary("Manage Backlog issues"),
+      new BeeCommand("issue-type").summary("Manage project issue types"),
+    );
+
+    expect(renderCompletionScript("bash", bee)).toContain('local commands="auth issue issue-type"');
+  });
+
+  it("describes each command with its summary for zsh", () => {
+    const bee = withCommands(new BeeCommand("issue").summary("Manage Backlog issues"));
+
+    expect(renderCompletionScript("zsh", bee)).toContain("'issue:Manage Backlog issues'");
+  });
+
+  it("describes each command with its summary for fish", () => {
+    const bee = withCommands(new BeeCommand("issue").summary("Manage Backlog issues"));
+
+    expect(renderCompletionScript("fish", bee)).toContain(
+      'complete -c bee -n "__fish_use_subcommand" -a "issue" -d "Manage Backlog issues"',
+    );
+  });
+
+  it("omits commander's built-in help subcommand", () => {
+    const bee = withCommands(
+      new BeeCommand("issue").summary("Manage Backlog issues"),
+      new BeeCommand("help").summary("display help for command"),
+    );
+
+    for (const shell of SUPPORTED_SHELLS) {
+      expect(renderCompletionScript(shell, bee)).not.toContain("help");
+    }
+  });
+
+  it("falls back to the description when a command has no summary", () => {
+    const bee = withCommands(
+      new BeeCommand("api").description("Make an authenticated API request"),
+    );
+
+    expect(renderCompletionScript("zsh", bee)).toContain("'api:Make an authenticated API request'");
+  });
+
+  it("escapes a colon in a summary so zsh keeps the whole description", () => {
+    const bee = withCommands(new BeeCommand("watching").summary("Manage watching: subscriptions"));
+
+    expect(renderCompletionScript("zsh", bee)).toContain(
+      String.raw`'watching:Manage watching\: subscriptions'`,
+    );
+  });
+
+  it("escapes a double quote in a summary so fish keeps the argument intact", () => {
+    const bee = withCommands(new BeeCommand("issue").summary(String.raw`Manage "Backlog" issues`));
+
+    expect(renderCompletionScript("fish", bee)).toContain(
+      String.raw`-d "Manage \"Backlog\" issues"`,
+    );
+  });
+
+  it("keeps the entry points each shell sources", () => {
+    const bee = withCommands(new BeeCommand("issue").summary("Manage Backlog issues"));
+
+    expect(renderCompletionScript("bash", bee)).toContain("complete -F _bee_completions bee");
+    expect(renderCompletionScript("zsh", bee)).toContain("#compdef bee");
+    expect(renderCompletionScript("zsh", bee)).toContain("compdef _bee bee");
+    expect(renderCompletionScript("fish", bee)).toContain("complete -c bee -e");
+  });
+});
+
+describe("isSupportedShell", () => {
+  it("accepts each supported shell", () => {
+    expect(SUPPORTED_SHELLS).toEqual(["bash", "zsh", "fish"]);
+    for (const shell of SUPPORTED_SHELLS) {
+      expect(isSupportedShell(shell)).toBe(true);
+    }
+  });
+
+  it("rejects a shell with no completion script", () => {
+    expect(isSupportedShell("powershell")).toBe(false);
+  });
+
+  it("rejects an inherited Object property masquerading as a shell", () => {
+    expect(isSupportedShell("toString")).toBe(false);
+  });
+});

--- a/apps/cli/src/lib/completion-script.ts
+++ b/apps/cli/src/lib/completion-script.ts
@@ -1,0 +1,109 @@
+import { type Command } from "commander";
+
+type CompletionEntry = {
+  name: string;
+  summary: string;
+};
+
+/**
+ * Commander lists `help` as a subcommand of every parent. Completing it would
+ * offer a command users reach through `--help`, so it never reaches a script.
+ */
+const isListable = (cmd: Command): boolean => cmd.name() !== "help";
+
+const toEntry = (cmd: Command): CompletionEntry => ({
+  name: cmd.name(),
+  summary: cmd.summary() || cmd.description(),
+});
+
+const commandEntries = (program: Command): CompletionEntry[] =>
+  program.commands.filter(isListable).map(toEntry);
+
+/**
+ * zsh's `_describe` takes `name:description` pairs, so a colon inside a summary
+ * would end the name early and truncate the completion label.
+ */
+const escapeZsh = (text: string): string => text.replaceAll(":", String.raw`\:`);
+
+const escapeDoubleQuoted = (text: string): string => text.replaceAll(/(["$`\\])/g, String.raw`\$1`);
+
+const renderBash = (entries: CompletionEntry[]): string => `# bash completion for bee
+# Add to ~/.bashrc:
+#   eval "$(bee completion bash)"
+
+_bee_completions() {
+  local cur="\${COMP_WORDS[COMP_CWORD]}"
+  local commands="${entries.map((entry) => entry.name).join(" ")}"
+
+  if [ "\${COMP_CWORD}" -eq 1 ]; then
+    COMPREPLY=( $(compgen -W "\${commands}" -- "\${cur}") )
+  fi
+}
+
+complete -F _bee_completions bee
+`;
+
+const renderZsh = (entries: CompletionEntry[]): string => {
+  const pairs = entries
+    .map((entry) => `      '${escapeZsh(entry.name)}:${escapeZsh(entry.summary)}'`)
+    .join(" \\\n");
+
+  return `#compdef bee
+# zsh completion for bee
+# Add to ~/.zshrc:
+#   eval "$(bee completion zsh)"
+
+_bee() {
+  local -a commands
+  commands=(
+${pairs}
+  )
+
+  _arguments '1: :->command' '*:: :->args'
+
+  case $state in
+    command)
+      _describe 'command' commands
+      ;;
+  esac
+}
+
+compdef _bee bee
+`;
+};
+
+const renderFish = (entries: CompletionEntry[]): string => {
+  const lines = entries
+    .map(
+      (entry) =>
+        `complete -c bee -n "__fish_use_subcommand" -a "${entry.name}" -d "${escapeDoubleQuoted(entry.summary)}"`,
+    )
+    .join("\n");
+
+  return `# fish completion for bee
+# Add to ~/.config/fish/completions/bee.fish:
+#   bee completion fish > ~/.config/fish/completions/bee.fish
+
+complete -c bee -e
+${lines}
+`;
+};
+
+/**
+ * Null-prototyped so a shell name that collides with an inherited property
+ * ("toString") fails validation instead of resolving to a non-renderer.
+ */
+const RENDERERS: Record<string, (entries: CompletionEntry[]) => string> = Object.assign(
+  Object.create(null) as Record<string, (entries: CompletionEntry[]) => string>,
+  { bash: renderBash, zsh: renderZsh, fish: renderFish },
+);
+
+const SUPPORTED_SHELLS = Object.keys(RENDERERS);
+
+const isSupportedShell = (shell: string): boolean => shell in RENDERERS;
+
+/** Render the completion script for `shell` from the program's top-level commands. */
+const renderCompletionScript = (shell: string, program: Command): string =>
+  RENDERERS[shell](commandEntries(program));
+
+export { SUPPORTED_SHELLS, isSupportedShell, renderCompletionScript };


### PR DESCRIPTION
## Summary

Removes the last hand-maintained duplicate of the top-level command list. `apps/cli/src/commands/completion.ts` embedded the list four times over — once per shell template, plus the registry — and nothing checked that they agreed.

```
local commands="auth project issue document notification pr repo team user wiki category milestone issue-type space status star watching dashboard browse api completion"
```

The lists were accurate, so this is not a bug report. It is the same drift #151 just fixed for `skills/using-bee/SKILL.md`, and here the failure mode is quieter: a stale completion offers a command that no longer exists, or hides one that does, and the only person who finds out is a user pressing Tab. There is no test, no CI check, and no error — just a menu that is subtly wrong.

Since #151 landed, `commands/registry.ts` is a single source of truth. This builds the completion lists from it, the same list the CLI entry point and the Skill generator already read.

## What changes

**New `apps/cli/src/lib/completion-script.ts`** renders all three scripts from a `Command` program. It follows the `command-table.ts` pattern, including excluding commander's injected `help` subcommand for the same reason — it is reached through `--help`, not by name.

**`completion.ts` drops 91 lines of template** and calls the renderer.

**zsh and fish get real descriptions.** Both templates described every command as the placeholder `"<name> commands"` — `'issue:issue commands'`, which tells a user nothing the name did not already. Reading `.summary()` gives those menus the descriptions the help output already carries:

```
'issue:Manage Backlog issues'
'watching:Manage watching (issue subscriptions)'
'dashboard:Show a summary of your Backlog activity'
```

## Output equivalence

I extracted the old hardcoded scripts from git and diffed them against generated output:

- **bash — byte-identical.**
- **zsh / fish — the only differences are the placeholder descriptions becoming real summaries.** Command names, order, and script structure are unchanged.

All three still emit 21 commands, and `help` appears in none of them.

## Two implementation notes

**The import cycle is real.** The registry imports the completion module, so a top-level `import` back into the registry closes the cycle and leaves `loadCommands` undefined at call time. `completion.ts` loads it with a dynamic `import()` inside the action, after every module has finished evaluating.

**Shell validation moved before the program build**, so `bee completion powershell` fails immediately instead of loading all 21 command modules only to throw.

## A bug I introduced and caught

My first version wrote the lookup as `shell in RENDERERS`. The `in` operator walks the prototype chain, so `bee completion toString` passed validation and then crashed trying to call a non-function. **The old code was safe here** — it tested the looked-up value for truthiness, and this refactor quietly removed that protection.

Fixed with a null-prototype object, plus a regression test. Both paths now fail properly:

```
$ bee completion toString
 ERROR  Unsupported shell: "toString". Supported shells: bash, zsh, fish.
```

## Test plan

`apps/cli/src/commands/completion.test.ts` passes unchanged — the existing behavioral contract still holds.

New `completion-script.test.ts` covers the generation logic that did not exist before: list contents and order per shell, summaries as descriptions, `help` exclusion, the `.description()` fallback, colon escaping for zsh's `_describe` pairs, double-quote escaping for fish, and the prototype-pollution case above.

**Verification on the rebased branch** (base `f72c7da`):

- `tsc --noEmit` — clean
- `vitest run` — **558 passed, 98 files**
- `oxlint apps/cli/src` — clean
- `oxfmt --check apps/cli/src` — clean, 218 files
- `generate:skill:check` — SKILL.md still up to date
- `bee completion {bash,zsh,fish}` — diffed against the old scripts as described above

One note on test flakiness, since I hit it and it is worth not misreading: on the very first run after a fresh `pnpm install`, two completion tests timed out at the 5s default while esbuild transformed the tree for the first time, with a lint job running concurrently. They pass at the default timeout on a cold cache when run alone, and the full suite is green on rerun. I did not raise the timeout, since the cost is one-time and not a property of this change — but flagging it in case CI's first run on a cold cache trips the same thing.

Refs #127
