### PR TITLE
fix(cli): stop the built CLI deadlocking on its own command chunks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,33 @@ jobs:
         if: always() && github.event_name == 'pull_request' && matrix.node-version == 24
         uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2
 
+  build:
+    runs-on: ubuntu-latest
+
+    name: Build
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: jdx/mise-action@c1ecc8f748cd28cdeabf76dab3cccde4ce692fe4 # v4.0.0.6.4.0.0
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      # `unbuild` exits 0 for a bundle that cannot actually run, so the built
+      # artifact is executed here rather than only being produced. A top-level
+      # await deadlock between the entry and its lazily imported command chunks
+      # shipped undetected precisely because nothing ran the output.
+      - name: Smoke test the built CLI
+        run: |
+          version=$(node apps/cli/bin/cli.mjs --version)
+          echo "bee --version -> ${version}"
+          test -n "$version"
+          node apps/cli/bin/cli.mjs --help > /dev/null
+          node apps/cli/bin/cli.mjs issue --help > /dev/null
+
   lint:
     runs-on: ubuntu-latest
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -10,12 +10,20 @@ installHttpDispatcher();
 
 const program = new BeeCommand("bee").version(pkg.version).description(pkg.description ?? "");
 
-await program.addCommands(loadCommands());
-
 program.exitOverride();
 
-try {
-  await program.parseAsync();
-} catch (error) {
-  handleError(error);
-}
+// Kept out of module scope: unbuild bundles the lazily imported command chunks
+// alongside this entry, and those chunks import shared values back from it. A
+// top-level `await` here would leave the entry mid-evaluation while they wait
+// on it, deadlocking the cycle -- Node reports `unsettled top-level await` and
+// exits 13 without running anything.
+const main = async (): Promise<void> => {
+  try {
+    await program.addCommands(loadCommands());
+    await program.parseAsync();
+  } catch (error) {
+    handleError(error);
+  }
+};
+
+void main();


### PR DESCRIPTION
Fixes #153.

## The bug

The built CLI exited **13** and printed nothing:

```
$ node apps/cli/bin/cli.mjs --version
Warning: Detected unsettled top-level await at .../dist/index.mjs:37908
await program.addCommands(loadCommands());
$ echo $?
13
```

## Root cause: a cycle the top-level await cannot escape

`index.ts` awaited command registration at module scope. The command modules are imported lazily and `unbuild` emits them as chunks next to the entry — but with `rollup.inlineDependencies: true`, the workspace packages that define `UserError` and the valibot helpers get inlined **into the entry**. So the chunks import those values back from it:

```js
// dist/chunks/api.mjs
import { U as UserError, a as vFiniteNumber } from '../index.mjs';
```

**50 of the 109 chunks do this.** The entry cannot finish evaluating until the awaited chunks resolve; the chunks cannot initialise until the entry finishes. Deadlock.

## The fix

Move the await into a `main()` function. The entry then finishes evaluating and exports its bindings *before* any chunk is requested, so the cycle resolves normally.

The lazy imports are kept deliberately — they are what lets the Skill generator load the command tree without executing the CLI, and what keeps `bee <command>` from paying for every module. Only the *timing* of the await changes.

`addCommands` also moves inside the existing `try`, so a failure loading a command now surfaces through `handleError` (exit 1, formatted) instead of as an unhandled rejection.

## Second commit: CI runs the built artifact

This shipped to `main` with every check green, which is the more important problem.

**CI never built the CLI at all.** `pnpm build` ran only in `release.yml`, immediately before `pnpm publish` — and that job does not run what it just built either. Tests and typecheck exercise the source, and `unbuild` exits 0 for a bundle that cannot execute.

The new job builds and then *runs* the output: `--version` must print something, and `--help` plus `bee issue --help` must exit 0. The subcommand matters — it is what forces a lazy chunk to load, which is where the deadlock lived.

**The guard was verified against the broken build**, not just the fixed one: `--version` returns empty with exit 13 and the job fails as intended.

## Scope note

Bisect pinned this to `837af0f` (#151), which introduced the lazy imports. The dependency work in #143 / #152 is not involved — those commits build a working CLI. Verified at each of `232f4d9`, `1b74675`, `4c296dc` (all fine) and `837af0f` (broken).

Published `@nulab/bee@1.0.0-rc.3` is **not** affected — it predates #151. But a release cut from `main` today would have shipped the broken bundle.

## Verification

- `pnpm build --force` — 2/2, CLI + 105 docs pages, internal links valid
- `pnpm typecheck` — 5/5
- `pnpm exec oxlint --max-warnings 0` — clean
- `pnpm format:check` — clean
- Built CLI: `--version` → `0.0.0` (exit 0), `--help` and `issue --help` exit 0, unknown command still exits 1

`pnpm test` — 780/781 locally; the one failure is `defaults to port 5033` (`EADDRINUSE`, an unrelated dev server on my machine). It fails identically on unmodified `main`. CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
